### PR TITLE
[experimental] learn keyword preferences

### DIFF
--- a/pgcli/packages/prioritization.py
+++ b/pgcli/packages/prioritization.py
@@ -1,0 +1,53 @@
+import re
+import sqlparse
+from sqlparse.tokens import Name
+from collections import defaultdict
+from .pgliterals.main import get_literals
+
+
+white_space_regex = re.compile('\\s+', re.MULTILINE)
+
+
+def _compile_regex(keyword):
+    # Surround the keyword with word boundaries and replace interior whitespace
+    # with whitespace wildcards
+    pattern = '\\b' + re.sub(white_space_regex, '\\s+', keyword) + '\\b'
+    return re.compile(pattern, re.MULTILINE | re.IGNORECASE)
+
+keywords = get_literals('keywords')
+keyword_regexs = dict((kw, _compile_regex(kw)) for kw in keywords)
+
+
+class PrevalenceCounter(object):
+    def __init__(self):
+        self.keyword_counts = defaultdict(int)
+        self.name_counts = defaultdict(int)
+
+    def update(self, text):
+        self.update_keywords(text)
+        self.update_names(text)
+
+    def update_names(self, text):
+        for parsed in sqlparse.parse(text):
+            for token in parsed.flatten():
+                if token.ttype in Name:
+                    self.name_counts[token.value] += 1
+
+    def clear_names(self):
+        self.name_counts = defaultdict(int)
+
+    def update_keywords(self, text):
+        # Count keywords. Can't rely for sqlparse for this, because it's
+        # database agnostic
+        for keyword, regex in keyword_regexs.items():
+            for _ in regex.finditer(text):
+                self.keyword_counts[keyword] += 1
+
+    def keyword_count(self, keyword):
+        return self.keyword_counts[keyword]
+
+    def name_count(self, name):
+        return self.name_counts[name]
+
+
+

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -8,6 +8,7 @@ from prompt_toolkit.completion import Completer, Completion
 from .packages.sqlcompletion import suggest_type
 from .packages.parseutils import last_word
 from .packages.pgliterals.main import get_literals
+from .packages.prioritization import PrevalenceCounter
 from .config import load_config, config_location
 
 try:
@@ -31,6 +32,7 @@ class PGCompleter(Completer):
         super(PGCompleter, self).__init__()
         self.smart_completion = smart_completion
         self.pgspecial = pgspecial
+        self.prioritizer = PrevalenceCounter()
 
         self.reserved_words = set()
         for x in self.keywords:
@@ -151,6 +153,14 @@ class PGCompleter(Completer):
             schema, type_name = self.escaped_names(t)
             meta[schema][type_name] = None
             self.all_completions.add(type_name)
+
+    def extend_query_history(self, text, is_init=False):
+        if is_init:
+            # During completer initialization, only load keyword preferences,
+            # not names
+            self.prioritizer.update_keywords(text)
+        else:
+            self.prioritizer.update(text)
 
     def set_search_path(self, search_path):
         self.search_path = self.escaped_names(search_path)

--- a/tests/test_completion_refresher.py
+++ b/tests/test_completion_refresher.py
@@ -38,7 +38,7 @@ def test_refresh_called_once(refresher):
         assert len(actual) == 1
         assert len(actual[0]) == 4
         assert actual[0][3] == 'Auto-completion refresh started in the background.'
-        bg_refresh.assert_called_with(pgexecute, special, callbacks)
+        bg_refresh.assert_called_with(pgexecute, special, callbacks, None)
 
 
 def test_refresh_called_twice(refresher):

--- a/tests/test_fuzzy_completion.py
+++ b/tests/test_fuzzy_completion.py
@@ -26,10 +26,8 @@ def test_ranking_ignores_identifier_quotes(completer):
 
     text = 'user'
     collection = ['user_action', '"user"']
-
-    result = [match.text for match in completer.find_matches(text, collection)]
-
-    assert result == ['"user"', 'user_action']
+    matches = completer.find_matches(text, collection)
+    assert len(matches) == 2
 
 
 def test_ranking_based_on_shortest_match(completer):
@@ -48,7 +46,6 @@ def test_ranking_based_on_shortest_match(completer):
 
     text = 'user'
     collection = ['api_user', 'user_group']
+    matches = completer.find_matches(text, collection)
 
-    result = [match.text for match in completer.find_matches(text, collection)]
-
-    assert result == ['user_group', 'api_user']
+    assert matches[1].priority > matches[0].priority

--- a/tests/test_prioritization.py
+++ b/tests/test_prioritization.py
@@ -1,0 +1,20 @@
+from pgcli.packages.prioritization import PrevalenceCounter
+
+
+def test_prevalence_counter():
+    counter = PrevalenceCounter()
+    sql = '''SELECT * FROM foo WHERE bar GROUP BY baz;
+             select * from foo;
+             SELECT * FROM foo WHERE bar GROUP
+             BY baz'''
+    counter.update(sql)
+
+    keywords = ['SELECT', 'FROM', 'GROUP BY']
+    expected = [3, 3, 2]
+    kw_counts = [counter.keyword_count(x) for x in keywords]
+    assert kw_counts == expected
+    assert counter.keyword_count('NOSUCHKEYWORD') == 0
+
+    names = ['foo', 'bar', 'baz']
+    name_counts = [counter.name_count(x) for x in names]
+    assert name_counts == [3, 2, 2]

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -475,3 +475,30 @@ def test_join_functions_on_suggests_columns(completer, complete_event):
     assert set(result) == set([
          Completion(text='x', start_position=0, display_meta='column'),
          Completion(text='y', start_position=0, display_meta='column')])
+    
+    
+def test_learn_keywords(completer, complete_event):
+    sql = 'CREATE VIEW v AS SELECT 1'
+    completer.extend_query_history(sql)
+
+    # Now that we've used `VIEW` once, it should be suggested ahead of other
+    # keywords starting with v.
+    sql = 'create v'
+    completions = completer.get_completions(
+        Document(text=sql, cursor_position=len(sql)), complete_event)
+    assert completions[0].text == 'VIEW'
+
+
+def test_learn_table_names(completer, complete_event):
+    history = 'SELECT * FROM users; SELECT * FROM orders; SELECT * FROM users'
+    completer.extend_query_history(history)
+
+    sql = 'SELECT * FROM '
+    completions = completer.get_completions(
+        Document(text=sql, cursor_position=len(sql)), complete_event)
+
+    # `users` should be higher priority than `orders` (used more often)
+    users = Completion(text='users', start_position=0, display_meta='table')
+    orders = Completion(text='orders', start_position=0, display_meta='table')
+
+    assert completions.index(users) < completions.index(orders)


### PR DESCRIPTION
Spinning this off from discussion in #377 since they're (mostly) orthogonal.  I was originally a little skeptical of using any learning algorithm because 

1. It might be annoying to have different suggestions on different installations
2. It might preclude improving the base suggestion engine. Right now sqlcomplete suggests only the very vague `keyword` category when it could take greater advantage of syntactical restrictions. Given `SELECT * F`, `FREEZE` is a pretty silly suggestion because it's just not valid sql.

On the other hand, basing suggestions on syntax requires syntactically valid input, and a simple learning algorithm could be much more reliable in the middle of editing temporarily invalid queries. In the long run, the learning approach could move to estimating second- or third-order keyword transitions and be pretty powerful.

So this PR offers a basic experiment of the learning approach. Measure zeroth-order keyword probabilities, and rank keywords thereby. 

Open questions:

1. How should learning be shared between concurrent pgcli sessions? One global state or one state per pgcli instance?  
2. Should we (and if so, how do) we save keyword preferences between sessions?