### PR TITLE
Upgrade to prompt_toolkit==0.42.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         install_requires=[
             'click >= 3.2',
             'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
-            'prompt_toolkit==0.40',
+            'prompt_toolkit==0.42',
             'psycopg2 >= 2.5.4',
             'sqlparse == 0.1.14',
             'configobj >= 5.0.6'


### PR DESCRIPTION
Upgrade to the latest prompt-toolkit.
Windows support should now have been improved significantly. Especially the rendering (the completion menu doesn't leave traces anymore), and handling of unicode input. French characters of latin-1 like ``éôë``, etc.. should work correctly.

Normally, there are no backwards incompatible changes in this release.

@darikg: Please have a look.

Cheers,
Jonathan