### PR TITLE
Issue #315 Add support for \x auto

### DIFF
--- a/pgcli/packages/expanded.py
+++ b/pgcli/packages/expanded.py
@@ -19,7 +19,7 @@ def expanded_table(rows, headers):
             max_row_len = row_len
 
         for header, value in zip(padded_headers, row):
-            row_result.append(u"%s %s" % (header, value))
+            row_result.append((u"%s" % header) + " " + (u"%s" % value).strip())
 
         results.append('\n'.join(row_result))
 

--- a/pgcli/packages/pgspecial/main.py
+++ b/pgcli/packages/pgspecial/main.py
@@ -120,33 +120,12 @@ class PGSpecial(object):
         return [(None, None, None, msg)]
 
 @export
-def is_wider_than_terminal(row):
-    line_len = sum([len(x) for x in row]) + (len(row)*3) + 2
-    return line_len > get_terminal_width() - 4
-
-def get_terminal_width():
-# From http://stackoverflow.com/questions/566746/how-to-get-console-window-width-in-python
-    import os
-    env = os.environ
-    def ioctl_GWINSZ(fd):
-        try:
-            import fcntl, termios, struct, os
-            cr = struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ,
-                '1234'))
-        except:
-            return
-        return cr
-    cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
-    if not cr:
-        try:
-            fd = os.open(os.ctermid(), os.O_RDONLY)
-            cr = ioctl_GWINSZ(fd)
-            os.close(fd)
-        except:
-            pass
-    if not cr:
-        cr = (env.get('LINES', 25), env.get('COLUMNS', 80))
-    return int(cr[1])
+def content_exceeds_width(row, width):
+    # Account for 3 characters between each column
+    separator_space = (len(row)*3)
+    # Add 2 columns for a bit of buffer
+    line_len = sum([len(x) for x in row]) + separator_space + 2
+    return line_len > width
 
 @export
 def parse_special_command(sql):

--- a/pgcli/packages/pgspecial/main.py
+++ b/pgcli/packages/pgspecial/main.py
@@ -82,15 +82,21 @@ class PGSpecial(object):
         return [(None, result, headers, None)]
 
     def toggle_expanded_output(self, pattern, **_):
-        if pattern.strip() == "auto":
+        flag = pattern.strip()
+        if flag == "auto":
             self.auto_expand = True
             self.expanded_output = False
-            message = u"Expanded display is used automatically."
+            return [(None, None, None, u"Expanded display is used automatically.")]
+        elif flag == "off":
+            self.expanded_output = False
+        elif flag == "on":
+            self.expanded_output = True
         else:
             self.expanded_output = not (self.expanded_output or self.auto_expand)
-            self.auto_expand = self.expanded_output
-            message = u"Expanded display is "
-            message += u"on." if self.expanded_output else u"off."
+
+        self.auto_expand = self.expanded_output
+        message = u"Expanded display is "
+        message += u"on." if self.expanded_output else u"off."
         return [(None, None, None, message)]
 
     def toggle_timing(self):

--- a/pgcli/packages/tabulate.py
+++ b/pgcli/packages/tabulate.py
@@ -879,6 +879,8 @@ def tabulate(tabular_data, headers=[], tablefmt="simple",
      eggs & 451      \\\\
     \\bottomrule
     \end{tabular}
+
+    Also returns a tuple of the raw rows pulled from tabular_data
     """
     if tabular_data is None:
         tabular_data = []
@@ -921,7 +923,7 @@ def tabulate(tabular_data, headers=[], tablefmt="simple",
     if not isinstance(tablefmt, TableFormat):
         tablefmt = _table_formats.get(tablefmt, _table_formats["simple"])
 
-    return _format_table(tablefmt, headers, rows, minwidths, aligns)
+    return _format_table(tablefmt, headers, rows, minwidths, aligns), rows
 
 
 def _build_simple_row(padded_cells, rowfmt):


### PR DESCRIPTION
Adds support for `\x auto` option.

* I'm not totally sure about returning `rows` from `tabulate` but it was the most straightforward way I could think of to reuse the data from `cur`
* The `get_terminal_width` function has been borrowed from Stack Overflow and is not extensively tested
(works well on GNOME Terminal 3.6.2)

