### PR TITLE
Bump up click version to address #288

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -345,7 +345,10 @@ class PGCli(object):
                     logger.error("traceback: %r", traceback.format_exc())
                     click.secho(str(e), err=True, fg='red')
                 else:
-                    click.echo_via_pager('\n'.join(output))
+                    try:
+                        click.echo_via_pager('\n'.join(output))
+                    except KeyboardInterrupt:
+                        pass
                     if self.pgspecial.timing_enabled:
                         print('Command Time: %0.03fs' % duration)
                         print('Format Time: %0.03fs' % total)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         description=description,
         long_description=open('README.rst').read(),
         install_requires=[
-            'click >= 3.2',
+            'click >= 4.1',
             'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
             'prompt_toolkit==0.42',
             'psycopg2 >= 2.5.4',


### PR DESCRIPTION
Reviewer: @macobo 

Upgrading the minimum required version of click to 4.1. We use the output_via_pager() function in pgcli. When the pager is active (if the output is longer than the screen) if a user presses Ctrl-C it will abort pgcli and cause the terminal to go weird. 

This latest version fixes the issue. 

Relevant PR: https://github.com/mitsuhiko/click/pull/351