### PR TITLE
Create a new error type for special command not found.

### DIFF
--- a/pgcli/packages/pgspecial/main.py
+++ b/pgcli/packages/pgspecial/main.py
@@ -15,6 +15,10 @@ SpecialCommand = namedtuple('SpecialCommand',
 COMMANDS = {}
 
 @export
+class CommandNotFound(Exception):
+    pass
+
+@export
 def parse_special_command(sql):
     command, _, arg = sql.partition(' ')
     verbose = '+' in command
@@ -47,12 +51,16 @@ def register_special_command(handler, command, syntax, description,
 @export
 def execute(cur, sql):
     command, verbose, pattern = parse_special_command(sql)
+
+    if (command not in COMMANDS) and (command.lower() not in COMMANDS):
+        raise CommandNotFound
+
     try:
         special_cmd = COMMANDS[command]
     except KeyError:
         special_cmd = COMMANDS[command.lower()]
         if special_cmd.case_sensitive:
-            raise KeyError('Command not found: %s' % command)
+            raise CommandNotFound('Command not found: %s' % command)
 
     if special_cmd.arg_type == NO_QUERY:
         return special_cmd.handler()

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -208,7 +208,7 @@ class PGExecute(object):
                 cur = self.conn.cursor()
                 for result in special.execute(cur, sql):
                     yield result
-            except KeyError:  # Regular SQL
+            except special.CommandNotFound:  # Regular SQL
                 yield self.execute_normal_sql(sql)
 
     def execute_normal_sql(self, split_sql):


### PR DESCRIPTION
Reviewer: @darikg 

Simple change to raise a custom exception type when a special command is not found.

Previously it used to raise KeyError, but this is not as explicit as I'd like it to be. 