### PR TITLE
Suggest functions as tables

### DIFF
--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -261,6 +261,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
                     {'type': 'keyword'}]
     elif (token_v.endswith('join') and token.is_keyword) or (token_v in
             ('copy', 'from', 'update', 'into', 'describe', 'truncate')):
+        
         schema = (identifier and identifier.get_parent_name()) or []
 
         # Suggest tables from either the currently-selected schema or the
@@ -274,6 +275,11 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
         # Only tables can be TRUNCATED, otherwise suggest views
         if token_v != 'truncate':
             suggest.append({'type': 'view', 'schema': schema})
+            
+        # Suggest set-returning functions in the FROM clause
+        if token_v == 'from' or (token_v.endswith('join') and token.is_keyword):
+            suggest.append({'type': 'function', 'schema': schema,
+                            'filter': 'is_set_returning'})
 
         return suggest
 

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -287,6 +287,10 @@ class PGCompleter(Completer):
                     funcs = self.populate_schema_objects(
                         suggestion['schema'], 'functions')
 
+                # Function overloading means we way have multiple functions
+                # of the same name at this point, so keep unique names only
+                funcs = set(funcs)
+
                 funcs = self.find_matches(word_before_cursor, funcs,
                                           meta='function')
                 completions.extend(funcs)

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -139,17 +139,23 @@ class PGCompleter(Completer):
             self.all_completions.add(column)
 
     def extend_functions(self, func_data):
+        
+        # func_data is a list of function metadata namedtuples
+        # with fields schema_name, func_name, arg_list, result,
+        # is_aggregate, is_window, is_set_returning
 
-        # func_data is an iterator of (schema_name, function_name)
-
-        # dbmetadata['functions']['schema_name']['function_name'] should return
-        # function metadata -- right now we're not storing any further metadata
-        # so just default to None as a placeholder
+        # dbmetadata['schema_name']['functions']['function_name'] should return
+        # the function metadata namedtuple for the corresponding function
         metadata = self.dbmetadata['functions']
 
         for f in func_data:
-            schema, func = self.escaped_names(f)
-            metadata[schema][func] = None
+            schema, func = self.escaped_names([f.schema_name, f.func_name])
+            
+            if func in metadata[schema]:
+                metadata[schema][func].append(f)
+            else:
+                metadata[schema][func] = [f]
+
             self.all_completions.add(func)
 
     def extend_datatypes(self, type_data):

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -17,8 +17,12 @@ metadata = {
                                 'shipments': ['id', 'address', 'user_id']
                             }},
             'functions': {
-                            'public':   ['func1', 'func2'],
-                            'custom':   ['func3', 'func4'],
+                            'public': [
+                                ['func1', '', '', False, False, False],
+                                ['func2', '', '', False, False, False]],
+                            'custom': [
+                                ['func3', '', '', False, False, False],
+                                ['set_returning_func', '', '', False, False, True]],
                          },
             'datatypes': {
                             'public':   ['typ1', 'typ2'],
@@ -41,9 +45,9 @@ def completer():
             tables.append((schema, table))
             columns.extend([(schema, table, col) for col in cols])
 
-    functions = [FunctionMetadata(schema, func, '', '', False, False, False)
+    functions = [FunctionMetadata(schema, *func_meta)
                     for schema, funcs in metadata['functions'].items()
-                    for func in funcs]
+                    for func_meta in funcs]
 
     datatypes = [(schema, datatype)
                     for schema, datatypes in metadata['datatypes'].items()
@@ -165,8 +169,9 @@ def test_suggested_table_names_with_schema_dot(completer, complete_event):
     assert set(result) == set([
         Completion(text='users', start_position=0, display_meta='table'),
         Completion(text='products', start_position=0, display_meta='table'),
-        Completion(text='shipments', start_position=0, display_meta='table')])
-
+        Completion(text='shipments', start_position=0, display_meta='table'),
+        Completion(text='set_returning_func', start_position=0, display_meta='function'),
+    ])
 def test_suggested_column_names_with_qualified_alias(completer, complete_event):
     """
     Suggest column names on table alias and dot
@@ -269,7 +274,7 @@ def test_schema_qualified_function_name(completer, complete_event):
         Document(text=text, cursor_position=postion), complete_event))
     assert result == set([
         Completion(text='func3', start_position=-len('func'), display_meta='function'),
-        Completion(text='func4', start_position=-len('func'), display_meta='function')])
+        Completion(text='set_returning_func', start_position=-len('func'), display_meta='function')])
 
 
 @pytest.mark.parametrize('text', [

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import pytest
 from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
+from pgcli.pgexecute import FunctionMetadata
 
 metadata = {
             'tables': {
@@ -40,7 +41,7 @@ def completer():
             tables.append((schema, table))
             columns.extend([(schema, table, col) for col in cols])
 
-    functions = [(schema, func)
+    functions = [FunctionMetadata(schema, func, '', '', False, False, False)
                     for schema, funcs in metadata['functions'].items()
                     for func in funcs]
 

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import pytest
 from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
+from pgcli.pgexecute import FunctionMetadata
 
 metadata = {
                 'tables': {
@@ -42,7 +43,8 @@ def completer():
     comp.extend_columns(columns, kind='views')
 
     # functions
-    functions = [('public', func) for func in metadata['functions']]
+    functions = [FunctionMetadata('public', func, '', '', False, False, False)
+                 for func in metadata['functions']]
     comp.extend_functions(functions)
 
     # types

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -11,7 +11,10 @@ metadata = {
                     'select': ['id', 'insert', 'ABC']},
                 'views': {
                     'user_emails': ['id', 'email']},
-                'functions': ['custom_func1', 'custom_func2'],
+                'functions': [
+                    ['custom_func1', '', '', False, False, False],
+                    ['custom_func2', '', '', False, False, False],
+                    ['set_returning_func', '', '', False, False, True]],
                 'datatypes': ['custom_type1', 'custom_type2'],
             }
 
@@ -43,8 +46,8 @@ def completer():
     comp.extend_columns(columns, kind='views')
 
     # functions
-    functions = [FunctionMetadata('public', func, '', '', False, False, False)
-                 for func in metadata['functions']]
+    functions = [FunctionMetadata('public', *func_meta)
+                 for func_meta in metadata['functions']]
     comp.extend_functions(functions)
 
     # types
@@ -90,7 +93,8 @@ def test_schema_or_visible_table_completion(completer, complete_event):
         Completion(text='users', start_position=0, display_meta='table'),
         Completion(text='"select"', start_position=0, display_meta='table'),
         Completion(text='orders', start_position=0, display_meta='table'),
-        Completion(text='user_emails', start_position=0, display_meta='view')])
+        Completion(text='user_emails', start_position=0, display_meta='view'),
+        Completion(text='set_returning_func', start_position=0, display_meta='function')])
 
 
 def test_builtin_function_name_completion(completer, complete_event):
@@ -156,7 +160,8 @@ def test_suggested_column_names_from_visible_table(completer, complete_event):
         Completion(text='first_name', start_position=0, display_meta='column'),
         Completion(text='last_name', start_position=0, display_meta='column'),
         Completion(text='custom_func1', start_position=0, display_meta='function'),
-        Completion(text='custom_func2', start_position=0, display_meta='function')] +
+        Completion(text='custom_func2', start_position=0, display_meta='function'),
+    Completion(text='set_returning_func', start_position=0, display_meta='function')] +
         list(map(lambda f: Completion(f, display_meta='function'), completer.functions)) +
         list(map(lambda x: Completion(x, display_meta='keyword'), completer.keywords))
         )
@@ -240,7 +245,8 @@ def test_suggested_multiple_column_names(completer, complete_event):
         Completion(text='first_name', start_position=0, display_meta='column'),
         Completion(text='last_name', start_position=0, display_meta='column'),
         Completion(text='custom_func1', start_position=0, display_meta='function'),
-        Completion(text='custom_func2', start_position=0, display_meta='function')] +
+        Completion(text='custom_func2', start_position=0, display_meta='function'),
+    Completion(text='set_returning_func', start_position=0, display_meta='function')] +
         list(map(lambda f: Completion(f, display_meta='function'), completer.functions)) +
         list(map(lambda x: Completion(x, display_meta='keyword'), completer.keywords))
         )
@@ -357,6 +363,7 @@ def test_table_names_after_from(completer, complete_event):
         Completion(text='orders', start_position=0, display_meta='table'),
         Completion(text='"select"', start_position=0, display_meta='table'),
         Completion(text='user_emails', start_position=0, display_meta='view'),
+        Completion(text='set_returning_func', start_position=0, display_meta='function')
         ])
 
 def test_auto_escaped_col_names(completer, complete_event):
@@ -371,7 +378,8 @@ def test_auto_escaped_col_names(completer, complete_event):
         Completion(text='"insert"', start_position=0, display_meta='column'),
         Completion(text='"ABC"', start_position=0, display_meta='column'),
         Completion(text='custom_func1', start_position=0, display_meta='function'),
-        Completion(text='custom_func2', start_position=0, display_meta='function')] +
+        Completion(text='custom_func2', start_position=0, display_meta='function'),
+        Completion(text='set_returning_func', start_position=0, display_meta='function')] +
         list(map(lambda f: Completion(f, display_meta='function'), completer.functions)) +
         list(map(lambda x: Completion(x, display_meta='keyword'), completer.keywords))
         )

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -79,39 +79,64 @@ def test_select_suggests_cols_and_funcs():
     assert sorted_dicts(suggestions) == sorted_dicts([
          {'type': 'column', 'tables': []},
          {'type': 'function', 'schema': []},
-         {'type': 'keyword'}
+         {'type': 'keyword'},
          ])
 
 
 @pytest.mark.parametrize('expression', [
-    'SELECT * FROM ',
     'INSERT INTO ',
     'COPY ',
     'UPDATE ',
     'DESCRIBE ',
-    'SELECT * FROM foo JOIN ',
 ])
-def test_expression_suggests_tables_views_and_schemas(expression):
+def test_suggests_tables_views_and_schemas(expression):
     suggestions = suggest_type(expression, expression)
     assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'table', 'schema': []},
         {'type': 'view', 'schema': []},
-        {'type': 'schema'}])
+        {'type': 'schema'},
+    ])
 
 
 @pytest.mark.parametrize('expression', [
-    'SELECT * FROM sch.',
+    'SELECT * FROM ',
+    'SELECT * FROM foo JOIN ',
+])
+def test_suggest_tables_views_schemas_and_set_returning_functions(expression):
+    suggestions = suggest_type(expression, expression)
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'table', 'schema': []},
+        {'type': 'view', 'schema': []},
+        {'type': 'function', 'schema': [], 'filter': 'is_set_returning'},
+        {'type': 'schema'},
+    ])
+
+
+@pytest.mark.parametrize('expression', [
     'INSERT INTO sch.',
     'COPY sch.',
     'UPDATE sch.',
     'DESCRIBE sch.',
-    'SELECT * FROM foo JOIN sch.',
 ])
-def test_expression_suggests_qualified_tables_views_and_schemas(expression):
+def test_suggest_qualified_tables_and_views(expression):
     suggestions = suggest_type(expression, expression)
     assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'table', 'schema': 'sch'},
-        {'type': 'view', 'schema': 'sch'}])
+        {'type': 'view', 'schema': 'sch'},
+    ])
+
+
+@pytest.mark.parametrize('expression', [
+    'SELECT * FROM sch.',
+    'SELECT * FROM foo JOIN sch.',
+])
+def test_suggest_qualified_tables_views_and_set_returning_functions(expression):
+    suggestions = suggest_type(expression, expression)
+    assert sorted_dicts(suggestions) == sorted_dicts([
+        {'type': 'table', 'schema': 'sch'},
+        {'type': 'view', 'schema': 'sch'},
+        {'type': 'function', 'schema': 'sch', 'filter': 'is_set_returning'},
+    ])
 
 
 def test_truncate_suggests_tables_and_schemas():
@@ -147,6 +172,7 @@ def test_table_comma_suggests_tables_and_schemas():
     assert sorted_dicts(suggestions) == sorted_dicts([
         {'type': 'table', 'schema': []},
         {'type': 'view', 'schema': []},
+        {'type': 'function', 'schema': [], 'filter': 'is_set_returning'},
         {'type': 'schema'}])
 
 
@@ -272,6 +298,7 @@ def test_sub_select_table_name_completion(expression):
     assert sorted_dicts(suggestion) == sorted_dicts([
         {'type': 'table', 'schema': []},
         {'type': 'view', 'schema': []},
+        {'type': 'function', 'schema': [], 'filter': 'is_set_returning'},
         {'type': 'schema'}])
 
 
@@ -314,6 +341,7 @@ def test_join_suggests_tables_and_schemas(tbl_alias, join_type):
     assert sorted_dicts(suggestion) == sorted_dicts([
         {'type': 'table', 'schema': []},
         {'type': 'view', 'schema': []},
+        {'type': 'function', 'schema': [], 'filter': 'is_set_returning'},
         {'type': 'schema'}])
 
 
@@ -323,6 +351,7 @@ def test_left_join_with_comma():
     assert sorted_dicts(suggestions) == sorted_dicts([
          {'type': 'table', 'schema': []},
          {'type': 'view', 'schema': []},
+         {'type': 'function', 'schema': [], 'filter': 'is_set_returning'},
          {'type': 'schema'}])
 
 
@@ -389,6 +418,7 @@ def test_2_statements_2nd_current():
     assert sorted_dicts(suggestions) == sorted_dicts([
          {'type': 'table', 'schema': []},
          {'type': 'view', 'schema': []},
+         {'type': 'function', 'schema': [], 'filter': 'is_set_returning'},
          {'type': 'schema'}])
 
     suggestions = suggest_type('select * from a; select  from b',
@@ -405,6 +435,7 @@ def test_2_statements_2nd_current():
     assert sorted_dicts(suggestions) == sorted_dicts([
          {'type': 'table', 'schema': []},
          {'type': 'view', 'schema': []},
+         {'type': 'function', 'schema': [], 'filter': 'is_set_returning'},
          {'type': 'schema'}])
 
 
@@ -414,6 +445,7 @@ def test_2_statements_1st_current():
     assert sorted_dicts(suggestions) == sorted_dicts([
          {'type': 'table', 'schema': []},
          {'type': 'view', 'schema': []},
+         {'type': 'function', 'schema': [], 'filter': 'is_set_returning'},
          {'type': 'schema'}])
 
     suggestions = suggest_type('select  from a; select * from b',
@@ -431,6 +463,7 @@ def test_3_statements_2nd_current():
     assert sorted_dicts(suggestions) == sorted_dicts([
          {'type': 'table', 'schema': []},
          {'type': 'view', 'schema': []},
+         {'type': 'function', 'schema': [], 'filter': 'is_set_returning'},
          {'type': 'schema'}])
 
     suggestions = suggest_type('select * from a; select  from b; select * from c',


### PR DESCRIPTION
Fixes #189. Suggest set-returning functions in the appropriate places.

This enhances the amount of function meta-data stored: the function argument list, the function return type, and boolean flags `is_aggregate`, `is_window`, and `is_set_returning`. This is a little bit overkill, in that all we need for this PR is `is_set_returning`, but I plan on using most of this in the future. In particular, after (if) this PR is accepted, I'll have follow up that suggests column names from set-returning functions used as tables. Ultimately after that I'd like to implement function tooltips/hints.