### PR TITLE
Upgrade to prompt-toolkit-0.52

### DIFF
--- a/pgcli/key_bindings.py
+++ b/pgcli/key_bindings.py
@@ -15,6 +15,8 @@ def pgcli_bindings(get_vi_mode_enabled, set_vi_mode_enabled):
     key_binding_manager = KeyBindingManager(
         enable_open_in_editor=True,
         enable_system_bindings=True,
+        enable_search=True,
+        enable_abort_and_exit_bindings=True,
         enable_vi_mode=Condition(lambda cli: get_vi_mode_enabled()))
 
     @key_binding_manager.registry.add_binding(Keys.F2)

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -15,8 +15,10 @@ import sqlparse
 from prompt_toolkit import CommandLineInterface, Application, AbortAction
 from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.shortcuts import create_default_layout, create_eventloop
+from prompt_toolkit.buffer import AcceptAction
 from prompt_toolkit.document import Document
 from prompt_toolkit.filters import Always, HasFocus, IsDone
+from prompt_toolkit.layout.lexers import PygmentsLexer
 from prompt_toolkit.layout.processors import (ConditionalProcessor,
                                         HighlightMatchingBracketProcessor)
 from prompt_toolkit.history import FileHistory
@@ -270,7 +272,7 @@ class PGCli(object):
         get_toolbar_tokens = create_toolbar_tokens_func(lambda: self.vi_mode,
                                                         lambda: self.completion_refresher.is_refreshing())
 
-        layout = create_default_layout(lexer=PostgresLexer,
+        layout = create_default_layout(lexer=PygmentsLexer(PostgresLexer),
                                        reserve_space_for_menu=True,
                                        get_prompt_tokens=prompt_tokens,
                                        get_bottom_toolbar_tokens=get_toolbar_tokens,
@@ -286,12 +288,15 @@ class PGCli(object):
         with self._completer_lock:
             buf = PGBuffer(always_multiline=self.multi_line, completer=self.completer,
                     history=FileHistory(os.path.expanduser(history_file)),
-                    complete_while_typing=Always())
+                    complete_while_typing=Always(),
+                    accept_action=AcceptAction.RETURN_DOCUMENT)
 
             application = Application(style=style_factory(self.syntax_style, self.cli_style),
                                       layout=layout, buffer=buf,
                                       key_bindings_registry=key_binding_manager.registry,
                                       on_exit=AbortAction.RAISE_EXCEPTION,
+                                      on_abort=AbortAction.RETRY,
+                                      mouse_support=True,
                                       ignore_case=True)
             self.cli = CommandLineInterface(application=application,
                                        eventloop=create_eventloop())

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         install_requires=[
             'click >= 4.1',
             'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
-            'prompt_toolkit==0.46',
+            'prompt_toolkit==0.52',
             'psycopg2 >= 2.5.4',
             'sqlparse == 0.1.16',
             'configobj >= 5.0.6'


### PR DESCRIPTION
Upgrade to the latest prompt toolkit. Mouse support enabled by default. (You can make this configurable if you want to.)

There were a few more changes I needed to make, because some defaults have changed to "do nothing". However, the ``prompt_toolkit.shortcuts.get_input`` method still has the same defaults. So, later I'd like to have a look at using that instead of creating the ``Application`` manually. I think that makes the integration more simple.