### PR TITLE
Implement fuzzy completion using regex.

### DIFF
--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -1,9 +1,9 @@
 from __future__ import print_function, unicode_literals
 import logging
+import re
 from prompt_toolkit.completion import Completer, Completion
 from .packages.sqlcompletion import suggest_type
 from .packages.parseutils import last_word
-from re import compile, escape
 
 try:
     from collections import Counter
@@ -48,7 +48,7 @@ class PGCompleter(Completer):
         self.reserved_words = set()
         for x in self.keywords:
             self.reserved_words.update(x.split())
-        self.name_pattern = compile("^[_a-z][_a-z0-9\$]*$")
+        self.name_pattern = re.compile("^[_a-z][_a-z0-9\$]*$")
 
         self.special_commands = []
         self.databases = []
@@ -175,8 +175,7 @@ class PGCompleter(Completer):
                            'datatypes': {}}
         self.all_completions = set(self.keywords + self.functions)
 
-    @staticmethod
-    def find_matches(text, collection, start_only=False, fuzzy=True):
+    def find_matches(self, text, collection, start_only=False, fuzzy=True):
         """Find completion matches for the given text.
 
         Given the user's input text and a collection of available
@@ -197,11 +196,10 @@ class PGCompleter(Completer):
         completions = []
 
         if fuzzy:
-            #pat = compile(''.join([escape(c) + r'.*' for c in text]))
-            regex = '.*'.join(map(escape, text))
-            pat = compile('(%s)' % regex)
+            regex = '.*?'.join(map(re.escape, text))
+            pat = re.compile('(%s)' % regex)
             for item in sorted(collection):
-                r = pat.search(item)
+                r = pat.search(self.unescape_name(item))
                 if r:
                     completions.append((len(r.group()), r.start(), item))
         else:

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -3,7 +3,7 @@ import logging
 from prompt_toolkit.completion import Completer, Completion
 from .packages.sqlcompletion import suggest_type
 from .packages.parseutils import last_word
-from re import compile
+from re import compile, escape
 
 try:
     from collections import Counter
@@ -176,7 +176,7 @@ class PGCompleter(Completer):
         self.all_completions = set(self.keywords + self.functions)
 
     @staticmethod
-    def find_matches(text, collection, start_only=False):
+    def find_matches(text, collection, start_only=False, fuzzy=True):
         """Find completion matches for the given text.
 
         Given the user's input text and a collection of available
@@ -194,12 +194,22 @@ class PGCompleter(Completer):
 
         text = last_word(text, include='most_punctuations').lower()
 
-        for item in sorted(collection):
-            match_end_limit = len(text) if start_only else None
-            match_point = item.lower().find(text, 0, match_end_limit)
+        completions = []
 
-            if match_point >= 0:
-                yield Completion(item, -len(text))
+        if fuzzy:
+            pat = compile(''.join([escape(c) + r'.*' for c in text]))
+            for item in sorted(collection):
+                r = pat.search(item)
+                if r:
+                    completions.append((r.start(), item))
+        else:
+            match_end_limit = len(text) if start_only else None
+            for item in sorted(collection):
+                match_point = item.lower().find(text, 0, match_end_limit)
+                if match_point >= 0:
+                    completions.append((match_point, item))
+
+        return (Completion(y, -len(text)) for x, y in sorted(completions))
 
     def get_completions(self, document, complete_event, smart_completion=None):
         word_before_cursor = document.get_word_before_cursor(WORD=True)
@@ -210,7 +220,7 @@ class PGCompleter(Completer):
         # 'word_before_cursor'.
         if not smart_completion:
             return self.find_matches(word_before_cursor, self.all_completions,
-                                     start_only=True)
+                                     start_only=True, fuzzy=False)
 
         completions = []
         suggestions = suggest_type(document.text, document.text_before_cursor)
@@ -247,7 +257,8 @@ class PGCompleter(Completer):
                     # matching
                     predefined_funcs = self.find_matches(word_before_cursor,
                                                          self.functions,
-                                                         start_only=True)
+                                                         start_only=True,
+                                                         fuzzy=False)
                     completions.extend(predefined_funcs)
 
             elif suggestion['type'] == 'schema':
@@ -297,13 +308,15 @@ class PGCompleter(Completer):
 
             elif suggestion['type'] == 'keyword':
                 keywords = self.find_matches(word_before_cursor, self.keywords,
-                                             start_only=True)
+                                             start_only=True,
+                                             fuzzy=False)
                 completions.extend(keywords)
 
             elif suggestion['type'] == 'special':
                 special = self.find_matches(word_before_cursor,
                                             self.special_commands,
-                                            start_only=True)
+                                            start_only=True,
+                                            fuzzy=False)
                 completions.extend(special)
 
             elif suggestion['type'] == 'datatype':
@@ -316,7 +329,8 @@ class PGCompleter(Completer):
                 if not suggestion['schema']:
                     # Also suggest hardcoded types
                     types = self.find_matches(word_before_cursor,
-                                              self.datatypes, start_only=True)
+                                              self.datatypes, start_only=True,
+                                              fuzzy=False)
                     completions.extend(types)
 
         return completions
@@ -383,7 +397,7 @@ class PGCompleter(Completer):
             try:
                 objects = metadata[schema].keys()
             except KeyError:
-                #schema doesn't exist
+                # schema doesn't exist
                 objects = []
         else:
             schemas = self.search_path

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -197,19 +197,21 @@ class PGCompleter(Completer):
         completions = []
 
         if fuzzy:
-            pat = compile(''.join([escape(c) + r'.*' for c in text]))
+            #pat = compile(''.join([escape(c) + r'.*' for c in text]))
+            regex = '.*'.join(map(escape, text))
+            pat = compile('(%s)' % regex)
             for item in sorted(collection):
                 r = pat.search(item)
                 if r:
-                    completions.append((r.start(), item))
+                    completions.append((len(r.group()), r.start(), item))
         else:
             match_end_limit = len(text) if start_only else None
             for item in sorted(collection):
                 match_point = item.lower().find(text, 0, match_end_limit)
                 if match_point >= 0:
-                    completions.append((match_point, item))
+                    completions.append((match_point, 0, item))
 
-        return (Completion(y, -len(text)) for x, y in sorted(completions))
+        return (Completion(z, -len(text)) for x, y, z in sorted(completions))
 
     def get_completions(self, document, complete_event, smart_completion=None):
         word_before_cursor = document.get_word_before_cursor(WORD=True)

--- a/tests/test_fuzzy_completion.py
+++ b/tests/test_fuzzy_completion.py
@@ -1,0 +1,54 @@
+from __future__ import unicode_literals
+import pytest
+from prompt_toolkit.completion import Completion
+from prompt_toolkit.document import Document
+
+
+@pytest.fixture
+def completer():
+    import pgcli.pgcompleter as pgcompleter
+    return pgcompleter.PGCompleter()
+
+
+def test_ranking_ignores_identifier_quotes(completer):
+    """When calculating result rank, identifier quotes should be ignored.
+
+    The result ranking algorithm ignores identifier quotes. Without this
+    correction, the match "user", which Postgres requires to be quoted
+    since it is also a reserved word, would incorrectly fall below the
+    match user_action because the literal quotation marks in "user"
+    alter the position of the match.
+
+    This test checks that the fuzzy ranking algorithm correctly ignores
+    quotation marks when computing match ranks.
+
+    """
+
+    text = 'user'
+    collection = ['user_action', '"user"']
+
+    result = [match.text for match in completer.find_matches(text, collection)]
+
+    assert result == ['"user"', 'user_action']
+
+
+def test_ranking_based_on_shortest_match(completer):
+    """Fuzzy result rank should be based on shortest match.
+
+    Result ranking in fuzzy searching is partially based on the length
+    of matches: shorter matches are considered more relevant than
+    longer ones. When searching for the text 'user', the length
+    component of the match 'user_group' could be either 4 ('user') or
+    7 ('user_gr').
+
+    This test checks that the fuzzy ranking algorithm uses the shorter
+    match when calculating result rank.
+
+    """
+
+    text = 'user'
+    collection = ['api_user', 'user_group']
+
+    result = [match.text for match in completer.find_matches(text, collection)]
+
+    assert result == ['user_group', 'api_user']


### PR DESCRIPTION
Reviewer: @drocco007 

This is an implementation of fuzzy completion (or true subsequence matching) for schemas/tables/columns/views. This is not enabled for keywords.

Typing `djms` will match `django_migrations`. It is implemented as follows:

When user types `djms` we create a regex pattern that looks like this `(d.*j.*m.*s)` and try to match against the collection. So `django_migrations` will be a positive match. 

In order to produce the relevant ordering in the suggestion menu, there are two ranking values used. 

1. Length of a matching group. 
2. Position of the first matching character. 

Here's how it is used:

Let's say there are two tables `django_migrations` and `misago_threads_post_mentions`. 

Case 1:
If a user starts to type `djm` it will be converted to `(d.*j.*m)`, which will match `django_migrations` which is what we want. 

Case 2:
If a user types `migr` it will be `(m.*i.*g.*r.*)` which will match both tables and depending on the location of the table in the list it is possibel that `misago_threads_post_mentions` will be listed first, but the user clearly intended to match `django_migrations` since they typed `migr`. The ranking algo will first check the length of the matching group in this case for `misago_threads_post_mentions` the matching group will be `misago_thr`. For `django_migrations` the matching group will be `migr`. The rank is assigned by the length of the matching group. So `django_migration` wins.

Another scenario: 

Let's take two table `django_migrations` and `migrations`. If the user types `migr`, the matching group will be the same for both strings, so the tie breaker is the appearance of the first matching character. In this case `migrations` table will win and it will be suggested first. 

This was a fun feature to implement. :)

Looking forward to your feedback.

ps: Thanks @zoltu. 