### PR TITLE
Fix autocomplete after an identifier in a where-clause

### DIFF
--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -154,6 +154,13 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
         # list. This means that token.value may be something like
         # 'where foo > 5 and '. We need to look "inside" token.tokens to handle
         # suggestions in complicated where clauses correctly
+
+        # Check to see if the last token in the where clause is an identifier
+        token = token.token_prev(len(token.tokens))
+        if isinstance(token, Identifier):
+            # SELECT * FROM foo WHERE bar <autosuggest>
+            return [{'type': 'keyword'}]
+
         prev_keyword, text_before_cursor = find_prev_keyword(text_before_cursor)
         return suggest_based_on_last_token(prev_keyword, text_before_cursor,
                                            full_text, identifier)

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -483,3 +483,10 @@ def test_invalid_sql():
     text = 'selt *'
     suggestions = suggest_type(text, text)
     assert suggestions == [{'type': 'keyword'}]
+
+
+def test_suggest_where_like():
+    # https://github.com/dbcli/mycli/issues/135
+    text = 'select * from foo where bar '
+    suggestions = suggest_type(text, text)
+    assert suggestions == [{'type': 'keyword'}]


### PR DESCRIPTION
Fixes dbcli/mycli#135 (Sorry don't have mycli installed so fixing it here instead)

Statements like `SELECT * FROM foo WHERE bar ` now suggest only keywords. (Is that right? I feel like I'm forgetting some other syntax option)

