### PR TITLE
Don't sort keyword suggestions alphabetically

### DIFF
--- a/pgcli/packages/pgliterals/pgliterals.json
+++ b/pgcli/packages/pgliterals/pgliterals.json
@@ -1,5 +1,11 @@
 {
     "keywords": [
+        "SELECT",
+        "FROM",
+        "WHERE",
+        "GROUP BY",
+        "HAVING",
+        "ORDER BY",
         "ACCESS",
         "ADD",
         "ALL",
@@ -46,12 +52,9 @@
         "FORCE_QUOTE",
         "FORCE_NOT_NULL",
         "FREEZE",
-        "FROM",
         "FULL",
         "FUNCTION",
         "GRANT",
-        "GROUP BY",
-        "HAVING",
         "HEADER",
         "IDENTIFIED",
         "IMMEDIATE",
@@ -91,7 +94,6 @@
         "ONLINE",
         "OPTION",
         "OR",
-        "ORDER BY",
         "OUTER",
         "OWNER",
         "PCTFREE",
@@ -109,7 +111,6 @@
         "ROWID",
         "ROWNUM",
         "ROWS",
-        "SELECT",
         "SESSION",
         "SET",
         "SHARE",
@@ -139,7 +140,6 @@
         "VIEW",
         "WHEN",
         "WHENEVER",
-        "WHERE",
         "WITH"
     ],
     "functions": [

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -341,10 +341,11 @@ class PGCompleter(Completer):
                 completions.extend(dbs)
 
             elif suggestion['type'] == 'keyword':
-                keywords = self.find_matches(word_before_cursor, self.keywords,
-                                             start_only=True,
-                                             fuzzy=False,
-                                             meta='keyword')
+                # Suggest keywords without sorting so they're suggested in the
+                # same order as listed in pgliterals
+                keywords = self.find_matches(
+                    word_before_cursor, self.keywords, start_only=True,
+                    fuzzy=False, sort_ranked=False, meta='keyword')
                 completions.extend(keywords)
 
             elif suggestion['type'] == 'special':

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -163,7 +163,7 @@ class PGCompleter(Completer):
         self.all_completions = set(self.keywords + self.functions)
 
     def find_matches(self, text, collection, start_only=False, fuzzy=True,
-                     meta=None, meta_collection=None):
+                     sort_ranked=True, meta=None, meta_collection=None):
         """Find completion matches for the given text.
 
         Given the user's input text and a collection of available
@@ -175,7 +175,9 @@ class PGCompleter(Completer):
         considered a match if the text appears anywhere within it.
 
         yields prompt_toolkit Completion instances for any matches found
-        in the collection of available completions.
+        in the collection of available completions. By default, matches are
+        sorted by priority. Specify sort_ranked=False to maintain the same order
+        as the supplied collection.
 
         """
 
@@ -218,8 +220,11 @@ class PGCompleter(Completer):
 
                 completions.append((sort_key, item, meta))
 
+        if sort_ranked:
+            completions = sorted(completions)
+
         return [Completion(item, -len(text), display_meta=meta)
-                for sort_key, item, meta in sorted(completions)]
+                for sort_key, item, meta in completions]
 
 
     def get_completions(self, document, complete_event, smart_completion=None):

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -484,3 +484,13 @@ def test_find_matches_no_sort_ranked(completer, complete_event):
         meta=None, meta_collection=None, sort_ranked=False)
     matches = [c.text for c in completions]
     assert matches == collection
+
+
+def test_suggest_keywords_in_proper_order(completer, complete_event):
+    sql = 'SELECT * FR'
+    pos = len(sql)
+    completions = completer.get_completions(
+        Document(text=sql, cursor_position=pos), complete_event)
+    completions = [c.text for c in completions]
+    assert completions.index('FROM') < completions.index('FREEZE')
+

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -475,3 +475,12 @@ def test_join_functions_on_suggests_columns(completer, complete_event):
     assert set(result) == set([
          Completion(text='x', start_position=0, display_meta='column'),
          Completion(text='y', start_position=0, display_meta='column')])
+
+
+def test_find_matches_no_sort_ranked(completer, complete_event):
+    collection = ['AB', 'AA']
+    completions = completer.find_matches(
+        'A', collection, start_only=True, fuzzy=False,
+        meta=None, meta_collection=None, sort_ranked=False)
+    matches = [c.text for c in completions]
+    assert matches == collection


### PR DESCRIPTION
Keywords now maintain the same order they were listed in the pgliterals definition, which allows us to prioritize `FROM` over `FREEZE` and `WHERE` over `WHEN`

See #287 
