### PR TITLE
Amjith/named query docs

### DIFF
--- a/pgcli/packages/pgspecial/main.py
+++ b/pgcli/packages/pgspecial/main.py
@@ -15,6 +15,10 @@ SpecialCommand = namedtuple('SpecialCommand',
 COMMANDS = {}
 
 @export
+class CommandNotFound(Exception):
+    pass
+
+@export
 def parse_special_command(sql):
     command, _, arg = sql.partition(' ')
     verbose = '+' in command
@@ -47,12 +51,16 @@ def register_special_command(handler, command, syntax, description,
 @export
 def execute(cur, sql):
     command, verbose, pattern = parse_special_command(sql)
+
+    if (command not in COMMANDS) and (command.lower() not in COMMANDS):
+        raise CommandNotFound
+
     try:
         special_cmd = COMMANDS[command]
     except KeyError:
         special_cmd = COMMANDS[command.lower()]
         if special_cmd.case_sensitive:
-            raise KeyError('Command not found: %s' % command)
+            raise CommandNotFound('Command not found: %s' % command)
 
     if special_cmd.arg_type == NO_QUERY:
         return special_cmd.handler()

--- a/pgcli/packages/pgspecial/namedqueries.py
+++ b/pgcli/packages/pgspecial/namedqueries.py
@@ -1,6 +1,35 @@
+# -*- coding: utf-8 -*-
 class NamedQueries(object):
 
     section_name = 'named queries'
+
+    usage = u'''Named Queries are a way to save frequently used queries
+with a short name. Think of them as favorites.
+Examples:
+
+    # Save a new named query.
+    > \\ns simple select * from abc where a is not Null;
+
+    # List all named queries.
+    > \\n+
+    ╒════════╤═══════════════════════════════════════╕
+    │ Name   │ Query                                 │
+    ╞════════╪═══════════════════════════════════════╡
+    │ simple │ SELECT * FROM abc where a is not NULL │
+    ╘════════╧═══════════════════════════════════════╛
+
+    # Run a named query.
+    > \\n simple
+    ╒════════╤════════╕
+    │ a      │ b      │
+    ╞════════╪════════╡
+    │ 日本語 │ 日本語 │
+    ╘════════╧════════╛
+
+    # Delete a named query.
+    > \\nd simple
+    simple: Deleted
+'''
 
     def __init__(self, config):
         self.config = config
@@ -18,9 +47,12 @@ class NamedQueries(object):
         self.config.write()
 
     def delete(self, name):
-        if self.section_name in self.config and name in self.config[self.section_name]:
+        try:
             del self.config[self.section_name][name]
-            self.config.write()
+        except KeyError:
+            return '%s: Not Found.' % name
+        self.config.write()
+        return '%s: Deleted' % name
 
 from ...config import load_config
 namedqueries = NamedQueries(load_config('~/.pgclirc'))

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -208,7 +208,7 @@ class PGExecute(object):
                 cur = self.conn.cursor()
                 for result in special.execute(cur, sql):
                     yield result
-            except KeyError:  # Regular SQL
+            except special.CommandNotFound:  # Regular SQL
                 yield self.execute_normal_sql(sql)
 
     def execute_normal_sql(self, split_sql):


### PR DESCRIPTION
Reviewer: @j-bennet 

Closes #264 #265 

When a user invokes `\n` and there are no saved queries, the documentation for that command will be printed. 

When a user makes a mistake like invoking `\ns` or `\nd` without giving it an argument, it will print the usage. 

This should help educate users about this awesome feature. :)

/cc @brettatoms 