### PR TITLE
Always use utf8 as the default encoding.

### DIFF
--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -162,6 +162,7 @@ class PGExecute(object):
                 password=unicode2utf8(password),
                 host=unicode2utf8(host),
                 port=unicode2utf8(port))
+        conn.set_client_encoding('utf8')
         if hasattr(self, 'conn'):
             self.conn.close()
         self.conn = conn


### PR DESCRIPTION
Fixes #274.

This change will enforce utf8 encoding while connecting to a database instead of using the encoding of the database. This is because all of pgcli depends on using utf8.

Reviewer: @drocco007 