### PR TITLE
Improve error handling in pgexecute

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -31,7 +31,7 @@ import pgspecial as special
 from .pgcompleter import PGCompleter
 from .pgtoolbar import create_toolbar_tokens_func
 from .pgstyle import style_factory
-from .pgexecute import PGExecute
+from .pgexecute import PGExecute, ON_ERROR_RESUME, ON_ERROR_STOP
 from .pgbuffer import PGBuffer
 from .completion_refresher import CompletionRefresher
 from .config import write_default_config, load_config, config_location
@@ -81,6 +81,10 @@ class PGCli(object):
         self.syntax_style = c['main']['syntax_style']
         self.cli_style = c['colors']
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
+
+        on_error_modes = {'STOP': ON_ERROR_STOP, 'RESUME': ON_ERROR_RESUME}
+        self.on_error = on_error_modes[c['main']['on_error'].upper()]
+
         self.completion_refresher = CompletionRefresher()
 
         self.logger = logging.getLogger(__name__)
@@ -130,7 +134,7 @@ class PGCli(object):
         except IOError as e:
             return [(None, None, None, str(e))]
 
-        return self.pgexecute.run(query, self.pgspecial)
+        return self.pgexecute.run(query, self.pgspecial, on_error=self.on_error)
 
     def initialize_logging(self):
 
@@ -330,7 +334,8 @@ class PGCli(object):
                     res = []
                     # Run the query.
                     start = time()
-                    res = pgexecute.run(document.text, self.pgspecial)
+                    res = pgexecute.run(document.text, self.pgspecial,
+                                        on_error=self.on_error)
                     successful = True
                     output = []
                     total = 0

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -44,6 +44,12 @@ syntax_style = default
 # for end are available in the REPL.
 vi = False
 
+# Error handling
+# When one of multiple SQL statements causes an error, choose to either
+# continue executing the remaining statements, or stopping
+# Possible values "STOP" or "RESUME"
+on_error = RESUME
+
 
 # Custom colors for the completion menu, toolbar, etc. 
 [colors]

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -258,11 +258,14 @@ class PGExecute(object):
 
                 # Not a special command, so execute as normal sql
                 yield self.execute_normal_sql(sql)
-            except psycopg2.ProgrammingError as e:
+            except psycopg2.DatabaseError as e:
                 _logger.error("sql: %r, error: %r", sql, e)
                 _logger.error("traceback: %r", traceback.format_exc())
 
-                if on_error == ON_ERROR_RAISE:
+                if (isinstance(e, psycopg2.OperationalError)
+                        or on_error == ON_ERROR_RAISE):
+                    # Always raise operational errors, regardless of on_error
+                    # specification
                     raise
 
                 result = click.style(utf8tounicode(str(e)), fg='red')

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -27,6 +27,11 @@ ext.register_type(ext.new_type((17,), 'BYTEA_TEXT', psycopg2.STRING))
 ext.set_wait_callback(psycopg2.extras.wait_select)
 
 
+ON_ERROR_RAISE = 0
+ON_ERROR_RESUME = 1
+ON_ERROR_STOP = 2
+
+
 def register_json_typecasters(conn, loads_fn):
     """Set the function for converting JSON data for a connection.
 
@@ -221,7 +226,7 @@ class PGExecute(object):
         else:
             return json_data
 
-    def run(self, statement, pgspecial=None):
+    def run(self, statement, pgspecial=None, on_error=ON_ERROR_RESUME):
         """Execute the sql in the database and return the results.
 
         :param statement: A string containing one or more sql statements
@@ -250,30 +255,39 @@ class PGExecute(object):
                 except special.CommandNotFound:
                     pass
 
-            yield self.execute_normal_sql(sql)
+            try:
+                yield self.execute_normal_sql(sql)
+            except psycopg2.ProgrammingError as e:
+                _logger.error("sql: %r, error: %r", sql, e)
+                _logger.error("traceback: %r", traceback.format_exc())
+
+                if on_error == ON_ERROR_RAISE:
+                    raise
+
+                result = click.style(utf8tounicode(str(e)), fg='red')
+                yield None, None, None, result
+
+                if on_error == ON_ERROR_STOP:
+                    break
 
     def execute_normal_sql(self, split_sql):
         _logger.debug('Regular sql statement. sql: %r', split_sql)
         cur = self.conn.cursor()
-        try:
-            cur.execute(split_sql)
-        except psycopg2.ProgrammingError as e:
-            _logger.error("sql: %r, error: %r", split_sql, e)
-            _logger.error("traceback: %r", traceback.format_exc())
-            return (None, None, None, click.style(utf8tounicode(str(e)), fg='red'))
+        cur.execute(split_sql)
 
         try:
             title = self.conn.notices.pop()
         except IndexError:
             title = None
+
         # cur.description will be None for operations that do not return
         # rows.
         if cur.description:
             headers = [x[0] for x in cur.description]
-            return (title, cur, headers, cur.statusmessage)
+            return title, cur, headers, cur.statusmessage
         else:
             _logger.debug('No rows in result.')
-            return (title, None, None, cur.statusmessage)
+            return title, None, None, cur.statusmessage
 
     def search_path(self):
         """Returns the current search path as a list of schema names"""

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -244,18 +244,19 @@ class PGExecute(object):
             # Remove spaces, eol and semi-colons.
             sql = sql.rstrip(';')
 
-            if pgspecial:
-                # First try to run each query as special
-                try:
+            try:
+                if pgspecial:
+                    # First try to run each query as special
                     _logger.debug('Trying a pgspecial command. sql: %r', sql)
                     cur = self.conn.cursor()
-                    for result in pgspecial.execute(cur, sql):
-                        yield result
-                    return
-                except special.CommandNotFound:
-                    pass
+                    try:
+                        for result in pgspecial.execute(cur, sql):
+                            yield result
+                        continue
+                    except special.CommandNotFound:
+                        pass
 
-            try:
+                # Not a special command, so execute as normal sql
                 yield self.execute_normal_sql(sql)
             except psycopg2.ProgrammingError as e:
                 _logger.error("sql: %r, error: %r", sql, e)


### PR DESCRIPTION
I don't like how errors are handled in pgexecute.run:

1. The default behavior with multiple statements, with errors in intermediate statements, is to continue executing the remaining statements. I'd like to be able to override that behavior to stop immediately on errors. 

2. Handling all exceptions makes it more difficult to reuse pgexecute outside of pgcli -- consumers may want to catch their own exceptions

3. \special commands are run outside the try clause. Because named queries can include arbitrary sql, they should be run like any other query

4. The `except` clause is too narrow. Currently, it catches `psycopg2.ProgrammingError`, which includes syntax errors, but not, for example, division by zero errors. See [here](http://initd.org/psycopg/docs/module.html#exceptions) for the psycopg2 exception hierarchy. I think ideally we'd widen all the way to catching `psycopg2.DatabaseError`, but `pgcli.main` relies on catching `psycopg2.OperationalError` in order to detect connection failures

This PR is one attempt at addressing these issues. It gives `pgexecute.run` and extra argument to specify how you want exceptions handled -- continue, stop, or reraise. I haven't done anything about point 4 though. Does catching `psycopg2.DatabaseError`, and always reraising `psycopg2.OperationalError` regardless of the `on_error` mode make sense?