### PR TITLE
Enable user set LESS options and \pset pager config toggling

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,10 @@ try:
     import setproctitle
 except ImportError:
     setproctitle = None
-from pgcli.main import obfuscate_process_password, format_output
+
+from pgcli.main import obfuscate_process_password, LESS_DEFAULTS, PGCli
+
+>>>>>>> d573d95... Preserve environmental LESS options if they are set
 
 
 @pytest.mark.skipif(platform.system() == 'Windows',
@@ -58,3 +61,17 @@ def test_format_output_auto_expand():
                                      max_width=1)
     expanded = ['Title', u'-[ RECORD 0 ]-------------------------\nhead1 | abc\nhead2 | def\n', 'test status']
     assert expanded_results == expanded
+
+def test_less_opts():
+    import os
+    original_less_opts = os.environ.get('LESS', '')
+    cli = PGCli.__new__(PGCli)
+    less_options_adjusted = cli.adjust_less_opts()
+    assert os.environ['LESS'] == LESS_DEFAULTS
+    assert less_options_adjusted is True
+    os.environ['LESS'] = '-lmnropst'
+    less_options_adjusted = cli.adjust_less_opts()
+    assert os.environ['LESS'] == '-lmnropst'
+    assert less_options_adjusted is False
+    os.environ['LESS'] = original_less_opts
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,10 +5,8 @@ try:
 except ImportError:
     setproctitle = None
 
-from pgcli.main import obfuscate_process_password, LESS_DEFAULTS, PGCli
-
->>>>>>> d573d95... Preserve environmental LESS options if they are set
-
+from pgcli.main import obfuscate_process_password, format_output, LESS_DEFAULTS, PGCli, output_fits_screen
+from collections import namedtuple
 
 @pytest.mark.skipif(platform.system() == 'Windows',
                     reason='Not applicable in windows')
@@ -42,6 +40,20 @@ def test_obfuscate_process_password():
     assert title == expected
 
     setproctitle.setproctitle(original_title)
+
+def test_display_output():
+    pass
+
+def test_output_fits_screen():
+    # Mock ScreenSize for tests
+    ScreenSize = namedtuple('ScreenSize', ['columns', 'rows'])
+    prepared_output = ['Title', '+---------+---------+\n| head1   | head2   |\n|---------+---------|\n| abc     | def     |\n+---------+---------+', 'test status']
+    screen_size = ScreenSize(columns=22, rows=5)
+    assert output_fits_screen(prepared_output, screen_size) is True
+    screen_size = ScreenSize(columns=20, rows=5)
+    assert output_fits_screen(prepared_output, screen_size) is False
+    screen_size = ScreenSize(columns=22, rows=4)
+    assert output_fits_screen(prepared_output, screen_size) is False
 
 def test_format_output():
     results = format_output('Title', [('abc', 'def')], ['head1', 'head2'],


### PR DESCRIPTION
Here is an initial implementation for fixing #399 (in tandem with https://github.com/dbcli/pgspecial/pull/6).

This should provide correct correct behaviour for \pset pager off/on/always options - without breaking the format_output api and maintaining correct behaviour when used with `\x` options. 

I've extracted the content_exceeds_width calculation out of format_output to avoid doing it twice. Perhaps the very nice way to do would be to check every row during formatting and raise if it breaks on a condition (rather than just checking the first-row as in the previous implementation) but I don't know how easy this would be since table-formatting is done by a different library. 

I will add some additional tests if this seems like a reasonable implementation. (Travisci currently fails because `pgspecial.pager_config` does not exist). 
