### PR TITLE
Make the horizontal separator in expanded mode a constant length.

### DIFF
--- a/pgcli/packages/expanded.py
+++ b/pgcli/packages/expanded.py
@@ -4,16 +4,8 @@ def pad(field, total, char=u" "):
     return field + (char * (total - len(field)))
 
 def get_separator(num, header_len, data_len):
-    total_len = header_len + data_len + 1
-
-    sep = u"-[ RECORD {0} ]".format(num)
-    if len(sep) < header_len:
-        sep = pad(sep, header_len - 1, u"-") + u"+"
-
-    if len(sep) < total_len:
-        sep = pad(sep, total_len, u"-")
-
-    return sep + u"\n"
+    sep = u"-[ RECORD {0} ]-------------------------\n".format(num)
+    return sep
 
 def expanded_table(rows, headers):
     header_len = max([len(x) for x in headers])

--- a/pgcli/packages/expanded.py
+++ b/pgcli/packages/expanded.py
@@ -3,14 +3,11 @@ from .tabulate import _text_type
 def pad(field, total, char=u" "):
     return field + (char * (total - len(field)))
 
-def get_separator(num, header_len, data_len):
-    sep = u"-[ RECORD {0} ]-------------------------\n".format(num)
-    return sep
-
 def expanded_table(rows, headers):
     header_len = max([len(x) for x in headers])
     max_row_len = 0
     results = []
+    sep = u"-[ RECORD {0} ]-------------------------\n"
 
     padded_headers = [pad(x, header_len) + u" |" for x in headers]
     header_len += 2
@@ -28,7 +25,7 @@ def expanded_table(rows, headers):
 
     output = []
     for i, result in enumerate(results):
-        output.append(get_separator(i, header_len, max_row_len))
+        output.append(sep.format(i))
         output.append(result)
         output.append('\n')
 

--- a/tests/test_expanded.py
+++ b/tests/test_expanded.py
@@ -4,10 +4,10 @@ import pytest
 def test_expanded_table_renders():
     input = [("hello", 123),("world", 456)]
 
-    expected = """-[ RECORD 0 ]
+    expected = """-[ RECORD 0 ]-------------------------
 name | hello
 age  | 123
--[ RECORD 1 ]
+-[ RECORD 1 ]-------------------------
 name | world
 age  | 456
 """


### PR DESCRIPTION
In expanded mode the record separator looks like this `-[ RECORD 26 ]-------------------------`. 

The number of dashes used to be calculated based on the longest value of a column. Now this is made a constant for two reasons. 

1. If a column has a really long value (say a multi-line paragraph). The separator will look ridiculous which  would make the expanded output useless. 
2. It is more performant to use a constant value instead of trying to iterate over the whole set of values just to determine the max length to use. 

Reviewer: @macobo 