### PR TITLE
Saving named queries

### DIFF
--- a/pgcli/packages/namedqueries.py
+++ b/pgcli/packages/namedqueries.py
@@ -4,10 +4,9 @@ from ..config import load_config
 class NamedQueries:
 
     section_name = 'named queries'
-    filename = '~/.pgclirc'
 
-    def __init__(self):
-        self.filename = expanduser('~/.pgclirc')
+    def __init__(self, filename):
+        self.filename = expanduser(filename)
         self.config = load_config(self.filename)
 
     def list(self):
@@ -36,4 +35,4 @@ class NamedQueries:
 
 
 
-namedqueries = NamedQueries()
+namedqueries = NamedQueries('~/.pgclirc')

--- a/pgcli/packages/namedqueries.py
+++ b/pgcli/packages/namedqueries.py
@@ -6,33 +6,24 @@ class NamedQueries:
     section_name = 'named queries'
 
     def __init__(self, filename):
-        self.filename = expanduser(filename)
-        self.config = load_config(self.filename)
+        self.config = load_config(filename)
 
     def list(self):
-        if self.config.has_section(self.section_name):
-            return self.config.options(self.section_name)
-        return []
+        return self.config.get(self.section_name, [])
 
     def get(self, name):
-        if not self.config.has_section(self.section_name):
-            return None
-        return self.config.get(self.section_name, name)
+        return self.config.get(self.section_name, {}).get(name, None)
 
     def save(self, name, query):
-        if not self.config.has_section(self.section_name):
-            self.config.add_section(self.section_name)
-        self.config.set(self.section_name, name, query)
-        self._write()
+        if self.section_name not in self.config:
+            self.config[self.section_name] = {}
+        self.config[self.section_name][name] = query
+        self.config.write()
 
     def delete(self, name):
-        self.config.remove_option(self.section_name, name)
-        self._write()
-
-    def _write(self):
-        with open(self.filename, 'w') as f:
-            self.config.write(f)
-
+        if self.section_name in self.config and name in self.config[self.section_name]:
+            del self.config[self.section_name][name]
+            self.config.write()
 
 
 namedqueries = NamedQueries('~/.pgclirc')

--- a/pgcli/packages/namedqueries.py
+++ b/pgcli/packages/namedqueries.py
@@ -1,7 +1,6 @@
-from os.path import expanduser
 from ..config import load_config
 
-class NamedQueries:
+class NamedQueries(object):
 
     section_name = 'named queries'
 

--- a/pgcli/packages/namedqueries.py
+++ b/pgcli/packages/namedqueries.py
@@ -1,0 +1,39 @@
+from os.path import expanduser
+from ..config import load_config
+
+class NamedQueries:
+
+    section_name = 'named queries'
+    filename = '~/.pgclirc'
+
+    def __init__(self):
+        self.filename = expanduser('~/.pgclirc')
+        self.config = load_config(self.filename)
+
+    def list(self):
+        if self.config.has_section(self.section_name):
+            return self.config.options(self.section_name)
+        return []
+
+    def get(self, name):
+        if not self.config.has_section(self.section_name):
+            return None
+        return self.config.get(self.section_name, name)
+
+    def save(self, name, query):
+        if not self.config.has_section(self.section_name):
+            self.config.add_section(self.section_name)
+        self.config.set(self.section_name, name, query)
+        self._write()
+
+    def delete(self, name):
+        self.config.remove_option(self.section_name, name)
+        self._write()
+
+    def _write(self):
+        with open(self.filename, 'w') as f:
+            self.config.write(f)
+
+
+
+namedqueries = NamedQueries()

--- a/pgcli/packages/pgspecial.py
+++ b/pgcli/packages/pgspecial.py
@@ -1035,11 +1035,15 @@ def list_named_queries(cur, arg, verbose):
 
 def save_named_query(cur, arg, verbose):
     """Returns (title, rows, headers, status)"""
+    if ' ' not in arg:
+        return [(None, None, None, "Invalid argument.")]
     name, query = arg.split(' ', 1)
     namedqueries.save(name, query)
     return [(None, None, None, "Saved.")]
 
 def delete_named_query(cur, arg, verbose):
+    if len(arg) == 0:
+        return [(None, None, None, "Invalid argument.")]
     namedqueries.delete(arg)
     return [(None, None, None, "Deleted.")]
 

--- a/pgcli/packages/pgspecial.py
+++ b/pgcli/packages/pgspecial.py
@@ -3,6 +3,7 @@ import sys
 import logging
 from collections import namedtuple
 from .tabulate import tabulate
+from .namedqueries import namedqueries
 
 TableInfo = namedtuple("TableInfo", ['checks', 'relkind', 'hasindex',
 'hasrules', 'hastriggers', 'hasoids', 'tablespace', 'reloptions', 'reloftype',
@@ -1022,6 +1023,44 @@ def toggle_timing(cur, arg, verbose):
     message += "on." if TIMING_ENABLED else "off."
     return [(None, None, None, message)]
 
+def list_named_queries(cur, arg, verbose):
+    """Returns (title, rows, headers, status)"""
+    if not verbose:
+        rows = [[r] for r in namedqueries.list()]
+        headers = ["Name"]
+    else:
+        headers = ["Name", "Query"]
+        rows = [[r, namedqueries.get(r)] for r in namedqueries.list()]
+    return [('', rows, headers, "")]
+
+def save_named_query(cur, arg, verbose):
+    """Returns (title, rows, headers, status)"""
+    name, query = arg.split(' ', 1)
+    namedqueries.save(name, query)
+    return [(None, None, None, "Saved.")]
+
+def delete_named_query(cur, arg, verbose):
+    namedqueries.delete(arg)
+    return [(None, None, None, "Deleted.")]
+
+def execute_named_query(cur, arg, verbose):
+    """Returns (title, rows, headers, status)"""
+    if arg == '':
+        return list_named_queries(cur, arg, verbose)
+
+    query = namedqueries.get(arg)
+    title = '> {}'.format(query)
+    if query is None:
+        message = "No named query: {}".format(arg)
+        return [(None, None, None, message)]
+    cur.execute(query)
+    if cur.description:
+        headers = [x[0] for x in cur.description]
+        return [(title, cur, headers, cur.statusmessage)]
+    else:
+        return [(title, None, None, cur.statusmessage)]
+
+
 CASE_SENSITIVE_COMMANDS = {
             '\?': (show_help, ['\?', 'Help on pgcli commands.']),
             '\c': (dummy_command, ['\c database_name', 'Connect to a new database.']),
@@ -1042,6 +1081,9 @@ CASE_SENSITIVE_COMMANDS = {
             '\sf': (in_progress, ['\sf[+] funcname', 'Not yet implemented.']),
             '\z': (in_progress, ['\z [pattern]', 'Not yet implemented.']),
             '\do': (in_progress, ['\do[S] [pattern]', 'Not yet implemented.']),
+            '\\n': (execute_named_query, ['\\n[+] [name]', 'List or execute named queries.']),
+            '\\ns': (save_named_query, ['\\ns [name [query]]', 'Save a named query.']),
+            '\\nd': (delete_named_query, ['\\nd [name]', 'Delete a named query.']),
             }
 
 NON_CASE_SENSITIVE_COMMANDS = {

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -33,3 +33,7 @@ syntax_style = default
 
 # Enables vi-mode
 vi = False
+
+# Named queries are queries you can rexecute by name
+[named queries]
+


### PR DESCRIPTION
This is the beginning of a patch for saving named queries in pgcli.  Named queries allow you to save and re-execute a query with a short name.  E.g.

```
; Save a query
\ns simple_query select 1;

; Execute saved query
\n simple_query

; List all saved query names
\n

; List all saved query names and the queries
\n+

; Delete saved query
\nd simple_query
```

There's a couple shortcoming that should probably be addressed before merging this PR:

1. Queries are saved in `~/.pgcli`.  This destroys any formatting and comments in the
config file.   It could be fixed by either saving the queries in a separate file or replacing `ConfigParser` with `ConfigObj` which should preserve the formatting and comments.
2. Autocomplete saved queries after entering `\n` and as you type. 
3. Tests