### PR TITLE
Do not escape the database names, since they clash with \c commands.

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -87,12 +87,11 @@ class PGCli(object):
                 aliases=('use', '\\connect', 'USE'))
 
     def change_db(self, pattern, **_):
-        db = pattern[1:-1] if pattern[0] == pattern[-1] == '"' else pattern
-
-        if pattern is None:
-            self.pgexecute.connect()
-        else:
+        if pattern:
+            db = pattern[1:-1] if pattern[0] == pattern[-1] == '"' else pattern
             self.pgexecute.connect(database=db)
+        else:
+            self.pgexecute.connect()
 
         yield (None, None, None, 'You are now connected to database "%s" as '
                 'user "%s"' % (self.pgexecute.dbname, self.pgexecute.user))

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -87,10 +87,12 @@ class PGCli(object):
                 aliases=('use', '\\connect', 'USE'))
 
     def change_db(self, pattern, **_):
+        db = pattern[1:-1] if pattern[0] == pattern[-1] == '"' else pattern
+
         if pattern is None:
             self.pgexecute.connect()
         else:
-            self.pgexecute.connect(database=pattern)
+            self.pgexecute.connect(database=db)
 
         yield (None, None, None, 'You are now connected to database "%s" as '
                 'user "%s"' % (self.pgexecute.dbname, self.pgexecute.user))

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -82,6 +82,7 @@ class PGCompleter(Completer):
         self.special_commands.extend(special_commands)
 
     def extend_database_names(self, databases):
+        databases = self.escaped_names(databases)
         self.databases.extend(databases)
 
     def extend_keywords(self, additional_keywords):

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -82,7 +82,6 @@ class PGCompleter(Completer):
         self.special_commands.extend(special_commands)
 
     def extend_database_names(self, databases):
-        databases = self.escaped_names(databases)
         self.databases.extend(databases)
 
     def extend_keywords(self, additional_keywords):


### PR DESCRIPTION
Database names should not be quoted even if they are keywords or have non-alphabets. 

Before this change database names with unicode characters were quoted. So when you try to change db, it will suggest  

![1__2_0_python_-__pgcli___users_amjith_dropbox_code_python_pgcli___tmux_](https://cloud.githubusercontent.com/assets/49260/8199514/adf4db2a-146b-11e5-81d3-441e47f571f1.png)

But choosing the database name with the quotes will result in error. 

![1__2_0_python_-__pgcli___users_amjith_dropbox_code_python_pgcli___tmux__and_comparing_master___amjith_no-escape-db-names_ _dbcli_pgcli](https://cloud.githubusercontent.com/assets/49260/8199521/ce3cfaf2-146b-11e5-9d88-e4e04724950a.png)

So quoting database names is not a desired behavior. 

/cc @darikg Can you review and merge? 