### PR TITLE
Change the on_error default value to STOP.

### DIFF
--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -48,7 +48,7 @@ vi = False
 # When one of multiple SQL statements causes an error, choose to either
 # continue executing the remaining statements, or stopping
 # Possible values "STOP" or "RESUME"
-on_error = RESUME
+on_error = STOP
 
 
 # Custom colors for the completion menu, toolbar, etc. 


### PR DESCRIPTION
@darikg Can you review and merge? 

I'd like to set the default to STOP since that is the conservative (aka "sane") option. 