### PR TITLE
"Referenced by" formatting fix

### DIFF
--- a/pgcli/packages/pgspecial/dbcommands.py
+++ b/pgcli/packages/pgspecial/dbcommands.py
@@ -721,7 +721,9 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
             if (cur.rowcount > 0):
                 status.append("Referenced by:\n")
             for row in cur:
-                status.append("    TABLE \"%s\" CONSTRAINT \"%s\" %s\n" % row)
+                status.append("    TABLE \"{table_name}\" CONSTRAINT \"{constraint_name}\" {definition}\n".format(
+                    table_name=row[1], constraint_name=row[0], definition=row[2]
+                ))
 
         # /* print rules */
         if (tableinfo.hasrules and tableinfo.relkind != 'm'):

--- a/pgcli/packages/pgspecial/dbcommands.py
+++ b/pgcli/packages/pgspecial/dbcommands.py
@@ -711,7 +711,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
 
         #/* print incoming foreign-key references (none if no triggers) */
         if (tableinfo.hastriggers):
-            sql = ("SELECT conname, conrelid::pg_catalog.regclass,\n"
+            sql = ("SELECT conrelid::pg_catalog.regclass, conname,\n"
                     "  pg_catalog.pg_get_constraintdef(c.oid, true) as condef\n"
                     "FROM pg_catalog.pg_constraint c\n"
                     "WHERE c.confrelid = '%s' AND c.contype = 'f' ORDER BY 1;" %
@@ -721,9 +721,7 @@ def describe_one_table_details(cur, schema_name, relation_name, oid, verbose):
             if (cur.rowcount > 0):
                 status.append("Referenced by:\n")
             for row in cur:
-                status.append("    TABLE \"{table_name}\" CONSTRAINT \"{constraint_name}\" {definition}\n".format(
-                    table_name=row[1], constraint_name=row[0], definition=row[2]
-                ))
+                status.append("    TABLE \"%s\" CONSTRAINT \"%s\" %s\n" % row)
 
         # /* print rules */
         if (tableinfo.hasrules and tableinfo.relkind != 'm'):

--- a/tests/behave.ini
+++ b/tests/behave.ini
@@ -1,5 +1,5 @@
 [behave.userdata]
 pg_test_user = postgres
-pg_test_pass =
+pg_test_pass = postrges
 pg_test_host = localhost
 pg_test_db = pgcli_behave_tests

--- a/tests/behave.ini
+++ b/tests/behave.ini
@@ -1,5 +1,5 @@
 [behave.userdata]
 pg_test_user = postgres
-pg_test_pass = postrges
+pg_test_pass =
 pg_test_host = localhost
 pg_test_db = pgcli_behave_tests


### PR DESCRIPTION
I realised when using `\d+` on a table, there's a bug in formatting the `Referenced by` section:

Using current implementation it shows:
```
Foreign-key constraints:
    ...
Referenced by:
    TABLE "constraint_name" CONSTRAINT "table_name" FOREIGN KEY ...
Has OIDs: no
```

After fix:
```
Foreign-key constraints:
    ...
Referenced by:
    TABLE "table_name" CONSTRAINT "constraint_name" FOREIGN KEY ...
Has OIDs: no
```