### PR TITLE
Suggest datatypes

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -363,6 +363,9 @@ class PGCli(object):
         # functions
         completer.extend_functions(pgexecute.functions())
 
+        # types
+        completer.extend_datatypes(pgexecute.datatypes())
+
         # databases
         completer.extend_database_names(pgexecute.databases())
 

--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -7,10 +7,10 @@ from sqlparse.tokens import Keyword, DML, Punctuation
 cleanup_regex = {
         # This matches only alphanumerics and underscores.
         'alphanum_underscore': re.compile(r'(\w+)$'),
-        # This matches everything except spaces, parens, and comma
-        'many_punctuations': re.compile(r'([^(),\s]+)$'),
-        # This matches everything except spaces, parens, comma, and period
-        'most_punctuations': re.compile(r'([^\.(),\s]+)$'),
+        # This matches everything except spaces, parens, colon, and comma
+        'many_punctuations': re.compile(r'([^():,\s]+)$'),
+        # This matches everything except spaces, parens, colon, comma, and period
+        'most_punctuations': re.compile(r'([^\.():,\s]+)$'),
         # This matches everything except a space.
         'all_punctuations': re.compile('([^\s]+)$'),
         }
@@ -43,6 +43,8 @@ def last_word(text, include='alphanum_underscore'):
     '\\\\def'
     >>> last_word('bac \def;', include='most_punctuations')
     '\\\\def;'
+    >>> last_word('bac::def', include='most_punctuations')
+    'def'
     """
 
     if not text:   # Empty string

--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -37,11 +37,11 @@ def last_word(text, include='alphanum_underscore'):
     ''
     >>> last_word('bac $def')
     'def'
-    >>> last_word('bac $def', True)
+    >>> last_word('bac $def', include='most_punctuations')
     '$def'
-    >>> last_word('bac \def', True)
+    >>> last_word('bac \def', include='most_punctuations')
     '\\\\def'
-    >>> last_word('bac \def;', True)
+    >>> last_word('bac \def;', include='most_punctuations')
     '\\\\def;'
     """
 

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -306,8 +306,8 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
     elif token_v in ('type', '::'):
         #   ALTER TABLE foo SET DATA TYPE bar
         #   SELECT foo::bar
-        # Note that tables are a form of composite type in postgresql, so they
-        # are be suggested here as well
+        # Note that tables are a form of composite type in postgresql, so
+        # they're suggested here as well
         schema = (identifier and identifier.get_parent_name()) or []
         suggestions = [{'type': 'datatype', 'schema': schema},
                        {'type': 'table', 'schema': schema}]

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -150,6 +150,22 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
         prev_keyword, text_before_cursor = find_prev_keyword(text_before_cursor)
         return suggest_based_on_last_token(prev_keyword, text_before_cursor,
                                            full_text, identifier)
+    elif isinstance(token, Identifier):
+        # If the previous token is an identifier, we can suggest datatypes if
+        # we're in a parenthesized column/field list, e.g.:
+        #       CREATE TABLE foo (Identifier <CURSOR>
+        #       CREATE FUNCTION foo (Identifier <CURSOR>
+        # If we're not in a parenthesized list, the most likely scenario is the
+        # user is about to specify an alias, e.g.:
+        #       SELECT Identifier <CURSOR>
+        #       SELECT foo FROM Identifier <CURSOR>
+        prev_keyword, _ = find_prev_keyword(text_before_cursor)
+        if prev_keyword == '(':
+            # Suggest datatypes
+            return suggest_based_on_last_token('type', text_before_cursor,
+                                           full_text, identifier)
+        else:
+            return [{'type': 'keyword'}]
     else:
         token_v = token.value.lower()
 
@@ -287,6 +303,17 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
                 prev_keyword, text_before_cursor, full_text, identifier)
         else:
             return []
+    elif token_v in ('type', '::'):
+        #   ALTER TABLE foo SET DATA TYPE bar
+        #   SELECT foo::bar
+        # Note that tables are a form of composite type in postgresql, so they
+        # are be suggested here as well
+        schema = (identifier and identifier.get_parent_name()) or []
+        suggestions = [{'type': 'datatype', 'schema': schema},
+                       {'type': 'table', 'schema': schema}]
+        if not schema:
+            suggestions.append({'type': 'schema'})
+        return suggestions
     else:
         return [{'type': 'keyword'}]
 

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -120,8 +120,12 @@ def suggest_special(text):
             return [{'type': 'schema'},
                     {'type': 'table', 'schema': []},
                     {'type': 'view', 'schema': []}]
-    elif cmd[1:] in ('dt', 'dv', 'df'):
-        rel_type = {'dt': 'table', 'dv': 'view', 'df': 'function'}[cmd[1:]]
+    elif cmd[1:] in ('dt', 'dv', 'df', 'dT'):
+        rel_type = {'dt': 'table',
+                    'dv': 'view',
+                    'df': 'function',
+                    'dT': 'datatype',
+                    }[cmd[1:]]
         if schema:
             return [{'type': rel_type, 'schema': schema}]
         else:

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -307,9 +307,17 @@ class PGCompleter(Completer):
                 completions.extend(special)
 
             elif suggestion['type'] == 'datatype':
-                datatypes = self.find_matches(word_before_cursor,
+                # suggest custom datatypes
+                types = self.populate_schema_objects(
+                    suggestion['schema'], 'datatypes')
+                types = self.find_matches(word_before_cursor, types)
+                completions.extend(types)
+
+                if not suggestion['schema']:
+                    # Also suggest hardcoded types
+                    types = self.find_matches(word_before_cursor,
                                               self.datatypes, start_only=True)
-                completions.extend(datatypes)
+                    completions.extend(types)
 
         return completions
 

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -39,6 +39,9 @@ class PGCompleter(Completer):
     functions = ['AVG', 'COUNT', 'FIRST', 'FORMAT', 'LAST', 'LCASE', 'LEN',
                  'MAX', 'MIN', 'MID', 'NOW', 'ROUND', 'SUM', 'TOP', 'UCASE']
 
+    datatypes = ['BIGINT', 'BOOLEAN', 'CHAR', 'DATE', 'DOUBLE PRECISION', 'INT',
+                 'INTEGER', 'NUMERIC', 'REAL', 'TEXT', 'VARCHAR']
+
     def __init__(self, smart_completion=True):
         super(PGCompleter, self).__init__()
         self.smart_completion = smart_completion
@@ -288,6 +291,11 @@ class PGCompleter(Completer):
                                             self.special_commands,
                                             start_only=True)
                 completions.extend(special)
+
+            elif suggestion['type'] == 'datatype':
+                datatypes = self.find_matches(word_before_cursor,
+                                              self.datatypes, start_only=True)
+                completions.extend(datatypes)
 
         return completions
 

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -52,7 +52,8 @@ class PGCompleter(Completer):
 
         self.special_commands = []
         self.databases = []
-        self.dbmetadata = {'tables': {}, 'views': {}, 'functions': {}}
+        self.dbmetadata = {'tables': {}, 'views': {}, 'functions': {},
+                           'datatypes': {}}
         self.search_path = []
 
         self.all_completions = set(self.keywords + self.functions)
@@ -152,13 +153,26 @@ class PGCompleter(Completer):
             metadata[schema][func] = None
             self.all_completions.add(func)
 
+    def extend_datatypes(self, type_data):
+
+        # dbmetadata['datatypes'][schema_name][type_name] should store type
+        # metadata, such as composite type field names. Currently, we're not
+        # storing any metadata beyond typename, so just store None
+        meta = self.dbmetadata['datatypes']
+
+        for t in type_data:
+            schema, type_name = self.escaped_names(t)
+            meta[schema][type_name] = None
+            self.all_completions.add(type_name)
+
     def set_search_path(self, search_path):
         self.search_path = self.escaped_names(search_path)
 
     def reset_completions(self):
         self.databases = []
         self.search_path = []
-        self.dbmetadata = {'tables': {}, 'views': {}, 'functions': {}}
+        self.dbmetadata = {'tables': {}, 'views': {}, 'functions': {},
+                           'datatypes': {}}
         self.all_completions = set(self.keywords + self.functions)
 
     @staticmethod

--- a/tests/test_parseutils.py
+++ b/tests/test_parseutils.py
@@ -97,3 +97,12 @@ def test_find_prev_keyword_using():
 def test_find_prev_keyword_where(sql):
     kw, stripped = find_prev_keyword(sql)
     assert kw == 'where' and stripped == 'select * from foo where'
+
+
+@pytest.mark.parametrize('sql', [
+    'create table foo (bar int, baz ',
+    'select * from foo() as bar (baz '
+])
+def test_find_prev_keyword_open_parens(sql):
+    kw, _ = find_prev_keyword(sql)
+    assert kw == '('

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -71,6 +71,14 @@ def test_functions_query(executor):
     funcs = list(executor.functions())
     assert funcs == [('public', 'func1'), ('schema1', 'func2')]
 
+
+@dbtest
+def test_datatypes_query(executor):
+    run(executor, 'create type foo AS (a int, b text)')
+
+    types = list(executor.datatypes())
+    assert types == [('public', 'foo')]
+
 @dbtest
 def test_database_list(executor):
     databases = executor.databases()

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -180,3 +180,14 @@ def test_large_numbers_render_directly(executor, value):
         "insert into numbertest (a) values ({0})".format(value))
 
     assert value in run(executor, "select * from numbertest", join=True)
+
+
+@dbtest
+@pytest.mark.parametrize('command', ['di', 'dv', 'ds', 'df', 'dT'])
+@pytest.mark.parametrize('verbose', ['', '+'])
+@pytest.mark.parametrize('pattern', ['', 'x', '*.*', 'x.y', 'x.*', '*.y'])
+def test_describe_special(executor, command, verbose, pattern):
+    # We don't have any tests for the output of any of the special commands,
+    # but we can at least make sure they run without error
+    sql = r'\{command}{verbose} {pattern}'.format(**locals())
+    executor.run(sql)

--- a/tests/test_pgspecial.py
+++ b/tests/test_pgspecial.py
@@ -53,3 +53,18 @@ def test_leading_whitespace_ok():
     whitespace = '   '
     suggestions = suggest_type(whitespace + cmd, whitespace + cmd)
     assert suggestions == suggest_type(cmd, cmd)
+
+
+def test_dT_suggests_schema_or_datatypes():
+    text = '\\dT '
+    suggestions = suggest_type(text, text)
+    assert sorted_dicts(suggestions) == sorted_dicts(
+        [{'type': 'schema'},
+         {'type': 'datatype', 'schema': []},
+        ])
+
+def test_schema_qualified_dT_suggests_datatypes():
+    text = '\\dT foo.'
+    suggestions = suggest_type(text, text)
+    assert sorted_dicts(suggestions) == sorted_dicts(
+        [{'type': 'datatype', 'schema': 'foo'}])

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -354,3 +354,15 @@ def test_auto_escaped_col_names(completer, complete_event):
         Completion(text='custom_func1', start_position=0),
         Completion(text='custom_func2', start_position=0)] +
         list(map(Completion, completer.functions)))
+
+
+@pytest.mark.parametrize('text', [
+    'SELECT 1::DOU',
+    'CREATE TABLE foo (bar DOU',
+    'CREATE FUNCTION foo (bar INT, baz DOU',
+])
+def test_suggest_datatype(text, completer, complete_event):
+    pos = len(text)
+    result = completer.get_completions(
+        Document(text=text, cursor_position=pos), complete_event)
+    assert result == [Completion(text='DOUBLE PRECISION', start_position=-3)]


### PR DESCRIPTION
1. The following contexts now suggest datatypes:
  - `SELECT foo::<TAB>`
  - `CREATE TABLE foo (bar <TAB>`
  - `CREATE FUNCTION foo (bar <TAB>`
  - `ALTER TABLE foo ALTER COLUMN bar TYPE <TAB>`

2. The special command `\dT` is now supported, and suggests types (but not tables)

Datatypes are suggested both from a hardcoded whitelist of builtin postgresql types, as well as user-defined custom types. Furthermore, since postgresql treats a table row as a form of composite type, table names are suggested in addition to data types.

The whitelist I just typed from memory of datatypes I use frequently, and would appreciate feedback on what belongs there. (Or we can just use all of them.) You should be able to use `\dT pg_catalog.*` to list all of the built-in types.


