### PR TITLE
Integration with prompt_toolkit==0.44

### DIFF
--- a/pgcli/key_bindings.py
+++ b/pgcli/key_bindings.py
@@ -13,6 +13,7 @@ def pgcli_bindings(get_vi_mode_enabled, set_vi_mode_enabled):
     assert callable(set_vi_mode_enabled)
 
     key_binding_manager = KeyBindingManager(
+        enable_open_in_editor=True,
         enable_vi_mode=Condition(lambda cli: get_vi_mode_enabled()))
 
     @key_binding_manager.registry.add_binding(Keys.F2)

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -71,6 +71,7 @@ class PGCli(object):
         self.pgspecial.timing_enabled = c['main'].as_bool('timing')
         self.table_format = c['main']['table_format']
         self.syntax_style = c['main']['syntax_style']
+        self.display_completions_in_columns = c['main'].as_bool('display_completions_in_columns')
 
         self.logger = logging.getLogger(__name__)
         self.initialize_logging()
@@ -241,6 +242,7 @@ class PGCli(object):
                                        reserve_space_for_menu=True,
                                        get_prompt_tokens=prompt_tokens,
                                        get_bottom_toolbar_tokens=get_toolbar_tokens,
+                                       display_completions_in_columns=self.display_completions_in_columns,
                                        extra_input_processors=[
                                            # Highlight matching brackets while editing.
                                            ConditionalProcessor(

--- a/pgcli/pgbuffer.py
+++ b/pgcli/pgbuffer.py
@@ -10,7 +10,8 @@ class PGBuffer(Buffer):
             doc = self.document
             return self.always_multiline and not _multiline_exception(doc.text)
 
-        super(self.__class__, self).__init__(*args, is_multiline=is_multiline, **kwargs)
+        super(self.__class__, self).__init__(*args, is_multiline=is_multiline,
+                                             tempfile_suffix='.sql', **kwargs)
 
 def _multiline_exception(text):
     text = text.strip()

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -5,6 +5,10 @@
 # possible completions will be listed.
 smart_completion = True
 
+# Display the completions in several columns. (More completions will be
+# visible.)
+display_completions_in_columns = False
+
 # Multi-line mode allows breaking up the sql statements into multiple lines. If
 # this is set to True, then the end of the statements must have a semi-colon.
 # If this is set to False then sql statements can't be split into multiple

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         install_requires=[
             'click >= 3.2',
             'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
-            'prompt_toolkit==0.42',
+            'prompt_toolkit==0.45',
             'psycopg2 >= 2.5.4',
             'sqlparse == 0.1.14',
             'configobj >= 5.0.6'


### PR DESCRIPTION
- Re-enable the open-in-editor functionality. Pressing 'v' in Vi mode or Control-X Control-E in emacs mode should open the EDITOR when the input can be edited.

- Visualization of completions in multiple columns. (This is off by default, but can be configured.)

edit: as always, test before merging ;)