### PR TITLE
Move config file to ~/.config/pgcli

### DIFF
--- a/pgcli/config.py
+++ b/pgcli/config.py
@@ -1,6 +1,14 @@
 import shutil
+import os
+import platform
 from os.path import expanduser, exists
 from configobj import ConfigObj
+
+def config_location():
+    if platform.system() == 'Windows':
+        return os.getenv('USERPROFILE') + '\AppData\Local\dbcli\pgcli\config'
+    else:
+        return expanduser('~/.config/pgcli/config')
 
 def load_config(usr_cfg, def_cfg=None):
     cfg = ConfigObj()
@@ -16,3 +24,7 @@ def write_default_config(source, destination, overwrite=False):
         return
 
     shutil.copyfile(source, destination)
+
+def upgrade_config(config, def_config):
+    cfg = load_config(config, def_config)
+    cfg.write()

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -475,6 +475,9 @@ def cli(database, user, host, port, prompt_passwd, never_prompt, dbname,
         print('Version:', __version__)
         sys.exit(0)
 
+    if not os.path.exists('~/.config/pgcli'):
+        os.mkdir('~/.config/pgcli')
+
     pgcli = PGCli(prompt_passwd, never_prompt, pgclirc_file=pgclirc)
 
     # Choose which ever one has a valid value.

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -476,9 +476,11 @@ def cli(database, user, host, port, prompt_passwd, never_prompt, dbname,
         print('Version:', __version__)
         sys.exit(0)
 
-    if not os.path.exists(os.path.expanduser('~/.config/pgcli')):
-        os.makedirs(os.path.expanduser('~/.config/pgcli'))
+    config_dir = os.path.dirname(config_location())
+    if not os.path.exists(config_dir):
+        os.makedirs(config_dir)
 
+    # Migrate the config file from old location.
     if os.path.exists(os.path.expanduser('~/.pgclirc')):
         if not os.path.exists(config_location()):
             shutil.move(os.path.expanduser('~/.pgclirc'), config_location())

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -7,6 +7,7 @@ import sys
 import traceback
 import logging
 import threading
+import shutil
 from time import time
 from codecs import open
 
@@ -33,7 +34,7 @@ from .pgstyle import style_factory
 from .pgexecute import PGExecute
 from .pgbuffer import PGBuffer
 from .completion_refresher import CompletionRefresher
-from .config import write_default_config, load_config
+from .config import write_default_config, load_config, config_location
 from .key_bindings import pgcli_bindings
 from .encodingutils import utf8tounicode
 from .__init__ import __version__
@@ -464,7 +465,7 @@ class PGCli(object):
 @click.option('-v', '--version', is_flag=True, help='Version of pgcli.')
 @click.option('-d', '--dbname', default='', envvar='PGDATABASE',
         help='database name to connect to.')
-@click.option('--pgclirc', default='~/.config/pgcli/config', envvar='PGCLIRC',
+@click.option('--pgclirc', default=config_location(), envvar='PGCLIRC',
         help='Location of pgclirc file.')
 @click.argument('database', default=lambda: None, envvar='PGDATABASE', nargs=1)
 @click.argument('username', default=lambda: None, envvar='PGUSER', nargs=1)
@@ -477,7 +478,17 @@ def cli(database, user, host, port, prompt_passwd, never_prompt, dbname,
 
     if not os.path.exists(os.path.expanduser('~/.config/pgcli')):
         os.makedirs(os.path.expanduser('~/.config/pgcli'))
-        
+
+    if os.path.exists(os.path.expanduser('~/.pgclirc')):
+        if not os.path.exists(config_location()):
+            shutil.move(os.path.expanduser('~/.pgclirc'), config_location())
+            print ('Config file (~/.pgclirc) moved to new location',
+                    config_location())
+        else:
+            print ('Config file is now located at', config_location())
+            print ('Please move the existing config file ~/.pgclirc to',
+                    config_location())
+
     pgcli = PGCli(prompt_passwd, never_prompt, pgclirc_file=pgclirc)
 
     # Choose which ever one has a valid value.

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -464,8 +464,8 @@ class PGCli(object):
 @click.option('-v', '--version', is_flag=True, help='Version of pgcli.')
 @click.option('-d', '--dbname', default='', envvar='PGDATABASE',
         help='database name to connect to.')
-@click.option('--pgclirc', default='~/.pgclirc', envvar='PGCLIRC',
-        help='Location of .pgclirc file.')
+@click.option('--pgclirc', default='~/.config/pgcli/config', envvar='PGCLIRC',
+        help='Location of pgclirc file.')
 @click.argument('database', default=lambda: None, envvar='PGDATABASE', nargs=1)
 @click.argument('username', default=lambda: None, envvar='PGUSER', nargs=1)
 def cli(database, user, host, port, prompt_passwd, never_prompt, dbname,

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -476,7 +476,7 @@ def cli(database, user, host, port, prompt_passwd, never_prompt, dbname,
         sys.exit(0)
 
     if not os.path.exists(os.path.expanduser('~/.config/pgcli')):
-        os.mkdir(os.path.expanduser('~/.config/pgcli'))
+        os.makedirs(os.path.expanduser('~/.config/pgcli'))
         
     pgcli = PGCli(prompt_passwd, never_prompt, pgclirc_file=pgclirc)
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -475,9 +475,9 @@ def cli(database, user, host, port, prompt_passwd, never_prompt, dbname,
         print('Version:', __version__)
         sys.exit(0)
 
-    if not os.path.exists('~/.config/pgcli'):
-        os.mkdir('~/.config/pgcli')
-
+    if not os.path.exists(os.path.expanduser('~/.config/pgcli')):
+        os.mkdir(os.path.expanduser('~/.config/pgcli'))
+        
     pgcli = PGCli(prompt_passwd, never_prompt, pgclirc_file=pgclirc)
 
     # Choose which ever one has a valid value.

--- a/pgcli/packages/pgspecial/namedqueries.py
+++ b/pgcli/packages/pgspecial/namedqueries.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import os
+
 class NamedQueries(object):
 
     section_name = 'named queries'
@@ -55,4 +57,7 @@ Examples:
         return '%s: Deleted' % name
 
 from ...config import load_config
-namedqueries = NamedQueries(load_config('~/.pgclirc'))
+if os.path.isfile('~/.config/pgcli/config'):
+    namedqueries = NamedQueries(load_config('~/.config/pgcli/config'))
+else:
+    namedqueries = NamedQueries(load_config('~/.pgclirc'))

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -16,10 +16,10 @@ wider_completion_menu = False
 multi_line = False
 
 # log_file location.
-log_file = ~/.pgcli.log
+log_file = ~/.config/pgcli/log
 
 # history_file location.
-history_file = ~/.pgcli-history
+history_file = ~/.config/pgcli/history
 
 # Default log level. Possible values: "CRITICAL", "ERROR", "WARNING", "INFO"
 # and "DEBUG".


### PR DESCRIPTION
This is PR #349 by @inkn to move the config file from ~/.pgclirc to ~/.config/pgcli/config. 

I've added one more commit to this PR which will auto-migrate the config file at launch time and print a message at the top. If there is already a config file under ~/.config/pgcli/config then we won't overwrite it. Pgcli will simply print a message saying the user has to merge their ~/.pgclirc to ~/.config/pgcli/config file. 

I've also added default paths that are compatible with Windows. 

@dbcli/pgcli-core Can you please review this? @darikg I'm interested to know if this works as expected in Windows. My Windows VMs have expired, so I'm still downloading a new Windows VM to test this out. 

/cc @inkn I'm going to close #349 since this PR has all of your original commits. 