### PR TITLE
Fix for listing triggers on \d special.

### DIFF
--- a/pgcli/packages/pgspecial.py
+++ b/pgcli/packages/pgspecial.py
@@ -781,7 +781,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
                     if triggerpos >= 0:
                         tgdef = triggerpos + 9;
 
-                    status.append("    %s\n" % tgdef);
+                    status.append("    %s\n" % row[1][tgdef:])
 
     #/*
     #* Finish printing the footer information about a table.


### PR DESCRIPTION
Small fix to show the actual triggerdef, instead of the position of the triggerdef after "CREATE TRIGGER ".