### PR TITLE
Perform auto-completion refresh in background.

### DIFF
--- a/pgcli/completion_refresher.py
+++ b/pgcli/completion_refresher.py
@@ -27,7 +27,7 @@ class CompletionRefresher(object):
                     has completed the refresh. The newly created completion
                     object will be passed in as an argument to each callback.
         """
-        if self._completer_thread and self._completer_thread.is_alive():
+        if self.is_refreshing():
             self._restart_refresh.set()
             return [(None, None, None, 'Auto-completion refresh restarted.')]
         else:
@@ -38,6 +38,9 @@ class CompletionRefresher(object):
             self._completer_thread.start()
             return [(None, None, None,
                      'Auto-completion refresh started in the background.')]
+
+    def is_refreshing(self):
+        return self._completer_thread and self._completer_thread.is_alive()
 
     def _bg_refresh(self, pgexecute, special, callbacks):
         completer = PGCompleter(smart_completion=True, pgspecial=special)

--- a/pgcli/completion_refresher.py
+++ b/pgcli/completion_refresher.py
@@ -1,5 +1,8 @@
 import threading
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    from .packages import OrderedDict
 
 from .pgcompleter import PGCompleter
 from .pgexecute import PGExecute

--- a/pgcli/completion_refresher.py
+++ b/pgcli/completion_refresher.py
@@ -2,7 +2,7 @@ import threading
 try:
     from collections import OrderedDict
 except ImportError:
-    from .packages import OrderedDict
+    from .packages.ordereddict import OrderedDict
 
 from .pgcompleter import PGCompleter
 from .pgexecute import PGExecute

--- a/pgcli/completion_refresher.py
+++ b/pgcli/completion_refresher.py
@@ -1,0 +1,93 @@
+import threading
+from collections import OrderedDict
+
+from .pgcompleter import PGCompleter
+from .pgexecute import PGExecute
+
+class CompletionRefresher(object):
+
+    refreshers = OrderedDict()
+
+    def __init__(self):
+        self._completer_thread = None
+        self._restart_completion = threading.Event()
+
+    def refresh(self, executor, special, callbacks):
+        if self._completer_thread and self._completer_thread.is_alive():
+            self._restart_completion.set()
+            return [(None, None, None, 'Auto-completion refresh restarted.')]
+        else:
+            self._completer_thread = threading.Thread(target=self._bg_refresh,
+                                                      args=(executor, special, callbacks),
+                                                      name='completion_refresh')
+            self._completer_thread.setDaemon(True)
+            self._completer_thread.start()
+            return [(None, None, None,
+                     'Auto-completion refresh started in the background.')]
+
+    def _bg_refresh(self, pgexecute, special, callbacks):
+        completer = PGCompleter(smart_completion=True, pgspecial=special)
+
+        # Create a new pgexecute method to popoulate the completions.
+        e = pgexecute
+        executor = PGExecute(e.dbname, e.user, e.password, e.host, e.port, e.dsn)
+
+        if callable(callbacks):
+            callbacks = [callbacks]
+
+        while 1:
+            for refresher in self.refreshers.values():
+                refresher(completer, executor)
+                if self._restart_completion.is_set():
+                    self._restart_completion.clear()
+                    break
+            else:
+                # Break out of while loop if the for loop finishes natually
+                # without hitting the break statement.
+                break
+
+            # Start over the refresh from the beginning if the for loop hit the
+            # break statement.
+            continue
+
+        for callback in callbacks:
+            callback(completer)
+
+def refresher(name, refreshers=CompletionRefresher.refreshers):
+    """Decorator to populate the dictionary of refreshers with the current
+    function.
+    """
+    def wrapper(wrapped):
+        refreshers[name] = wrapped
+        return wrapped
+    return wrapper
+
+@refresher('schemata')
+def refresh_schemata(completer, executor):
+    completer.set_search_path(executor.search_path())
+    completer.extend_schemata(executor.schemata())
+
+@refresher('tables')
+def refresh_tables(completer, executor):
+    completer.extend_relations(executor.tables(),
+                                      kind='tables')
+    completer.extend_columns(executor.table_columns(),
+                                    kind='tables')
+
+@refresher('views')
+def refresh_views(completer, executor):
+    completer.extend_relations(executor.views(), kind='views')
+    completer.extend_columns(executor.view_columns(),
+                                    kind='views')
+
+@refresher('functions')
+def refresh_functions(completer, executor):
+    completer.extend_functions(executor.functions())
+
+@refresher('types')
+def refresh_types(completer, executor):
+    completer.extend_datatypes(executor.datatypes())
+
+@refresher('databases')
+def refresh_databases(completer, executor):
+    completer.extend_database_names(executor.databases())

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -92,7 +92,6 @@ class PGCli(object):
         completer = PGCompleter(smart_completion, pgspecial=self.pgspecial)
         self.completer = completer
         self._completer_lock = threading.Lock()
-        self._restart_completion = threading.Event()
         self.register_special_commands()
 
     def register_special_commands(self):

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -6,6 +6,7 @@ import os
 import sys
 import traceback
 import logging
+import threading
 from time import time
 from codecs import open
 
@@ -410,6 +411,11 @@ class PGCli(object):
         return less_opts
 
     def refresh_completions(self):
+        t = threading.Thread(target=self.background_refresh, name='completion_refresh')
+        t.start()
+        return [(None, None, None, 'Auto-completion refresh has started in the background.')]
+
+    def background_refresh(self):
         completer = self.completer
         completer.reset_completions()
 
@@ -435,8 +441,6 @@ class PGCli(object):
 
         # databases
         completer.extend_database_names(pgexecute.databases())
-
-        return [(None, None, None, 'Auto-completions refreshed.')]
 
     def get_completions(self, text, cursor_positition):
         return self.completer.get_completions(

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -32,6 +32,7 @@ from .pgtoolbar import create_toolbar_tokens_func
 from .pgstyle import style_factory
 from .pgexecute import PGExecute
 from .pgbuffer import PGBuffer
+from .completion_refresher import CompletionRefresher
 from .config import write_default_config, load_config
 from .key_bindings import pgcli_bindings
 from .encodingutils import utf8tounicode
@@ -79,6 +80,7 @@ class PGCli(object):
         self.syntax_style = c['main']['syntax_style']
         self.cli_style = c['colors']
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
+        self.completion_refresher = CompletionRefresher()
 
         self.logger = logging.getLogger(__name__)
         self.initialize_logging()
@@ -89,7 +91,6 @@ class PGCli(object):
         smart_completion = c['main'].as_bool('smart_completion')
         completer = PGCompleter(smart_completion, pgspecial=self.pgspecial)
         self.completer = completer
-        self._completer_thread = None
         self._completer_lock = threading.Lock()
         self._restart_completion = threading.Event()
         self.register_special_commands()
@@ -416,79 +417,21 @@ class PGCli(object):
         return less_opts
 
     def refresh_completions(self):
+        self.completion_refresher.refresh(self.pgexecute, self.pgspecial,
+                                          self._swap_completer_objects)
+        return [(None, None, None,
+                'Auto-completion refresh started in the background.')]
 
-        if self._completer_thread and self._completer_thread.is_alive():
-            self._restart_completion.set()
-            return [(None, None, None, 'Auto-completion refresh restarted.')]
-        else:
-            self._completer_thread = threading.Thread(target=self.background_refresh, name='completion_refresh')
-            self._completer_thread.setDaemon(True)
-            self._completer_thread.start()
-            return [(None, None, None, 'Auto-completion refresh started in the background.')]
-
-    def background_refresh(self):
-        completer = PGCompleter(smart_completion=True, pgspecial=self.pgspecial)
-
-        # Create a new pgexecute method to popoulate the completions.
-        e = self.pgexecute
-        pgexecute = PGExecute(e.dbname, e.user, e.password, e.host, e.port, e.dsn)
-
-        while (1):
-            # schemata
-            completer.set_search_path(pgexecute.search_path())
-            completer.extend_schemata(pgexecute.schemata())
-
-            if self._restart_completion.is_set():
-                self._restart_completion.clear()
-                continue
-
-            # tables
-            completer.extend_relations(pgexecute.tables(), kind='tables')
-            completer.extend_columns(pgexecute.table_columns(), kind='tables')
-
-            if self._restart_completion.is_set():
-                self._restart_completion.clear()
-                continue
-
-            # views
-            completer.extend_relations(pgexecute.views(), kind='views')
-            completer.extend_columns(pgexecute.view_columns(), kind='views')
-
-            if self._restart_completion.is_set():
-                self._restart_completion.clear()
-                continue
-
-            # functions
-            completer.extend_functions(pgexecute.functions())
-
-            if self._restart_completion.is_set():
-                self._restart_completion.clear()
-                continue
-
-            # types
-            completer.extend_datatypes(pgexecute.datatypes())
-
-            if self._restart_completion.is_set():
-                self._restart_completion.clear()
-                continue
-
-            # databases
-            completer.extend_database_names(pgexecute.databases())
-
-            if self._restart_completion.is_set():
-                self._restart_completion.clear()
-                continue
-
-            # Swap the completer object in cli with the newly created completer.
-            with self._completer_lock:
-                self.completer = completer
-                # When pgcli is first launched we call refresh_completions before
-                # instantiating the cli object. So it is necessary to check if cli
-                # exists before trying the replace the completer object in cli.
-                if hasattr(self, 'cli'):
-                    self.cli.current_buffer.completer = completer
-
-            break
+    def _swap_completer_objects(self, completer):
+        """Swap the completer object in cli with the newly created completer.
+        """
+        with self._completer_lock:
+            self.completer = completer
+            # When pgcli is first launched we call refresh_completions before
+            # instantiating the cli object. So it is necessary to check if cli
+            # exists before trying the replace the completer object in cli.
+            if hasattr(self, 'cli'):
+                self.cli.current_buffer.completer = completer
 
     def get_completions(self, text, cursor_positition):
         with self._completer_lock:

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -94,6 +94,8 @@ class PGCli(object):
         self._completer_lock = threading.Lock()
         self.register_special_commands()
 
+        self.cli = None
+
     def register_special_commands(self):
 
         self.pgspecial.register(self.change_db, '\\c',
@@ -430,7 +432,7 @@ class PGCli(object):
             # When pgcli is first launched we call refresh_completions before
             # instantiating the cli object. So it is necessary to check if cli
             # exists before trying the replace the completer object in cli.
-            if hasattr(self, 'cli'):
+            if self.cli:
                 self.cli.current_buffer.completer = new_completer
 
     def get_completions(self, text, cursor_positition):

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -412,14 +412,16 @@ class PGCli(object):
 
     def refresh_completions(self):
         t = threading.Thread(target=self.background_refresh, name='completion_refresh')
+        t.setDaemon(True)
         t.start()
-        return [(None, None, None, 'Auto-completion refresh has started in the background.')]
+        return [(None, None, None, 'Auto-completion refresh started in the background.')]
 
     def background_refresh(self):
         completer = self.completer
         completer.reset_completions()
 
-        pgexecute = self.pgexecute
+        e = self.pgexecute
+        pgexecute = PGExecute(e.dbname, e.user, e.password, e.host, e.port, e.dsn)
 
         # schemata
         completer.set_search_path(pgexecute.search_path())

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -419,8 +419,14 @@ class PGCli(object):
         return less_opts
 
     def refresh_completions(self):
+        callbacks = [self._swap_completer_objects]
+        if self.cli:
+            # After refreshing, redraw the CLI to clear the statusbar
+            # "Refreshing completions..." indicator
+            callbacks.append(lambda _: self.cli.request_redraw())
+
         self.completion_refresher.refresh(self.pgexecute, self.pgspecial,
-                                          self._swap_completer_objects)
+                                          callbacks)
         return [(None, None, None,
                 'Auto-completion refresh started in the background.')]
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -265,7 +265,9 @@ class PGCli(object):
         def prompt_tokens(cli):
             return [(Token.Prompt,  '%s> ' % pgexecute.dbname)]
 
-        get_toolbar_tokens = create_toolbar_tokens_func(lambda: self.vi_mode)
+        get_toolbar_tokens = create_toolbar_tokens_func(lambda: self.vi_mode,
+                                                        lambda: self.completion_refresher.is_refreshing())
+
         layout = create_default_layout(lexer=PostgresLexer,
                                        reserve_space_for_menu=True,
                                        get_prompt_tokens=prompt_tokens,

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -419,16 +419,18 @@ class PGCli(object):
         return less_opts
 
     def refresh_completions(self):
-        callbacks = [self._swap_completer_objects]
+        self.completion_refresher.refresh(self.pgexecute, self.pgspecial,
+                                          self._on_completions_refreshed)
+        return [(None, None, None,
+                'Auto-completion refresh started in the background.')]
+
+    def _on_completions_refreshed(self, new_completer):
+        self._swap_completer_objects(new_completer)
+
         if self.cli:
             # After refreshing, redraw the CLI to clear the statusbar
             # "Refreshing completions..." indicator
-            callbacks.append(lambda _: self.cli.request_redraw())
-
-        self.completion_refresher.refresh(self.pgexecute, self.pgspecial,
-                                          callbacks)
-        return [(None, None, None,
-                'Auto-completion refresh started in the background.')]
+            self.cli.request_redraw()
 
     def _swap_completer_objects(self, new_completer):
         """Swap the completer object in cli with the newly created completer.

--- a/pgcli/packages/ordereddict.py
+++ b/pgcli/packages/ordereddict.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2009 Raymond Hettinger
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+
+from UserDict import DictMixin
+
+class OrderedDict(dict, DictMixin):
+
+    def __init__(self, *args, **kwds):
+        if len(args) > 1:
+            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+        try:
+            self.__end
+        except AttributeError:
+            self.clear()
+        self.update(*args, **kwds)
+
+    def clear(self):
+        self.__end = end = []
+        end += [None, end, end]         # sentinel node for doubly linked list
+        self.__map = {}                 # key --> [key, prev, next]
+        dict.clear(self)
+
+    def __setitem__(self, key, value):
+        if key not in self:
+            end = self.__end
+            curr = end[1]
+            curr[2] = end[1] = self.__map[key] = [key, curr, end]
+        dict.__setitem__(self, key, value)
+
+    def __delitem__(self, key):
+        dict.__delitem__(self, key)
+        key, prev, next = self.__map.pop(key)
+        prev[2] = next
+        next[1] = prev
+
+    def __iter__(self):
+        end = self.__end
+        curr = end[2]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[2]
+
+    def __reversed__(self):
+        end = self.__end
+        curr = end[1]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[1]
+
+    def popitem(self, last=True):
+        if not self:
+            raise KeyError('dictionary is empty')
+        if last:
+            key = reversed(self).next()
+        else:
+            key = iter(self).next()
+        value = self.pop(key)
+        return key, value
+
+    def __reduce__(self):
+        items = [[k, self[k]] for k in self]
+        tmp = self.__map, self.__end
+        del self.__map, self.__end
+        inst_dict = vars(self).copy()
+        self.__map, self.__end = tmp
+        if inst_dict:
+            return (self.__class__, (items,), inst_dict)
+        return self.__class__, (items,)
+
+    def keys(self):
+        return list(self)
+
+    setdefault = DictMixin.setdefault
+    update = DictMixin.update
+    pop = DictMixin.pop
+    values = DictMixin.values
+    items = DictMixin.items
+    iterkeys = DictMixin.iterkeys
+    itervalues = DictMixin.itervalues
+    iteritems = DictMixin.iteritems
+
+    def __repr__(self):
+        if not self:
+            return '%s()' % (self.__class__.__name__,)
+        return '%s(%r)' % (self.__class__.__name__, self.items())
+
+    def copy(self):
+        return self.__class__(self)
+
+    @classmethod
+    def fromkeys(cls, iterable, value=None):
+        d = cls()
+        for key in iterable:
+            d[key] = value
+        return d
+
+    def __eq__(self, other):
+        if isinstance(other, OrderedDict):
+            if len(self) != len(other):
+                return False
+            for p, q in  zip(self.items(), other.items()):
+                if p != q:
+                    return False
+            return True
+        return dict.__eq__(self, other)
+
+    def __ne__(self, other):
+        return not self == other

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -119,7 +119,7 @@ class PGCompleter(Completer):
         for schema, relname in data:
             try:
                 metadata[schema][relname] = ['*']
-            except AttributeError:
+            except KeyError:
                 _logger.error('%r %r listed in unrecognized schema %r',
                               kind, relname, schema)
             self.all_completions.add(relname)

--- a/pgcli/pgtoolbar.py
+++ b/pgcli/pgtoolbar.py
@@ -1,12 +1,12 @@
 from pygments.token import Token
 
-def create_toolbar_tokens_func(get_vi_mode_enabled, token=None):
+def create_toolbar_tokens_func(get_vi_mode_enabled):
     """
     Return a function that generates the toolbar tokens.
     """
     assert callable(get_vi_mode_enabled)
 
-    token = token or Token.Toolbar
+    token = Token.Toolbar
 
     def get_toolbar_tokens(cli):
         result = []

--- a/pgcli/pgtoolbar.py
+++ b/pgcli/pgtoolbar.py
@@ -1,6 +1,7 @@
 from pygments.token import Token
 
-def create_toolbar_tokens_func(get_vi_mode_enabled):
+
+def create_toolbar_tokens_func(get_vi_mode_enabled, get_is_refreshing):
     """
     Return a function that generates the toolbar tokens.
     """
@@ -30,6 +31,9 @@ def create_toolbar_tokens_func(get_vi_mode_enabled):
             result.append((token.On, '[F4] Vi-mode'))
         else:
             result.append((token.On, '[F4] Emacs-mode'))
+
+        if get_is_refreshing():
+            result.append((token, '     Refreshing completions...'))
 
         return result
     return get_toolbar_tokens

--- a/tests/features/iocommands.feature
+++ b/tests/features/iocommands.feature
@@ -1,6 +1,5 @@
 Feature: I/O commands
 
-  @wip
   Scenario: edit sql in file with external editor
      Given we have pgcli installed
       when we run pgcli

--- a/tests/features/specials.feature
+++ b/tests/features/specials.feature
@@ -1,0 +1,10 @@
+Feature: Special commands
+
+  @wip
+  Scenario: run refresh command
+     Given we have pgcli installed
+      when we run pgcli
+      and we wait for prompt
+      and we refresh completions
+      and we wait for prompt
+      then we see completions refresh started

--- a/tests/features/steps/step_definitions.py
+++ b/tests/features/steps/step_definitions.py
@@ -179,6 +179,14 @@ def step_db_connect_postgres(context):
     context.cli.sendline('\connect postgres')
 
 
+@when('we refresh completions')
+def step_refresh_completions(context):
+    """
+    Send refresh command.
+    """
+    context.cli.sendline('\\refresh')
+
+
 @then('pgcli exits')
 def step_wait_exit(context):
     """
@@ -275,3 +283,12 @@ def step_see_table_dropped(context):
     Wait to see drop output.
     """
     context.cli.expect_exact('DROP TABLE', timeout=2)
+
+
+@then('we see completions refresh started')
+def step_see_refresh_started(context):
+    """
+    Wait to see refresh output.
+    """
+    context.cli.expect_exact(
+        'refresh started in the background', timeout=2)

--- a/tests/test_completion_refresher.py
+++ b/tests/test_completion_refresher.py
@@ -1,0 +1,88 @@
+import time
+import pytest
+from mock import Mock, patch
+
+
+@pytest.fixture
+def refresher():
+    from pgcli.completion_refresher import CompletionRefresher
+    return CompletionRefresher()
+
+
+def test_ctor(refresher):
+    """
+    Refresher object should contain a few handlers
+    :param refresher:
+    :return:
+    """
+    assert len(refresher.refreshers) > 0
+    actual_handlers = list(refresher.refreshers.keys())
+    expected_handlers = ['schemata', 'tables', 'views', 'functions',
+                         'types', 'databases']
+    assert expected_handlers == actual_handlers
+
+
+def test_refresh_called_once(refresher):
+    """
+
+    :param refresher:
+    :return:
+    """
+    callbacks = Mock()
+    pgexecute = Mock()
+    special = Mock()
+
+    with patch.object(refresher, '_bg_refresh') as bg_refresh:
+        actual = refresher.refresh(pgexecute, special, callbacks)
+        time.sleep(1)  # Wait for the thread to work.
+        assert len(actual) == 1
+        assert len(actual[0]) == 4
+        assert actual[0][3] == 'Auto-completion refresh started in the background.'
+        bg_refresh.assert_called_with(pgexecute, special, callbacks)
+
+
+def test_refresh_called_twice(refresher):
+    """
+    If refresh is called a second time, it should be restarted
+    :param refresher:
+    :return:
+    """
+    callbacks = Mock()
+
+    pgexecute = Mock()
+    special = Mock()
+
+    def dummy_bg_refresh(*args):
+        time.sleep(3)  # seconds
+
+    refresher._bg_refresh = dummy_bg_refresh
+
+    actual1 = refresher.refresh(pgexecute, special, callbacks)
+    time.sleep(1)  # Wait for the thread to work.
+    assert len(actual1) == 1
+    assert len(actual1[0]) == 4
+    assert actual1[0][3] == 'Auto-completion refresh started in the background.'
+
+    actual2 = refresher.refresh(pgexecute, special, callbacks)
+    time.sleep(1)  # Wait for the thread to work.
+    assert len(actual2) == 1
+    assert len(actual2[0]) == 4
+    assert actual2[0][3] == 'Auto-completion refresh restarted.'
+
+
+def test_refresh_with_callbacks(refresher):
+    """
+    Callbacks must be called
+    :param refresher:
+    """
+    callbacks = [Mock()]
+    pgexecute_class = Mock()
+    pgexecute = Mock()
+    special = Mock()
+
+    with patch('pgcli.completion_refresher.PGExecute', pgexecute_class):
+        # Set refreshers to 0: we're not testing refresh logic here
+        refresher.refreshers = {}
+        refresher.refresh(pgexecute, special, callbacks)
+        time.sleep(1)  # Wait for the thread to work.
+        assert (callbacks[0].call_count == 1)


### PR DESCRIPTION
@dbcli/vcli-core @dbcli/pgcli-core 

This is my first attempt at making the auto-completion refresh in a background thread. I tried it on a database with 40,000 tables in them and I can see a noticeable different in the startup time. I could get more granular by spawning a thread for each type of completion (eg: tables, views, columns etc), but that'll require some granular locking on data-structures.

Since we get a tremendous speed boost with just one thread, I'm not motivated to do multiple threads.

Please pitch in and let me know if there are better ways of doing this. 