### PR TITLE
More specials refactoring

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -448,13 +448,13 @@ def cli(database, user, host, port, prompt_passwd, never_prompt, dbname,
 
     pgcli.run_cli()
 
-def format_output(title, cur, headers, status, table_format):
+def format_output(title, cur, headers, status, table_format, expanded=False):
     output = []
     if title:  # Only print the title if it's not None.
         output.append(title)
     if cur:
         headers = [utf8tounicode(x) for x in headers]
-        if special.is_expanded_output():
+        if expanded:
             output.append(expanded_table(cur, headers))
         else:
             output.append(tabulate(cur, headers, tablefmt=table_format,

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -23,7 +23,7 @@ from pygments.token import Token
 
 from .packages.tabulate import tabulate
 from .packages.expanded import expanded_table
-from .packages.pgspecial.main import (COMMANDS, NO_QUERY)
+from .packages.pgspecial.main import (PGSpecial, NO_QUERY)
 import pgcli.packages.pgspecial as special
 from .pgcompleter import PGCompleter
 from .pgtoolbar import create_toolbar_tokens_func
@@ -62,11 +62,15 @@ class PGCli(object):
         default_config = os.path.join(package_root, 'pgclirc')
         write_default_config(default_config, '~/.pgclirc')
 
+        self.use_expanded_output = False
+
+        self.pgspecial = PGSpecial()
+
         # Load config.
         c = self.config = load_config('~/.pgclirc', default_config)
         self.multi_line = c['main'].as_bool('multi_line')
         self.vi_mode = c['main'].as_bool('vi')
-        special.set_timing(c['main'].as_bool('timing'))
+        self.timing_enabled = c['main'].as_bool('timing')
         self.table_format = c['main']['table_format']
         self.syntax_style = c['main']['syntax_style']
 
@@ -82,13 +86,21 @@ class PGCli(object):
         self.register_special_commands()
 
     def register_special_commands(self):
-        special.register_special_command(self.change_db, '\\c',
-                '\\c[onnect] database_name', 'Change to a new database.',
-                aliases=('use', '\\connect', 'USE'))
-        special.register_special_command(self.refresh_completions, '\\#',
-                '\\#', 'Refresh auto-completions.', arg_type=NO_QUERY)
-        special.register_special_command(self.refresh_completions, '\\refresh',
-                '\\refresh', 'Refresh auto-completions.', arg_type=NO_QUERY)
+
+        self.pgspecial.register(self.change_db, '\\c',
+                              '\\c[onnect] database_name',
+                              'Change to a new database.',
+                              aliases=('use', '\\connect', 'USE'))
+        self.pgspecial.register(self.refresh_completions, '\\#', '\\#',
+                              'Refresh auto-completions.', arg_type=NO_QUERY)
+        self.pgspecial.register(self.refresh_completions, '\\refresh', '\\refresh',
+                              'Refresh auto-completions.', arg_type=NO_QUERY)
+
+        self.pgspecial.register(self.toggle_expanded_output, '\\x', '\\x',
+                              'Toggle expanded output.', arg_type=NO_QUERY)
+
+        self.pgspecial.register(self.toggle_timing, '\\timing', '\\timing',
+                      'Toggle timing of commands.', arg_type=NO_QUERY)
 
     def change_db(self, pattern, **_):
         if pattern:
@@ -305,8 +317,11 @@ class PGCli(object):
                             if not click.confirm('Do you want to continue?'):
                                 click.secho("Aborted!", err=True, fg='red')
                                 break
-                        output.extend(format_output(title, cur, headers,
-                            status, self.table_format))
+
+                        formatted = format_output(title, cur, headers, status,
+                                                  self.table_format,
+                                                  self.use_expanded_output)
+                        output.extend(formatted)
                         end = time()
                         total += end - start
                         mutating = mutating or is_mutating(status)
@@ -339,7 +354,7 @@ class PGCli(object):
                     click.secho(str(e), err=True, fg='red')
                 else:
                     click.echo_via_pager('\n'.join(output))
-                    if special.get_timing():
+                    if self.timing_enabled:
                         print('Command Time: %0.03fs' % duration)
                         print('Format Time: %0.03fs' % total)
 
@@ -397,13 +412,26 @@ class PGCli(object):
         completer.extend_database_names(pgexecute.databases())
 
         # special commands
-        completer.extend_special_commands(COMMANDS.keys())
+        completer.extend_special_commands(self.pgspecial.commands.keys())
 
         return [(None, None, None, 'Auto-completions refreshed.')]
 
     def get_completions(self, text, cursor_positition):
         return self.completer.get_completions(
             Document(text=text, cursor_position=cursor_positition), None)
+
+    def toggle_expanded_output(self):
+        """Callback for the \\x special command"""
+        self.use_expanded_output = not self.use_expanded_output
+        message = u"Expanded display is "
+        message += u"on." if self.use_expanded_output else u"off."
+        return [(None, None, None, message)]
+
+    def toggle_timing(self):
+        self.timing_enabled = not self.timing_enabled
+        message = "Timing is "
+        message += "on." if self.timing_enabled else "off."
+        return [(None, None, None, message)]
 
 @click.command()
 # Default host is '' so psycopg2 can default to either localhost or unix socket

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -299,7 +299,7 @@ class PGCli(object):
                     res = []
                     start = time()
                     # Run the query.
-                    res = pgexecute.run(document.text)
+                    res = pgexecute.run(document.text, self.pgspecial)
                     duration = time() - start
                     successful = True
                     output = []

--- a/pgcli/packages/pgspecial/iocommands.py
+++ b/pgcli/packages/pgspecial/iocommands.py
@@ -8,38 +8,6 @@ from . import export
 
 _logger = logging.getLogger(__name__)
 
-TIMING_ENABLED = True
-use_expanded_output = False
-
-@export
-def is_expanded_output():
-    return use_expanded_output
-
-@special_command('\\x', '\\x', 'Toggle expanded output.', arg_type=NO_QUERY)
-def toggle_expanded_output():
-    global use_expanded_output
-    use_expanded_output = not use_expanded_output
-    message = u"Expanded display is "
-    message += u"on." if use_expanded_output else u"off."
-    return [(None, None, None, message)]
-
-@special_command('\\timing', '\\timing', 'Toggle timing of commands.', arg_type=NO_QUERY)
-def toggle_timing():
-    global TIMING_ENABLED
-    TIMING_ENABLED = not TIMING_ENABLED
-    message = "Timing is "
-    message += "on." if TIMING_ENABLED else "off."
-    return [(None, None, None, message)]
-
-@export
-def set_timing(enable=True):
-    global TIMING_ENABLED
-    TIMING_ENABLED = enable
-
-@export
-def get_timing():
-    return TIMING_ENABLED
-
 
 @export
 def editor_command(command):

--- a/pgcli/packages/pgspecial/main.py
+++ b/pgcli/packages/pgspecial/main.py
@@ -25,8 +25,18 @@ class PGSpecial(object):
         self.timing_enabled = True
 
         self.commands = COMMANDS.copy()
+
+        self.timing_enabled = False
+        self.expanded_output = False
+
         self.register(self.show_help, '\\?', '\\?', 'Show Help.',
                       arg_type=NO_QUERY)
+
+        self.register(self.toggle_expanded_output, '\\x', '\\x',
+                      'Toggle expanded output.', arg_type=NO_QUERY)
+
+        self.register(self.toggle_timing, '\\timing', '\\timing',
+                      'Toggle timing of commands.', arg_type=NO_QUERY)
 
     def register(self, *args, **kwargs):
         register_special_command(*args, command_dict=self.commands, **kwargs)
@@ -42,6 +52,18 @@ class PGSpecial(object):
             if not value.hidden:
                 result.append((value.syntax, value.description))
         return [(None, result, headers, None)]
+
+    def toggle_expanded_output(self):
+        self.expanded_output = not self.expanded_output
+        message = u"Expanded display is "
+        message += u"on." if self.expanded_output else u"off."
+        return [(None, None, None, message)]
+
+    def toggle_timing(self):
+        self.timing_enabled = not self.timing_enabled
+        message = "Timing is "
+        message += "on." if self.timing_enabled else "off."
+        return [(None, None, None, message)]
 
 
 @export

--- a/pgcli/packages/pgspecial/tests/conftest.py
+++ b/pgcli/packages/pgspecial/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from dbutils import (create_db, db_connection, setup_db, teardown_db)
-from pgcli.packages.pgspecial.main import execute
+from pgcli.packages.pgspecial import PGSpecial
 
 
 @pytest.yield_fixture(scope='module')
@@ -23,10 +23,11 @@ def cursor(connection):
 @pytest.fixture
 def executor(connection):
     cur = connection.cursor()
+    pgspecial = PGSpecial()
 
     def query_runner(sql):
         results = []
-        for title, rows, headers, status in execute(cur=cur, sql=sql):
+        for title, rows, headers, status in pgspecial.execute(cur=cur, sql=sql):
             results.extend((title, list(rows), headers, status))
         return results
     return query_runner

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -2,6 +2,7 @@
 
 import pytest
 import psycopg2
+from pgcli.packages.pgspecial import PGSpecial
 from textwrap import dedent
 from utils import run, dbtest, requires_json, requires_jsonb
 
@@ -120,8 +121,8 @@ def test_multiple_queries_same_line(executor):
     assert "bar" in result[2]
 
 @dbtest
-def test_multiple_queries_with_special_command_same_line(executor):
-    result = run(executor, "select 'foo'; \d")
+def test_multiple_queries_with_special_command_same_line(executor, pgspecial):
+    result = run(executor, "select 'foo'; \d", pgspecial=pgspecial)
     assert len(result) == 4  # 2 * (output+status)
     assert "foo" in result[0]
     # This is a lame check. :(
@@ -133,9 +134,15 @@ def test_multiple_queries_same_line_syntaxerror(executor):
         run(executor, "select 'foo'; invalid syntax")
     assert 'syntax error at or near "invalid"' in str(excinfo.value)
 
+
+@pytest.fixture
+def pgspecial():
+    return PGSpecial()
+
+
 @dbtest
-def test_special_command_help(executor):
-    result = run(executor, '\\?')[0].split('|')
+def test_special_command_help(executor, pgspecial):
+    result = run(executor, '\\?', pgspecial=pgspecial)[0].split('|')
     assert(result[1].find(u'Command') != -1)
     assert(result[2].find(u'Description') != -1)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -58,10 +58,10 @@ def drop_tables(conn):
             DROP SCHEMA IF EXISTS schema2 CASCADE''')
 
 
-def run(executor, sql, join=False, expanded=False):
+def run(executor, sql, join=False, expanded=False, pgspecial=None):
     " Return string output for the sql to be run "
     result = []
-    for title, rows, headers, status in executor.run(sql):
+    for title, rows, headers, status in executor.run(sql, pgspecial):
         result.extend(format_output(title, rows, headers, status, 'psql',
                                     expanded=expanded))
     if join:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -58,11 +58,12 @@ def drop_tables(conn):
             DROP SCHEMA IF EXISTS schema2 CASCADE''')
 
 
-def run(executor, sql, join=False):
+def run(executor, sql, join=False, expanded=False):
     " Return string output for the sql to be run "
     result = []
     for title, rows, headers, status in executor.run(sql):
-        result.extend(format_output(title, rows, headers, status, 'psql'))
+        result.extend(format_output(title, rows, headers, status, 'psql',
+                                    expanded=expanded))
     if join:
         result = '\n'.join(result)
     return result


### PR DESCRIPTION
Building on @amjith's last specials refactor, this wraps up a lot of the specials.main file into a PGSpecial class, which makes it possible for multiple PGCli instances to coexist in the same python interpreter without interfering with each other through module level globals in pgspecial. While doing this I was also able to weaken some of the coupling between pgspecial, pgexecute, and pgcli.

As before, special commands that do not manipulate state are defined by the `@special_command` decorator, which stores metadata in the `COMMANDS` variable. During initialization of a new PGSpecial object, a *copy* of `COMMANDS` is stored in the member variable `commands`. Further special method registration is done through the method PGSpecial.register, which of course modifies only the member variable, not the module one.

One hesitation I had was where the code for `\x` and `\timing` belonged. Because they're ultimately responsible for mutating the state of the cli application I moved them out of the specials package and into PGCli, in parallel to `\c` and `\#`.