### PR TITLE
fix broken suggestions after compound where clause

### DIFF
--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -151,6 +151,7 @@ def extract_tables(sql):
     stream = extract_from_part(parsed[0], stop_at_punctuation=insert_stmt)
     return list(extract_table_identifiers(stream))
 
+
 def find_prev_keyword(sql):
     """ Find the last sql keyword in an SQL statement
 
@@ -161,10 +162,26 @@ def find_prev_keyword(sql):
         return None, ''
 
     parsed = sqlparse.parse(sql)[0]
-    for t in reversed(list(parsed.flatten())):
-        if t.is_keyword or t.value == '(':
-            idx = parsed.token_index(t)
-            text = ''.join(tok.value for tok in parsed.tokens[:idx+1])
+    flattened = list(parsed.flatten())
+
+    trivial_keywords = ('AND', 'OR', 'NOT', 'BETWEEN')
+
+    for t in reversed(flattened):
+        if t.value == '(' or (t.is_keyword and (
+                              t.value.upper() not in trivial_keywords)):
+            # Find the location of token t in the original parsed statement
+            # We can't use parsed.token_index(t) because t may be a child token
+            # inside a TokenList, in which case token_index thows an error
+            # Minimal example:
+            #   p = sqlparse.parse('select * from foo where bar')
+            #   t = list(p.flatten())[-3]  # The "Where" token
+            #   p.token_index(t)  # Throws ValueError: not in list
+            idx = flattened.index(t)
+
+            # Combine the string values of all tokens in the original list
+            # up to and including the target keyword token t, to produce a
+            # query string with everything after the keyword token removed
+            text = ''.join(tok.value for tok in flattened[:idx+1])
             return t.value, text
 
     return None, ''

--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -164,11 +164,11 @@ def find_prev_keyword(sql):
     parsed = sqlparse.parse(sql)[0]
     flattened = list(parsed.flatten())
 
-    trivial_keywords = ('AND', 'OR', 'NOT', 'BETWEEN')
+    logical_operators = ('AND', 'OR', 'NOT', 'BETWEEN')
 
     for t in reversed(flattened):
         if t.value == '(' or (t.is_keyword and (
-                              t.value.upper() not in trivial_keywords)):
+                              t.value.upper() not in logical_operators)):
             # Find the location of token t in the original parsed statement
             # We can't use parsed.token_index(t) because t may be a child token
             # inside a TokenList, in which case token_index thows an error

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -190,9 +190,9 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
                 # Technically, we should suggest columns AND keywords, as
                 # per case 4. However, IN is different from ANY, SOME, ALL
                 # in that it can accept a *list* of columns, or a subquery.
-                # Because of the way lists of columns are reduced in this
-                # function, "SELECT * FROM foo WHERE bar IN (baz, qux, " would
-                # also suggest keywords, which is kinda gross.
+                # But suggesting keywords for , "SELECT * FROM foo WHERE bar IN
+                # (baz, qux, " would be overwhelming. So we special case 'IN'
+                # to not suggest keywords.
                 return column_suggestions
             else:
                 return column_suggestions

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 import sys
 import sqlparse
 from sqlparse.sql import Comparison, Identifier
-from sqlparse.tokens import Keyword
 from .parseutils import last_word, extract_tables, find_prev_keyword
 from .pgspecial import parse_special_command
 
@@ -185,7 +184,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
         else:
             return [{'type': 'column', 'tables': extract_tables(full_text)},
                     {'type': 'function', 'schema': []}]
-    elif (token_v.endswith('join') and token.ttype in Keyword) or (token_v in
+    elif (token_v.endswith('join') and token.is_keyword) or (token_v in
             ('copy', 'from', 'update', 'into', 'describe', 'truncate')):
         schema = (identifier and identifier.get_parent_name()) or []
 

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import sys
 import sqlparse
-from sqlparse.sql import Comparison, Identifier
+from sqlparse.sql import Comparison, Identifier, Where
 from .parseutils import last_word, extract_tables, find_prev_keyword
 from .pgspecial import parse_special_command
 
@@ -134,22 +134,68 @@ def suggest_special(text):
 def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier):
     if isinstance(token, string_types):
         token_v = token.lower()
-    else:
+    elif isinstance(token, Comparison):
         # If 'token' is a Comparison type such as
         # 'select * FROM abc a JOIN def d ON a.id = d.'. Then calling
         # token.value on the comparison type will only return the lhs of the
         # comparison. In this case a.id. So we need to do token.tokens to get
         # both sides of the comparison and pick the last token out of that
         # list.
-        if isinstance(token, Comparison):
-            token_v = token.tokens[-1].value.lower()
-        else:
-            token_v = token.value.lower()
+        token_v = token.tokens[-1].value.lower()
+    elif isinstance(token, Where):
+        # sqlparse groups all tokens from the where clause into a single token
+        # list. This means that token.value may be something like
+        # 'where foo > 5 and '. We need to look "inside" token.tokens to handle
+        # suggestions in complicated where clauses correctly
+        prev_keyword, text_before_cursor = find_prev_keyword(text_before_cursor)
+        return suggest_based_on_last_token(prev_keyword, text_before_cursor,
+                                           full_text, identifier)
+    else:
+        token_v = token.value.lower()
 
     if not token:
         return [{'type': 'keyword'}, {'type': 'special'}]
     elif token_v.endswith('('):
         p = sqlparse.parse(text_before_cursor)[0]
+
+        if p.tokens and isinstance(p.tokens[-1], Where):
+            # Four possibilities:
+            #  1 - Parenthesized clause like "WHERE foo AND ("
+            #        Suggest columns/functions
+            #  2 - Function call like "WHERE foo("
+            #        Suggest columns/functions
+            #  3 - Subquery expression like "WHERE EXISTS ("
+            #        Suggest keywords, in order to do a subquery
+            #  4 - Subquery OR array comparison like "WHERE foo = ANY("
+            #        Suggest columns/functions AND keywords. (If we wanted to be
+            #        really fancy, we could suggest only array-typed columns)
+
+            column_suggestions = suggest_based_on_last_token('where',
+                                    text_before_cursor, full_text, identifier)
+
+            # Check for a subquery expression (cases 3 & 4)
+            where = p.tokens[-1]
+            prev_tok = where.token_prev(len(where.tokens) - 1)
+
+            if isinstance(prev_tok, Comparison):
+                # e.g. "SELECT foo FROM bar WHERE foo = ANY("
+                prev_tok = prev_tok.tokens[-1]
+
+            prev_tok = prev_tok.value.lower()
+            if prev_tok == 'exists':
+                return [{'type': 'keyword'}]
+            elif prev_tok in ('any', 'some', 'all'):
+                return column_suggestions + [{'type': 'keyword'}]
+            elif prev_tok == 'in':
+                # Technically, we should suggest columns AND keywords, as
+                # per case 4. However, IN is different from ANY, SOME, ALL
+                # in that it can accept a *list* of columns, or a subquery.
+                # Because of the way lists of columns are reduced in this
+                # function, "SELECT * FROM foo WHERE bar IN (baz, qux, " would
+                # also suggest keywords, which is kinda gross.
+                return column_suggestions
+            else:
+                return column_suggestions
 
         # Get the token before the parens
         prev_tok = p.token_prev(len(p.tokens) - 1)

--- a/tests/test_parseutils.py
+++ b/tests/test_parseutils.py
@@ -88,3 +88,12 @@ def test_find_prev_keyword_using():
     q = 'select * from tbl1 inner join tbl2 using (col1, '
     kw, q2 = find_prev_keyword(q)
     assert kw == '(' and q2 == 'select * from tbl1 inner join tbl2 using ('
+
+@pytest.mark.parametrize('sql', [
+    'select * from foo where bar',
+    'select * from foo where bar = 1 and baz or ',
+    'select * from foo where bar = 1 and baz between qux and ',
+])
+def test_find_prev_keyword_where(sql):
+    kw, stripped = find_prev_keyword(sql)
+    assert kw == 'where' and stripped == 'select * from foo where'


### PR DESCRIPTION
Previously, 'SELECT * FROM foo WHERE ' correctly suggested columns, but 'SELECT * FROM foo WHERE bar = 1 AND ' incorrectly suggested keywords. This was due to the fact that sqlparse was grouping the entire where clause into a single Where token.

This seems such a simple fix I feel like I'm missing something! Suggestions on any extra tests here would be appreciated