### PR TITLE
Fix the crashing autocompletion on joins.

### DIFF
--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -184,7 +184,7 @@ def find_prev_keyword(sql):
             # up to and including the target keyword token t, to produce a
             # query string with everything after the keyword token removed
             text = ''.join(tok.value for tok in flattened[:idx+1])
-            return t.value, text
+            return t, text
 
     return None, ''
 

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -167,7 +167,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
         #       SELECT Identifier <CURSOR>
         #       SELECT foo FROM Identifier <CURSOR>
         prev_keyword, _ = find_prev_keyword(text_before_cursor)
-        if prev_keyword == '(':
+        if prev_keyword.value == '(':
             # Suggest datatypes
             return suggest_based_on_last_token('type', text_before_cursor,
                                            full_text, identifier)

--- a/tests/test_parseutils.py
+++ b/tests/test_parseutils.py
@@ -87,7 +87,7 @@ def test_join_as_table():
 def test_find_prev_keyword_using():
     q = 'select * from tbl1 inner join tbl2 using (col1, '
     kw, q2 = find_prev_keyword(q)
-    assert kw == '(' and q2 == 'select * from tbl1 inner join tbl2 using ('
+    assert kw.value == '(' and q2 == 'select * from tbl1 inner join tbl2 using ('
 
 @pytest.mark.parametrize('sql', [
     'select * from foo where bar',
@@ -96,7 +96,7 @@ def test_find_prev_keyword_using():
 ])
 def test_find_prev_keyword_where(sql):
     kw, stripped = find_prev_keyword(sql)
-    assert kw == 'where' and stripped == 'select * from foo where'
+    assert kw.value == 'where' and stripped == 'select * from foo where'
 
 
 @pytest.mark.parametrize('sql', [
@@ -105,4 +105,4 @@ def test_find_prev_keyword_where(sql):
 ])
 def test_find_prev_keyword_open_parens(sql):
     kw, _ = find_prev_keyword(sql)
-    assert kw == '('
+    assert kw.value == '('

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -248,6 +248,14 @@ def test_join_suggests_tables_and_schemas(tbl_alias, join_type):
         {'type': 'view', 'schema': []},
         {'type': 'schema'}])
 
+def test_left_join_with_comma():
+    text = 'select * from foo f left join bar b,'
+    suggestions = suggest_type(text, text)
+    assert sorted_dicts(suggestions) == sorted_dicts([
+         {'type': 'table', 'schema': []},
+         {'type': 'view', 'schema': []},
+         {'type': 'schema'}])
+
 def test_join_alias_dot_suggests_cols1():
     suggestions = suggest_type('SELECT * FROM abc a JOIN def d ON a.',
             'SELECT * FROM abc a JOIN def d ON a.')
@@ -289,7 +297,6 @@ def test_on_suggests_tables_right_side():
         'select abc.x, bcd.y from abc join bcd on ',
         'select abc.x, bcd.y from abc join bcd on ')
     assert suggestions == [{'type': 'alias', 'aliases': ['abc', 'bcd']}]
-
 
 @pytest.mark.parametrize('col_list', ['', 'col1, '])
 def test_join_using_suggests_common_columns(col_list):
@@ -382,7 +389,7 @@ def test_handle_pre_completion_comma_gracefully(text):
 def test_drop_schema_suggests_schemas():
     sql = 'DROP SCHEMA '
     assert suggest_type(sql, sql) == [{'type': 'schema'}]
-    
+
 
 @pytest.mark.parametrize('text', [
     'SELECT x::',


### PR DESCRIPTION
@darikg Can you review? 

Bug: Entering `select * from foo f left join bar b,` will crash pgcli. Notice the trailing comma at the end. 

After the merge that should be handled correctly. 

