### PR TITLE
Make named query names to the fuzzy matched.

### DIFF
--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -337,7 +337,7 @@ class PGCompleter(Completer):
 
             elif suggestion['type'] == 'namedquery':
                 queries = self.find_matches(word_before_cursor, namedqueries.list(),
-                                            start_only=True, fuzzy=False)
+                                            start_only=False, fuzzy=True)
                 completions.extend(queries)
 
         return completions


### PR DESCRIPTION
Reviewer: @j-bennet 

Previously the named queries were only matched based on starting characters. This change makes the matching to be fuzzy. 

Reasoning: We do start_only matching for keywords, special commands and datatypes. There is no need to restrict the named query matching to start_only. 

/cc @brettatoms 