### PR TITLE
Add --service option to pgcli

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -73,6 +73,7 @@ class PGCli(object):
         self.pgspecial.timing_enabled = c['main'].as_bool('timing')
         self.table_format = c['main']['table_format']
         self.syntax_style = c['main']['syntax_style']
+        self.cli_style = c['colors']
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
 
         self.logger = logging.getLogger(__name__)
@@ -256,7 +257,7 @@ class PGCli(object):
                 history=FileHistory(os.path.expanduser(history_file)),
                 complete_while_typing=Always())
 
-        application = Application(style=style_factory(self.syntax_style),
+        application = Application(style=style_factory(self.syntax_style, self.cli_style),
                                   layout=layout, buffer=buf,
                                   key_bindings_registry=key_binding_manager.registry,
                                   on_exit=AbortAction.RAISE_EXCEPTION)

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -135,13 +135,17 @@ class PGCli(object):
         root_logger.debug('Initializing pgcli logging.')
         root_logger.debug('Log file %r.', log_file)
 
+    def connect_dsn(self, dsn):
+        self.connect(dsn=dsn)
+
     def connect_uri(self, uri):
         uri = urlparse(uri)
         database = uri.path[1:]  # ignore the leading fwd slash
         self.connect(database, uri.hostname, uri.username,
                      uri.port, uri.password)
 
-    def connect(self, database='', host='', user='', port='', passwd=''):
+    def connect(self, database='', host='', user='', port='', passwd='',
+                dsn=''):
         # Connect to the database.
 
         if not user:
@@ -174,13 +178,14 @@ class PGCli(object):
         # a password (no -w flag), prompt for a passwd and try again.
         try:
             try:
-                pgexecute = PGExecute(database, user, passwd, host, port)
+                pgexecute = PGExecute(database, user, passwd, host, port, dsn)
             except OperationalError as e:
                 if ('no password supplied' in utf8tounicode(e.args[0]) and
                         auto_passwd_prompt):
                     passwd = click.prompt('Password', hide_input=True,
                                           show_default=False, type=str)
-                    pgexecute = PGExecute(database, user, passwd, host, port)
+                    pgexecute = PGExecute(database, user, passwd, host, port,
+                                          dsn)
                 else:
                     raise e
 
@@ -453,6 +458,10 @@ def cli(database, user, host, port, prompt_passwd, never_prompt, dbname,
 
     if '://' in database:
         pgcli.connect_uri(database)
+    elif "=" in database:
+        pgcli.connect_dsn(database)
+    elif os.environ.get('PGSERVICE', None):
+        pgcli.connect_dsn('service={0}'.format(os.environ['PGSERVICE']))
     else:
         pgcli.connect(database, host, user, port)
 

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -44,6 +44,22 @@ syntax_style = default
 # for end are available in the REPL.
 vi = False
 
-# Named queries are queries you can rexecute by name
+
+# Custom colors for the completion menu, toolbar, etc. 
+[colors]
+Token.Menu.Completions.Completion.Current = 'bg:#ffffff #000000'
+Token.Menu.Completions.Completion = 'bg:#008888 #ffffff'
+Token.Menu.Completions.Meta.Current = 'bg:#44aaaa #000000'
+Token.Menu.Completions.Meta = 'bg:#448888 #ffffff'
+Token.Menu.Completions.ProgressButton = 'bg:#003333'
+Token.Menu.Completions.ProgressBar = 'bg:#00aaaa'
+Token.SelectedText = '#ffffff bg:#6666aa'
+Token.IncrementalSearchMatch = '#ffffff bg:#4444aa'
+Token.IncrementalSearchMatch.Current = '#ffffff bg:#44aa44'
+Token.Toolbar = 'bg:#222222 #aaaaaa'
+Token.Toolbar.Off = 'bg:#222222 #888888'
+Token.Toolbar.On = 'bg:#222222 #ffffff'
+
+# Named queries are queries you can execute by name.
 [named queries]
 

--- a/pgcli/pgstyle.py
+++ b/pgcli/pgstyle.py
@@ -5,7 +5,7 @@ from prompt_toolkit.styles import default_style_extensions
 import pygments.styles
 
 
-def style_factory(name):
+def style_factory(name, cli_style):
     try:
         style = pygments.styles.get_style_by_name(name)
     except ClassNotFound:
@@ -16,20 +16,6 @@ def style_factory(name):
 
         styles.update(style.styles)
         styles.update(default_style_extensions)
-        styles.update({
-            Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
-            Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',
-            Token.Menu.Completions.Meta.Current: 'bg:#44aaaa #000000',
-            Token.Menu.Completions.Meta: 'bg:#448888 #ffffff',
-            Token.Menu.Completions.ProgressButton: 'bg:#003333',
-            Token.Menu.Completions.ProgressBar: 'bg:#00aaaa',
-            Token.SelectedText: '#ffffff bg:#6666aa',
-            Token.IncrementalSearchMatch: '#ffffff bg:#4444aa',
-            Token.IncrementalSearchMatch.Current: '#ffffff bg:#44aa44',
-            Token.Toolbar: 'bg:#440044 #ffffff',
-            Token.Toolbar: 'bg:#222222 #aaaaaa',
-            Token.Toolbar.Off: 'bg:#222222 #888888',
-            Token.Toolbar.On: 'bg:#222222 #ffffff',
-        })
-
+        custom_styles = dict([(eval(x), y) for x, y in cli_style.items()])
+        styles.update(custom_styles)
     return PGStyle

--- a/pgcli/pgstyle.py
+++ b/pgcli/pgstyle.py
@@ -1,4 +1,4 @@
-from pygments.token import Token
+from pygments.token import string_to_tokentype
 from pygments.style import Style
 from pygments.util import ClassNotFound
 from prompt_toolkit.styles import default_style_extensions
@@ -16,6 +16,7 @@ def style_factory(name, cli_style):
 
         styles.update(style.styles)
         styles.update(default_style_extensions)
-        custom_styles = dict([(eval(x), y) for x, y in cli_style.items()])
+        custom_styles = dict([(string_to_tokentype(x), y)
+                                for x, y in cli_style.items()])
         styles.update(custom_styles)
     return PGStyle

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,4 +23,4 @@ def cursor(connection):
 @pytest.fixture
 def executor(connection):
     return pgcli.pgexecute.PGExecute(database='_test_db', user=POSTGRES_USER,
-            host=POSTGRES_HOST, password=None, port=None)
+            host=POSTGRES_HOST, password=None, port=None, dsn=None)


### PR DESCRIPTION
This is to address issue #289. Pgcli can be run with:

```
pgcli --service boo
```

and configuration for service name "boo" would be read from ~/.pg_service.conf or a system-wide pg_service.conf file.

It does not exactly copy psql behavior, as it uses "--service=boo" instead of "service=boo". If this is a problem, let me know.