### PR TITLE
setup.py: Remove jedi hack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         install_requires=[
             'click >= 3.2',
             'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
-            'jedi == 0.8.1',   # Temporary fix for installation woes.
             'prompt_toolkit==0.25',  # Need to pin this to 0.25 since APIs change quite a bit after this.
             'psycopg2 >= 2.5.4',
             'sqlparse >= 0.1.14',


### PR DESCRIPTION
A PEP 440 compliant version of Jedi was released to PyPI. See https://github.com/davidhalter/jedi/issues/521#issuecomment-68700893