### PR TITLE
Pin codecov version in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.4"
 
 install: 
-  - pip install . pytest mock codecov behave pexpect==3.3
+  - pip install . pytest mock codecov==1.5.1 behave pexpect==3.3
 
 script:
   - coverage run --source pgcli -m py.test


### PR DESCRIPTION
A new version of codecov (1.6.0) was released to PyPi today and our tests on travis starting failing on python 2.6. The log shows some import error in behave, so I have no idea how pinning the codecov version to 1.5.1 fixes it, but it does.