### PR TITLE
Fix for None dereference on "\d schemaname." with sequence

### DIFF
--- a/pgcli/packages/pgspecial/dbcommands.py
+++ b/pgcli/packages/pgspecial/dbcommands.py
@@ -600,7 +600,8 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
         log.debug(sql)
         cur.execute(sql)
         result = cur.fetchone()
-        status.append("Owned by: %s" % result[0])
+        if result:
+            status.append("Owned by: %s" % result[0])
 
         #/*
          #* If we get no rows back, don't show anything (obviously). We should


### PR DESCRIPTION
The result of doing the command "\d schemaname." on my db was

    'NoneType' object has no attribute '__getitem__'

This fix makes the output look a lot more like what you would see with
the same command on psql.