### PR TITLE
Fix tests breaking with pexpect 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.4"
 
 install: 
-  - pip install . pytest mock codecov behave pexpect
+  - pip install . pytest mock codecov behave pexpect==3.3
 
 script:
   - coverage run --source pgcli -m py.test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ pytest>=2.7.0
 mock>=1.0.1
 tox>=1.9.2
 behave>=1.2.4
-pexpect>=3.3
+pexpect==3.3

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -84,6 +84,5 @@ def after_scenario(context, _):
     """
 
     if hasattr(context, 'cli') and not context.exit_sent:
-        # Send Ctrl + D into cli
-        context.cli.sendcontrol('d')
-        context.cli.expect(pexpect.EOF, timeout=5)
+        # Terminate nicely.
+        context.cli.terminate()

--- a/tests/features/steps/step_definitions.py
+++ b/tests/features/steps/step_definitions.py
@@ -133,7 +133,7 @@ def step_db_connect_test(context):
     Send connect to database.
     """
     db_name = context.conf['dbname']
-    context.cli.sendline('\connect {0}'.format(db_name))
+    context.cli.sendline('\\connect {0}'.format(db_name))
 
 
 @when('we start external editor providing a file name')
@@ -177,7 +177,7 @@ def step_db_connect_postgres(context):
     """
     Send connect to database.
     """
-    context.cli.sendline('\connect postgres')
+    context.cli.sendline('\\connect postgres')
 
 
 @when('we refresh completions')
@@ -296,8 +296,7 @@ def _expect_exact(context, expected, timeout):
         context.cli.expect_exact(expected, timeout=timeout)
     except:
         # Strip color codes out of the output.
-        actual = re.sub('\x1b\[[0-9;]*m', '', context.cli.before)
-        actual = re.sub('\x1b\[(.*)?.{1}', '', actual)
+        actual = re.sub(r'\x1b\[([0-9A-Za-z;?])+[m|K]?', '', context.cli.before)
         raise Exception('Expected:\n---\n{0}\n---\n\nActual:\n---\n{1}\n---'.format(
             expected,
             actual))

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,5 @@ envlist = py26, py27, py33, py34
 [testenv]
 deps = pytest
     mock
+    pgspecial
 commands = py.test


### PR DESCRIPTION
This PR:

* Uses a different method of exiting the cli with pexpect (`.terminate()`)
* Updates a regexp to filter out ANSI escape sequences.
* Pins pexpect to 3.3.
* Adds pgspecial to tox.

Connected to #374.