### PR TITLE
[wip/rfc] Put meta info in the completions menu

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -79,7 +79,7 @@ class PGCli(object):
 
         # Initialize completer
         smart_completion = c['main'].as_bool('smart_completion')
-        completer = PGCompleter(smart_completion)
+        completer = PGCompleter(smart_completion, pgspecial=self.pgspecial)
         self.completer = completer
         self.register_special_commands()
 
@@ -402,9 +402,6 @@ class PGCli(object):
 
         # databases
         completer.extend_database_names(pgexecute.databases())
-
-        # special commands
-        completer.extend_special_commands(self.pgspecial.commands.keys())
 
         return [(None, None, None, 'Auto-completions refreshed.')]
 

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -345,11 +345,15 @@ class PGCompleter(Completer):
                 if not self.pgspecial:
                     continue
 
-                special = self.find_matches(word_before_cursor,
-                                            self.pgspecial.commands.keys(),
+                commands = self.pgspecial.commands
+                cmd_names = commands.keys()
+                desc = [commands[cmd].description for cmd in cmd_names]
+
+                special = self.find_matches(word_before_cursor, cmd_names,
                                             start_only=True,
                                             fuzzy=False,
-                                            meta='special command')
+                                            meta_collection=desc)
+
                 completions.extend(special)
 
             elif suggestion['type'] == 'datatype':

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -265,14 +265,16 @@ class PGCompleter(Completer):
                                          in Counter(scoped_cols).items()
                                            if count > 1 and col != '*']
 
-                cols = self.find_matches(word_before_cursor, scoped_cols)
+                cols = self.find_matches(word_before_cursor, scoped_cols,
+                                         meta='column')
                 completions.extend(cols)
 
             elif suggestion['type'] == 'function':
                 # suggest user-defined functions using substring matching
                 funcs = self.populate_schema_objects(
                     suggestion['schema'], 'functions')
-                user_funcs = self.find_matches(word_before_cursor, funcs)
+                user_funcs = self.find_matches(word_before_cursor, funcs,
+                                               meta='function')
                 completions.extend(user_funcs)
 
                 if not suggestion['schema']:
@@ -281,7 +283,8 @@ class PGCompleter(Completer):
                     predefined_funcs = self.find_matches(word_before_cursor,
                                                          self.functions,
                                                          start_only=True,
-                                                         fuzzy=False)
+                                                         fuzzy=False,
+                                                         meta='function')
                     completions.extend(predefined_funcs)
 
             elif suggestion['type'] == 'schema':
@@ -293,7 +296,9 @@ class PGCompleter(Completer):
                     schema_names = [s for s in schema_names
                                       if not s.startswith('pg_')]
 
-                schema_names = self.find_matches(word_before_cursor, schema_names)
+                schema_names = self.find_matches(word_before_cursor,
+                                                 schema_names,
+                                                 meta='schema')
                 completions.extend(schema_names)
 
             elif suggestion['type'] == 'table':
@@ -306,7 +311,8 @@ class PGCompleter(Completer):
                         not word_before_cursor.startswith('pg_')):
                     tables = [t for t in tables if not t.startswith('pg_')]
 
-                tables = self.find_matches(word_before_cursor, tables)
+                tables = self.find_matches(word_before_cursor, tables,
+                                           meta='table')
                 completions.extend(tables)
 
             elif suggestion['type'] == 'view':
@@ -317,48 +323,55 @@ class PGCompleter(Completer):
                         not word_before_cursor.startswith('pg_')):
                     views = [v for v in views if not v.startswith('pg_')]
 
-                views = self.find_matches(word_before_cursor, views)
+                views = self.find_matches(word_before_cursor, views,
+                                          meta='view')
                 completions.extend(views)
 
             elif suggestion['type'] == 'alias':
                 aliases = suggestion['aliases']
-                aliases = self.find_matches(word_before_cursor, aliases)
+                aliases = self.find_matches(word_before_cursor, aliases,
+                                            meta='table alias')
                 completions.extend(aliases)
 
             elif suggestion['type'] == 'database':
-                dbs = self.find_matches(word_before_cursor, self.databases)
+                dbs = self.find_matches(word_before_cursor, self.databases,
+                                        meta='database')
                 completions.extend(dbs)
 
             elif suggestion['type'] == 'keyword':
                 keywords = self.find_matches(word_before_cursor, self.keywords,
                                              start_only=True,
-                                             fuzzy=False)
+                                             fuzzy=False,
+                                             meta='keyword')
                 completions.extend(keywords)
 
             elif suggestion['type'] == 'special':
                 special = self.find_matches(word_before_cursor,
                                             self.special_commands,
                                             start_only=True,
-                                            fuzzy=False)
+                                            fuzzy=False,
+                                            meta='special command')
                 completions.extend(special)
 
             elif suggestion['type'] == 'datatype':
                 # suggest custom datatypes
                 types = self.populate_schema_objects(
                     suggestion['schema'], 'datatypes')
-                types = self.find_matches(word_before_cursor, types)
+                types = self.find_matches(word_before_cursor, types,
+                                          meta='datatype')
                 completions.extend(types)
 
                 if not suggestion['schema']:
                     # Also suggest hardcoded types
                     types = self.find_matches(word_before_cursor,
                                               self.datatypes, start_only=True,
-                                              fuzzy=False)
+                                              fuzzy=False, meta='datatype')
                     completions.extend(types)
 
             elif suggestion['type'] == 'namedquery':
                 queries = self.find_matches(word_before_cursor, namedqueries.list(),
-                                            start_only=False, fuzzy=True)
+                                            start_only=False, fuzzy=True,
+                                            meta='named query')
                 completions.extend(queries)
 
         return completions

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -224,8 +224,10 @@ class PGCompleter(Completer):
         for item, meta in collection:
             sort_key = _match(item)
             if sort_key:
-                # Truncate meta-text to 50 characters, if necessary
-                meta = meta if len(meta) <= 50 else meta[:47] + u'...'
+                if meta and len(meta) > 50:
+                    # Truncate meta-text to 50 characters, if necessary
+                    meta = meta[:47] + u'...'
+
                 completions.append((sort_key, item, meta))
 
         return [Completion(item, -len(text), display_meta=meta)

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -224,6 +224,8 @@ class PGCompleter(Completer):
         for item, meta in collection:
             sort_key = _match(item)
             if sort_key:
+                # Truncate meta-text to 50 characters, if necessary
+                meta = meta if len(meta) <= 50 else meta[:47] + u'...'
                 completions.append((sort_key, item, meta))
 
         return [Completion(item, -len(text), display_meta=meta)

--- a/pgcli/pgstyle.py
+++ b/pgcli/pgstyle.py
@@ -19,8 +19,8 @@ def style_factory(name):
         styles.update({
             Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
             Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',
-            Token.Menu.Completions.Meta.Current: 'bg:#00aaaa #000000',
-            Token.Menu.Completions.Meta: 'bg:#008888 #ffffff',
+            Token.Menu.Completions.Meta.Current: 'bg:#44aaaa #000000',
+            Token.Menu.Completions.Meta: 'bg:#448888 #ffffff',
             Token.Menu.Completions.ProgressButton: 'bg:#003333',
             Token.Menu.Completions.ProgressBar: 'bg:#00aaaa',
             Token.SelectedText: '#ffffff bg:#6666aa',

--- a/pgcli/pgstyle.py
+++ b/pgcli/pgstyle.py
@@ -19,6 +19,8 @@ def style_factory(name):
         styles.update({
             Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
             Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',
+            Token.Menu.Completions.Meta.Current: 'bg:#00aaaa #000000',
+            Token.Menu.Completions.Meta: 'bg:#008888 #ffffff',
             Token.Menu.Completions.ProgressButton: 'bg:#003333',
             Token.Menu.Completions.ProgressBar: 'bg:#00aaaa',
             Token.SelectedText: '#ffffff bg:#6666aa',

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -67,11 +67,12 @@ def test_schema_or_visible_table_completion(completer, complete_event):
     position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
-    assert set(result) == set([Completion(text='public', start_position=0),
-                               Completion(text='custom', start_position=0),
-                               Completion(text='users', start_position=0),
-                               Completion(text='"select"', start_position=0),
-                               Completion(text='orders', start_position=0)])
+    assert set(result) == set([
+       Completion(text='public', start_position=0, display_meta='schema'),
+       Completion(text='custom', start_position=0, display_meta='schema'),
+       Completion(text='users', start_position=0, display_meta='table'),
+       Completion(text='"select"', start_position=0, display_meta='table'),
+       Completion(text='orders', start_position=0, display_meta='table')])
 
 def test_suggested_column_names_from_shadowed_visible_table(completer, complete_event):
     """
@@ -86,14 +87,14 @@ def test_suggested_column_names_from_shadowed_visible_table(completer, complete_
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='email', start_position=0),
-        Completion(text='first_name', start_position=0),
-        Completion(text='last_name', start_position=0),
-        Completion(text='func1', start_position=0),
-        Completion(text='func2', start_position=0)] +
-        list(map(Completion, completer.functions)))
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='email', start_position=0, display_meta='column'),
+        Completion(text='first_name', start_position=0, display_meta='column'),
+        Completion(text='last_name', start_position=0, display_meta='column'),
+        Completion(text='func1', start_position=0, display_meta='function'),
+        Completion(text='func2', start_position=0, display_meta='function')] +
+        list(map(lambda f: Completion(f, display_meta='function'), completer.functions)))
 
 def test_suggested_column_names_from_qualified_shadowed_table(completer, complete_event):
     text = 'SELECT  from custom.users'
@@ -102,12 +103,12 @@ def test_suggested_column_names_from_qualified_shadowed_table(completer, complet
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='phone_number', start_position=0),
-        Completion(text='func1', start_position=0),
-        Completion(text='func2', start_position=0)] +
-        list(map(Completion, completer.functions)))
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='phone_number', start_position=0, display_meta='column'),
+        Completion(text='func1', start_position=0, display_meta='function'),
+        Completion(text='func2', start_position=0, display_meta='function')] +
+        list(map(lambda f: Completion(f, display_meta='function'), completer.functions)))
 
 def test_suggested_column_names_from_schema_qualifed_table(completer, complete_event):
     """
@@ -121,13 +122,13 @@ def test_suggested_column_names_from_schema_qualifed_table(completer, complete_e
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position), complete_event))
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='product_name', start_position=0),
-        Completion(text='price', start_position=0),
-        Completion(text='func1', start_position=0),
-        Completion(text='func2', start_position=0)] +
-        list(map(Completion, completer.functions)))
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='product_name', start_position=0, display_meta='column'),
+        Completion(text='price', start_position=0, display_meta='column'),
+        Completion(text='func1', start_position=0, display_meta='function'),
+        Completion(text='func2', start_position=0, display_meta='function')] +
+        list(map(lambda f: Completion(f, display_meta='function'), completer.functions)))
 
 def test_suggested_column_names_in_function(completer, complete_event):
     """
@@ -143,10 +144,10 @@ def test_suggested_column_names_in_function(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event)
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='product_name', start_position=0),
-        Completion(text='price', start_position=0)])
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='product_name', start_position=0, display_meta='column'),
+        Completion(text='price', start_position=0, display_meta='column')])
 
 def test_suggested_table_names_with_schema_dot(completer, complete_event):
     text = 'SELECT * FROM custom.'
@@ -154,9 +155,9 @@ def test_suggested_table_names_with_schema_dot(completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([
-        Completion(text='users', start_position=0),
-        Completion(text='products', start_position=0),
-        Completion(text='shipments', start_position=0)])
+        Completion(text='users', start_position=0, display_meta='table'),
+        Completion(text='products', start_position=0, display_meta='table'),
+        Completion(text='shipments', start_position=0, display_meta='table')])
 
 def test_suggested_column_names_with_qualified_alias(completer, complete_event):
     """
@@ -171,10 +172,10 @@ def test_suggested_column_names_with_qualified_alias(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='product_name', start_position=0),
-        Completion(text='price', start_position=0)])
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='product_name', start_position=0, display_meta='column'),
+        Completion(text='price', start_position=0, display_meta='column')])
 
 def test_suggested_multiple_column_names(completer, complete_event):
     """
@@ -190,13 +191,13 @@ def test_suggested_multiple_column_names(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='product_name', start_position=0),
-        Completion(text='price', start_position=0),
-        Completion(text='func1', start_position=0),
-        Completion(text='func2', start_position=0)] +
-        list(map(Completion, completer.functions)))
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='product_name', start_position=0, display_meta='column'),
+        Completion(text='price', start_position=0, display_meta='column'),
+        Completion(text='func1', start_position=0, display_meta='function'),
+        Completion(text='func2', start_position=0, display_meta='function')] +
+        list(map(lambda f: Completion(f, display_meta='function'), completer.functions)))
 
 def test_suggested_multiple_column_names_with_alias(completer, complete_event):
     """
@@ -212,10 +213,10 @@ def test_suggested_multiple_column_names_with_alias(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='product_name', start_position=0),
-        Completion(text='price', start_position=0)])
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='product_name', start_position=0, display_meta='column'),
+        Completion(text='price', start_position=0, display_meta='column')])
 
 def test_suggested_aliases_after_on(completer, complete_event):
     text = 'SELECT x.id, y.product_name FROM custom.products x JOIN custom.products y ON '
@@ -224,8 +225,8 @@ def test_suggested_aliases_after_on(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='x', start_position=0),
-        Completion(text='y', start_position=0)])
+        Completion(text='x', start_position=0, display_meta='table alias'),
+        Completion(text='y', start_position=0, display_meta='table alias')])
 
 def test_suggested_aliases_after_on_right_side(completer, complete_event):
     text = 'SELECT x.id, y.product_name FROM custom.products x JOIN custom.products y ON x.id = '
@@ -234,8 +235,8 @@ def test_suggested_aliases_after_on_right_side(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='x', start_position=0),
-        Completion(text='y', start_position=0)])
+        Completion(text='x', start_position=0, display_meta='table alias'),
+        Completion(text='y', start_position=0, display_meta='table alias')])
 
 def test_table_names_after_from(completer, complete_event):
     text = 'SELECT * FROM '
@@ -244,11 +245,11 @@ def test_table_names_after_from(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='public', start_position=0),
-        Completion(text='custom', start_position=0),
-        Completion(text='users', start_position=0),
-        Completion(text='orders', start_position=0),
-        Completion(text='"select"', start_position=0),
+        Completion(text='public', start_position=0, display_meta='schema'),
+        Completion(text='custom', start_position=0, display_meta='schema'),
+        Completion(text='users', start_position=0, display_meta='table'),
+        Completion(text='orders', start_position=0, display_meta='table'),
+        Completion(text='"select"', start_position=0, display_meta='table'),
         ])
 
 def test_schema_qualified_function_name(completer, complete_event):
@@ -257,8 +258,8 @@ def test_schema_qualified_function_name(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=postion), complete_event))
     assert result == set([
-        Completion(text='func3', start_position=-len('func')),
-        Completion(text='func4', start_position=-len('func'))])
+        Completion(text='func3', start_position=-len('func'), display_meta='function'),
+        Completion(text='func4', start_position=-len('func'), display_meta='function')])
 
 
 @pytest.mark.parametrize('text', [
@@ -272,9 +273,9 @@ def test_schema_qualified_type_name(text, completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event)
     assert set(result) == set([
-        Completion(text='typ3'),
-        Completion(text='typ4'),
-        Completion(text='users'),
-        Completion(text='products'),
-        Completion(text='shipments'),
+        Completion(text='typ3', display_meta='datatype'),
+        Completion(text='typ4', display_meta='datatype'),
+        Completion(text='users', display_meta='table'),
+        Completion(text='products', display_meta='table'),
+        Completion(text='shipments', display_meta='table'),
         ])

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -65,7 +65,8 @@ def test_empty_string_completion(completer, complete_event):
         completer.get_completions(
             Document(text=text, cursor_position=position),
             complete_event))
-    assert set(map(Completion, completer.keywords)) == result
+    assert set(map(lambda x: Completion(x, display_meta='keyword'),
+                    completer.keywords)) == result
 
 def test_select_keyword_completion(completer, complete_event):
     text = 'SEL'
@@ -73,7 +74,8 @@ def test_select_keyword_completion(completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event)
-    assert set(result) == set([Completion(text='SELECT', start_position=-3)])
+    assert set(result) == set([Completion(text='SELECT', start_position=-3,
+                                          display_meta='keyword')])
 
 
 def test_schema_or_visible_table_completion(completer, complete_event):
@@ -81,11 +83,12 @@ def test_schema_or_visible_table_completion(completer, complete_event):
     position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
-    assert set(result) == set([Completion(text='public', start_position=0),
-                               Completion(text='users', start_position=0),
-                               Completion(text='"select"', start_position=0),
-                               Completion(text='orders', start_position=0),
-                               Completion(text='user_emails', start_position=0)])
+    assert set(result) == set([
+        Completion(text='public', start_position=0, display_meta='schema'),
+        Completion(text='users', start_position=0, display_meta='table'),
+        Completion(text='"select"', start_position=0, display_meta='table'),
+        Completion(text='orders', start_position=0, display_meta='table'),
+        Completion(text='user_emails', start_position=0, display_meta='view')])
 
 
 def test_builtin_function_name_completion(completer, complete_event):
@@ -93,7 +96,8 @@ def test_builtin_function_name_completion(completer, complete_event):
     position = len('SELECT MA')
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
-    assert set(result) == set([Completion(text='MAX', start_position=-2)])
+    assert set(result) == set([Completion(text='MAX', start_position=-2,
+                                          display_meta='function')])
 
 
 def test_builtin_function_matches_only_at_start(completer, complete_event):
@@ -113,8 +117,8 @@ def test_user_function_name_completion(completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([
-        Completion(text='custom_func1', start_position=-2),
-        Completion(text='custom_func2', start_position=-2)])
+        Completion(text='custom_func1', start_position=-2, display_meta='function'),
+        Completion(text='custom_func2', start_position=-2, display_meta='function')])
 
 
 def test_user_function_name_completion_matches_anywhere(completer,
@@ -124,8 +128,8 @@ def test_user_function_name_completion_matches_anywhere(completer,
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([
-        Completion(text='custom_func1', start_position=-2),
-        Completion(text='custom_func2', start_position=-2)])
+        Completion(text='custom_func1', start_position=-2, display_meta='function'),
+        Completion(text='custom_func2', start_position=-2, display_meta='function')])
 
 
 def test_suggested_column_names_from_visible_table(completer, complete_event):
@@ -141,14 +145,15 @@ def test_suggested_column_names_from_visible_table(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='email', start_position=0),
-        Completion(text='first_name', start_position=0),
-        Completion(text='last_name', start_position=0),
-        Completion(text='custom_func1', start_position=0),
-        Completion(text='custom_func2', start_position=0)] +
-        list(map(Completion, completer.functions)))
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='email', start_position=0, display_meta='column'),
+        Completion(text='first_name', start_position=0, display_meta='column'),
+        Completion(text='last_name', start_position=0, display_meta='column'),
+        Completion(text='custom_func1', start_position=0, display_meta='function'),
+        Completion(text='custom_func2', start_position=0, display_meta='function')] +
+        list(map(lambda f: Completion(f, display_meta='function'), completer.functions)))
+
 
 def test_suggested_column_names_in_function(completer, complete_event):
     """
@@ -164,11 +169,11 @@ def test_suggested_column_names_in_function(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event)
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='email', start_position=0),
-        Completion(text='first_name', start_position=0),
-        Completion(text='last_name', start_position=0)])
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='email', start_position=0, display_meta='column'),
+        Completion(text='first_name', start_position=0, display_meta='column'),
+        Completion(text='last_name', start_position=0, display_meta='column')])
 
 def test_suggested_column_names_with_table_dot(completer, complete_event):
     """
@@ -183,11 +188,11 @@ def test_suggested_column_names_with_table_dot(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='email', start_position=0),
-        Completion(text='first_name', start_position=0),
-        Completion(text='last_name', start_position=0)])
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='email', start_position=0, display_meta='column'),
+        Completion(text='first_name', start_position=0, display_meta='column'),
+        Completion(text='last_name', start_position=0, display_meta='column')])
 
 def test_suggested_column_names_with_alias(completer, complete_event):
     """
@@ -202,11 +207,11 @@ def test_suggested_column_names_with_alias(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='email', start_position=0),
-        Completion(text='first_name', start_position=0),
-        Completion(text='last_name', start_position=0)])
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='email', start_position=0, display_meta='column'),
+        Completion(text='first_name', start_position=0, display_meta='column'),
+        Completion(text='last_name', start_position=0, display_meta='column')])
 
 def test_suggested_multiple_column_names(completer, complete_event):
     """
@@ -222,14 +227,14 @@ def test_suggested_multiple_column_names(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='email', start_position=0),
-        Completion(text='first_name', start_position=0),
-        Completion(text='last_name', start_position=0),
-        Completion(text='custom_func1', start_position=0),
-        Completion(text='custom_func2', start_position=0)] +
-        list(map(Completion, completer.functions)))
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='email', start_position=0, display_meta='column'),
+        Completion(text='first_name', start_position=0, display_meta='column'),
+        Completion(text='last_name', start_position=0, display_meta='column'),
+        Completion(text='custom_func1', start_position=0, display_meta='function'),
+        Completion(text='custom_func2', start_position=0, display_meta='function')] +
+        list(map(lambda f: Completion(f, display_meta='function'), completer.functions)))
 
 def test_suggested_multiple_column_names_with_alias(completer, complete_event):
     """
@@ -245,11 +250,11 @@ def test_suggested_multiple_column_names_with_alias(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='email', start_position=0),
-        Completion(text='first_name', start_position=0),
-        Completion(text='last_name', start_position=0)])
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='email', start_position=0, display_meta='column'),
+        Completion(text='first_name', start_position=0, display_meta='column'),
+        Completion(text='last_name', start_position=0, display_meta='column')])
 
 def test_suggested_multiple_column_names_with_dot(completer, complete_event):
     """
@@ -265,11 +270,11 @@ def test_suggested_multiple_column_names_with_dot(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='email', start_position=0),
-        Completion(text='first_name', start_position=0),
-        Completion(text='last_name', start_position=0)])
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='email', start_position=0, display_meta='column'),
+        Completion(text='first_name', start_position=0, display_meta='column'),
+        Completion(text='last_name', start_position=0, display_meta='column')])
 
 def test_suggested_aliases_after_on(completer, complete_event):
     text = 'SELECT u.name, o.id FROM users u JOIN orders o ON '
@@ -278,8 +283,8 @@ def test_suggested_aliases_after_on(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='u', start_position=0),
-        Completion(text='o', start_position=0)])
+        Completion(text='u', start_position=0, display_meta='table alias'),
+        Completion(text='o', start_position=0, display_meta='table alias')])
 
 def test_suggested_aliases_after_on_right_side(completer, complete_event):
     text = 'SELECT u.name, o.id FROM users u JOIN orders o ON o.user_id = '
@@ -288,8 +293,8 @@ def test_suggested_aliases_after_on_right_side(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='u', start_position=0),
-        Completion(text='o', start_position=0)])
+        Completion(text='u', start_position=0, display_meta='table alias'),
+        Completion(text='o', start_position=0, display_meta='table alias')])
 
 def test_suggested_tables_after_on(completer, complete_event):
     text = 'SELECT users.name, orders.id FROM users JOIN orders ON '
@@ -298,8 +303,8 @@ def test_suggested_tables_after_on(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='users', start_position=0),
-        Completion(text='orders', start_position=0)])
+        Completion(text='users', start_position=0, display_meta='table alias'),
+        Completion(text='orders', start_position=0, display_meta='table alias')])
 
 def test_suggested_tables_after_on_right_side(completer, complete_event):
     text = 'SELECT users.name, orders.id FROM users JOIN orders ON orders.user_id = '
@@ -308,8 +313,8 @@ def test_suggested_tables_after_on_right_side(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='users', start_position=0),
-        Completion(text='orders', start_position=0)])
+        Completion(text='users', start_position=0, display_meta='table alias'),
+        Completion(text='orders', start_position=0, display_meta='table alias')])
 
 def test_join_using_suggests_common_columns(completer, complete_event):
     text = 'SELECT * FROM users INNER JOIN orders USING ('
@@ -317,8 +322,8 @@ def test_join_using_suggests_common_columns(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event))
     assert set(result) == set([
-        Completion(text='id', start_position=0),
-        Completion(text='email', start_position=0),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='email', start_position=0, display_meta='column'),
         ])
 
 def test_join_using_suggests_columns_after_first_column(completer, complete_event):
@@ -327,8 +332,8 @@ def test_join_using_suggests_columns_after_first_column(completer, complete_even
     result = set(completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event))
     assert set(result) == set([
-        Completion(text='id', start_position=0),
-        Completion(text='email', start_position=0),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='email', start_position=0, display_meta='column'),
         ])
 
 def test_table_names_after_from(completer, complete_event):
@@ -338,11 +343,11 @@ def test_table_names_after_from(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='public', start_position=0),
-        Completion(text='users', start_position=0),
-        Completion(text='orders', start_position=0),
-        Completion(text='"select"', start_position=0),
-        Completion(text='user_emails', start_position=0),
+        Completion(text='public', start_position=0, display_meta='schema'),
+        Completion(text='users', start_position=0, display_meta='table'),
+        Completion(text='orders', start_position=0, display_meta='table'),
+        Completion(text='"select"', start_position=0, display_meta='table'),
+        Completion(text='user_emails', start_position=0, display_meta='view'),
         ])
 
 def test_auto_escaped_col_names(completer, complete_event):
@@ -352,13 +357,13 @@ def test_auto_escaped_col_names(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='*', start_position=0),
-        Completion(text='id', start_position=0),
-        Completion(text='"insert"', start_position=0),
-        Completion(text='"ABC"', start_position=0),
-        Completion(text='custom_func1', start_position=0),
-        Completion(text='custom_func2', start_position=0)] +
-        list(map(Completion, completer.functions)))
+        Completion(text='*', start_position=0, display_meta='column'),
+        Completion(text='id', start_position=0, display_meta='column'),
+        Completion(text='"insert"', start_position=0, display_meta='column'),
+        Completion(text='"ABC"', start_position=0, display_meta='column'),
+        Completion(text='custom_func1', start_position=0, display_meta='function'),
+        Completion(text='custom_func2', start_position=0, display_meta='function')] +
+        list(map(lambda f: Completion(f, display_meta='function'), completer.functions)))
 
 
 @pytest.mark.parametrize('text', [
@@ -371,16 +376,13 @@ def test_suggest_datatype(text, completer, complete_event):
     pos = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event)
-    assert set(result) == set(
-        [Completion(t) for t in [
-            # Custom types
-            'custom_type1', 'custom_type2',
-
-            # Tables
-            'public', 'users', 'orders', '"select"',
-
-            # Built-in datatypes
-            ] + completer.datatypes
-        ])
+    assert set(result) == set([
+        Completion(text='custom_type1', start_position=0, display_meta='datatype'),
+        Completion(text='custom_type2', start_position=0, display_meta='datatype'),
+        Completion(text='public', start_position=0, display_meta='schema'),
+        Completion(text='users', start_position=0, display_meta='table'),
+        Completion(text='orders', start_position=0, display_meta='table'),
+        Completion(text='"select"', start_position=0, display_meta='table')] +
+        list(map(lambda f: Completion(f, display_meta='datatype'), completer.datatypes)))
 
 


### PR DESCRIPTION
See #200.

Looks like this:

![1](https://cloud.githubusercontent.com/assets/6875882/8521328/a38064c6-23b0-11e5-9322-e313b8609028.png)

It turns out this is almost trivially easy to do. However, it breaks all of our completions tests. So I before I go ahead and update all the tests, I wanted everyone to get a chance to suggest what should or should not go in the metadata. I think a simple category label is almost a waste.

As an experiment, I shuffled some code around so I could put special command help text directly in the completions menu:

![2](https://cloud.githubusercontent.com/assets/6875882/8521381/0ccbe068-23b1-11e5-8447-60ed0839cf01.png)

Let me know what you think! This branch works fine, despite the failing tests, if you want to try it out.

