### PR TITLE
Fix incorrect super() calls

### DIFF
--- a/pgcli/pgbuffer.py
+++ b/pgcli/pgbuffer.py
@@ -4,7 +4,7 @@ class PGBuffer(Buffer):
     def __init__(self, always_multiline, *args, **kwargs):
         self.always_multiline = always_multiline
         is_multiline = lambda doc: self.always_multiline and not _multiline_exception(doc.text)
-        super(self.__class__, self).__init__(*args, is_multiline=is_multiline, **kwargs)
+        super(PGBuffer, self).__init__(*args, is_multiline=is_multiline, **kwargs)
 
 def _multiline_exception(text):
     text = text.strip()

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -40,7 +40,7 @@ class PGCompleter(Completer):
                  'MAX', 'MIN', 'MID', 'NOW', 'ROUND', 'SUM', 'TOP', 'UCASE']
 
     def __init__(self, smart_completion=True):
-        super(self.__class__, self).__init__()
+        super(PGCompleter, self).__init__()
         self.smart_completion = smart_completion
         self.reserved_words = set()
         for x in self.keywords:

--- a/pgcli/pgtoolbar.py
+++ b/pgcli/pgtoolbar.py
@@ -6,7 +6,7 @@ class PGToolbar(Toolbar):
     def __init__(self, key_binding_manager, token=None):
         self.key_binding_manager = key_binding_manager
         token = token or Token.Toolbar.Status
-        super(self.__class__, self).__init__(token=token)
+        super(PGToolbar, self).__init__(token=token)
 
     def get_tokens(self, cli, width):
         result = TokenList()


### PR DESCRIPTION
From the “not a problem now but could be later” department, this PR is preventative maintenance to fix some incorrect calls to `super()`. The spelling

```python

super(self.__class__, self)…
```

is a subtle error that unfortunately tends to manifest itself long after the call is written. To see why it's a problem, consider this class hierarchy:

```python

class A(object):
    def report(self):
        print 'A reporting'

class B(A):
    def report(self):
        print 'B reporting'
        super(self.__class__, self).report()

class C(B):
    def report(self):
        print 'C reporting'
        super(self.__class__, self).report()

C().report()
```

The expected output is

    C reporting
    B reporting
    A reporting

but you actually get a stack overflow. The first `super()` call from `C` to `B` works as expected, but in `B.report()`, when called from `C`, `self.__class__` is `C`, so `super(self.__class__, self)` == `super(C, self)` == `B`! This is correct from a semantic point of view but almost certainly not what was intended; the result is that `B.report()` keeps calling itself recursively until stack space is exhausted.

