### PR TITLE
Upgrade to prompt-toolkit 0.34

### DIFF
--- a/pgcli/key_bindings.py
+++ b/pgcli/key_bindings.py
@@ -42,7 +42,11 @@ def pgcli_bindings(vi_mode=False):
         Force autocompletion at cursor.
         """
         _logger.debug('Detected <Tab> key.')
-        event.cli.current_buffer.complete_next()
+        b = event.cli.current_buffer
+        if b.complete_state:
+            b.complete_next()
+        else:
+            event.cli.start_completion(select_first=True)
 
     @key_binding_manager.registry.add_binding(Keys.ControlSpace)
     def _(event):
@@ -55,6 +59,11 @@ def pgcli_bindings(vi_mode=False):
         If the menu is showing, select the next completion.
         """
         _logger.debug('Detected <C-Space> key.')
-        event.cli.current_buffer.complete_next(start_at_first=False)
+
+        b = event.cli.current_buffer
+        if b.complete_state:
+            b.complete_next()
+        else:
+            event.cli.start_completion(select_first=False)
 
     return key_binding_manager

--- a/pgcli/pgbuffer.py
+++ b/pgcli/pgbuffer.py
@@ -1,9 +1,15 @@
 from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.filters import Condition
 
 class PGBuffer(Buffer):
     def __init__(self, always_multiline, *args, **kwargs):
         self.always_multiline = always_multiline
-        is_multiline = lambda doc: self.always_multiline and not _multiline_exception(doc.text)
+
+        @Condition
+        def is_multiline():
+            doc = self.document
+            return self.always_multiline and not _multiline_exception(doc.text)
+
         super(self.__class__, self).__init__(*args, is_multiline=is_multiline, **kwargs)
 
 def _multiline_exception(text):

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -29,7 +29,7 @@ table_format = psql
 # Syntax Style. Possible values: manni, igor, xcode, vim, autumn, vs, rrt,
 # native, perldoc, borland, tango, emacs, friendly, monokai, paraiso-dark,
 # colorful, murphy, bw, pastie, paraiso-light, trac, default, fruity
-syntax_style = native
+syntax_style = default
 
 # Enables vi-mode
 vi = False

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 import logging
 from prompt_toolkit.completion import Completer, Completion
 from .packages.sqlcompletion import suggest_type

--- a/pgcli/pgstyle.py
+++ b/pgcli/pgstyle.py
@@ -1,6 +1,7 @@
 from pygments.token import Token
 from pygments.style import Style
 from pygments.util import ClassNotFound
+from prompt_toolkit.styles import default_style_extensions
 import pygments.styles
 
 
@@ -11,19 +12,22 @@ def style_factory(name):
         style = pygments.styles.get_style_by_name('native')
 
     class PGStyle(Style):
-        styles = {
-                Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
-                Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',
-                Token.Menu.Completions.ProgressButton: 'bg:#003333',
-                Token.Menu.Completions.ProgressBar: 'bg:#00aaaa',
-                Token.SelectedText: '#ffffff bg:#6666aa',
-                Token.IncrementalSearchMatch: '#ffffff bg:#4444aa',
-                Token.IncrementalSearchMatch.Current: '#ffffff bg:#44aa44',
-                Token.Toolbar: 'bg:#440044 #ffffff',
-                Token.Toolbar.Status: 'bg:#222222 #aaaaaa',
-                Token.Toolbar.Status.Off: 'bg:#222222 #888888',
-                Token.Toolbar.Status.On: 'bg:#222222 #ffffff',
-                }
+        styles = {}
+
         styles.update(style.styles)
+        styles.update(default_style_extensions)
+        styles.update({
+            Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
+            Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',
+            Token.Menu.Completions.ProgressButton: 'bg:#003333',
+            Token.Menu.Completions.ProgressBar: 'bg:#00aaaa',
+            Token.SelectedText: '#ffffff bg:#6666aa',
+            Token.IncrementalSearchMatch: '#ffffff bg:#4444aa',
+            Token.IncrementalSearchMatch.Current: '#ffffff bg:#44aa44',
+            Token.Toolbar: 'bg:#440044 #ffffff',
+            Token.Toolbar: 'bg:#222222 #aaaaaa',
+            Token.Toolbar.Off: 'bg:#222222 #888888',
+            Token.Toolbar.On: 'bg:#222222 #ffffff',
+        })
 
     return PGStyle

--- a/pgcli/pgtoolbar.py
+++ b/pgcli/pgtoolbar.py
@@ -1,34 +1,34 @@
-from prompt_toolkit.layout.toolbars import Toolbar
-from prompt_toolkit.layout.utils import TokenList
 from pygments.token import Token
 
-class PGToolbar(Toolbar):
-    def __init__(self, key_binding_manager, token=None):
-        self.key_binding_manager = key_binding_manager
-        token = token or Token.Toolbar.Status
-        super(self.__class__, self).__init__(token=token)
 
-    def get_tokens(self, cli, width):
-        result = TokenList()
-        result.append((self.token, ' '))
+def create_toolbar_tokens_func(key_binding_manager, token=None):
+    """
+    Return a function that generates the toolbar tokens.
+    """
+    token = token or Token.Toolbar
+
+    def get_toolbar_tokens(cli):
+        result = []
+        result.append((token, ' '))
 
         if cli.buffers['default'].completer.smart_completion:
-            result.append((self.token.On, '[F2] Smart Completion: ON  '))
+            result.append((token.On, '[F2] Smart Completion: ON  '))
         else:
-            result.append((self.token.Off, '[F2] Smart Completion: OFF  '))
+            result.append((token.Off, '[F2] Smart Completion: OFF  '))
 
         if cli.buffers['default'].always_multiline:
-            result.append((self.token.On, '[F3] Multiline: ON  '))
+            result.append((token.On, '[F3] Multiline: ON  '))
         else:
-            result.append((self.token.Off, '[F3] Multiline: OFF  '))
+            result.append((token.Off, '[F3] Multiline: OFF  '))
 
         if cli.buffers['default'].always_multiline:
-            result.append((self.token,
+            result.append((token,
                 ' (Semi-colon [;] will end the line)'))
 
-        if self.key_binding_manager.enable_vi_mode:
-            result.append((self.token.On, '[F4] Vi-mode'))
+        if key_binding_manager.enable_vi_mode:
+            result.append((token.On, '[F4] Vi-mode'))
         else:
-            result.append((self.token.On, '[F4] Emacs-mode'))
+            result.append((token.On, '[F4] Emacs-mode'))
 
         return result
+    return get_toolbar_tokens

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         install_requires=[
             'click >= 3.2',
             'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
-            'prompt_toolkit==0.26',
+            'prompt_toolkit==0.36',
             'psycopg2 >= 2.5.4',
             'sqlparse == 0.1.14'
             ],


### PR DESCRIPTION
This should be enough for the upgrade to 0.34.

Please keep version 0.34 still hard-coded in the setup.py. (The prompt-toolkit API becomes mature, but small changes can still happen.)

One other change I made, was to use the color scheme 'default', instead of 'native'. Not sure whether it is related to the upgrade, but for some reason all of my text was gray instead of black or white. The Pygments default color scheme doesn't touch the color of normal text.

Jonathan

edit: don't simply click merge ;) Have a look and feel free to alter the commit before merging.