### PR TITLE
Only show expanded layout if valid list of headers provided

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -526,7 +526,7 @@ def format_output(title, cur, headers, status, table_format, expanded=False, max
         output.append(title)
     if cur:
         headers = [utf8tounicode(x) for x in headers]
-        if expanded:
+        if expanded and headers:
             output.append(expanded_table(cur, headers))
         else:
             tabulated, rows = tabulate(cur, headers, tablefmt=table_format,


### PR DESCRIPTION
A continuation of the conversation from https://github.com/dbcli/pgcli/pull/366

A small fix to support showing the `\h` list whilst in expanded layout mode.