### PR TITLE
Assign a filename to the config obj.

### DIFF
--- a/pgcli/config.py
+++ b/pgcli/config.py
@@ -6,6 +6,7 @@ def load_config(usr_cfg, def_cfg=None):
     cfg = ConfigObj()
     cfg.merge(ConfigObj(def_cfg, interpolation=False))
     cfg.merge(ConfigObj(expanduser(usr_cfg), interpolation=False))
+    cfg.filename = expanduser(usr_cfg)
 
     return cfg
 


### PR DESCRIPTION
Reviewer: @macobo 

During my refactor of the config.py I had chosen to instantiate an empty ConfigObj() and then merge in the default and the user config files on it. But this meant the ConfigObj() that I created didn't have a filename associated with it. This broke the behavior of NamedQueries when it tried to save the queries to the ~/.pgclirc file. This PR fixes that issue.

/cc @brettatoms 