### PR TITLE
Use only immutable datatypes for suggestions

### DIFF
--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -161,7 +161,7 @@ def extract_tables(sql):
     """
     parsed = sqlparse.parse(sql)
     if not parsed:
-        return []
+        return ()
 
     # INSERT statements must stop looking for tables at the sign of first
     # Punctuation. eg: INSERT INTO abc (col1, col2) VALUES (1, 2)
@@ -177,7 +177,7 @@ def extract_tables(sql):
     # to have is_function=True
     identifiers = extract_table_identifiers(stream,
                                             allow_functions=not insert_stmt)
-    return list(identifiers)
+    return tuple(identifiers)
 
 
 def find_prev_keyword(sql):

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -300,7 +300,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
         if token_v == 'from' or (token_v.endswith('join') and token.is_keyword):
             suggest.append(Function(schema=schema, filter='is_set_returning'))
 
-        return suggest
+        return tuple(suggest)
 
     elif token_v in ('table', 'view', 'function'):
         # E.g. 'DROP FUNCTION <funcname>', 'ALTER TABLE <tablname>'
@@ -340,7 +340,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
             return suggest_based_on_last_token(
                 prev_keyword, text_before_cursor, full_text, identifier)
         else:
-            return []
+            return ()
     elif token_v in ('type', '::'):
         #   ALTER TABLE foo SET DATA TYPE bar
         #   SELECT foo::bar
@@ -351,7 +351,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
                        Table(schema=schema)]
         if not schema:
             suggestions.append(Schema())
-        return suggestions
+        return tuple(suggestions)
     else:
         return Keyword(),
 

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -126,13 +126,13 @@ def suggest_special(text):
 
     if cmd == text:
         # Trying to complete the special command itself
-        return Special(),
+        return (Special(),)
 
     if cmd in ('\\c', '\\connect'):
-        return Database(),
+        return (Database(),)
 
     if cmd == '\\dn':
-        return Schema(),
+        return (Schema(),)
 
     if arg:
         # Try to distinguish "\d name" from "\d schema.name"
@@ -162,14 +162,14 @@ def suggest_special(text):
                     'dT': Datatype,
                     }[cmd[1:]]
         if schema:
-            return rel_type(schema=schema),
+            return (rel_type(schema=schema),)
         else:
-            return Schema(), rel_type(schema=None)
+            return (Schema(), rel_type(schema=None))
 
     if cmd in ['\\n', '\\ns', '\\nd']:
-        return NamedQuery(),
+        return (NamedQuery(),)
 
-    return Keyword(), Special()
+    return (Keyword(), Special())
 
 
 def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier):
@@ -206,12 +206,12 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
             return suggest_based_on_last_token('type', text_before_cursor,
                                            full_text, identifier)
         else:
-            return Keyword(),
+            return (Keyword(),)
     else:
         token_v = token.value.lower()
 
     if not token:
-        return Keyword(), Special()
+        return (Keyword(), Special())
     elif token_v.endswith('('):
         p = sqlparse.parse(text_before_cursor)[0]
 
@@ -240,7 +240,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
 
             prev_tok = prev_tok.value.lower()
             if prev_tok == 'exists':
-                return Keyword(),
+                return (Keyword(),)
             else:
                 return column_suggestions
 
@@ -251,18 +251,18 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
             tables = extract_tables(full_text)
 
             # suggest columns that are present in more than one table
-            return Column(tables=tables, drop_unique=True),
+            return (Column(tables=tables, drop_unique=True),)
 
         elif p.token_first().value.lower() == 'select':
             # If the lparen is preceeded by a space chances are we're about to
             # do a sub-select.
             if last_word(text_before_cursor,
                          'all_punctuations').startswith('('):
-                return Keyword(),
+                return (Keyword(),)
         # We're probably in a function argument list
-        return Column(tables=extract_tables(full_text)),
+        return (Column(tables=extract_tables(full_text)),)
     elif token_v in ('set', 'by', 'distinct'):
-        return Column(tables=extract_tables(full_text)),
+        return (Column(tables=extract_tables(full_text)),)
     elif token_v in ('select', 'where', 'having'):
         # Check for a table alias or schema qualification
         parent = (identifier and identifier.get_parent_name()) or []
@@ -307,9 +307,9 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
         rel_type = {'table': Table, 'view': View, 'function': Function}[token_v]
         schema = (identifier and identifier.get_parent_name()) or None
         if schema:
-            return rel_type(schema=schema),
+            return (rel_type(schema=schema),)
         else:
-            return Schema(), rel_type(schema=schema)
+            return (Schema(), rel_type(schema=schema))
     elif token_v == 'on':
         tables = extract_tables(full_text)  # [(schema, table, alias), ...]
         parent = (identifier and identifier.get_parent_name()) or None
@@ -325,15 +325,15 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
             # ON <suggestion>
             # Use table alias if there is one, otherwise the table name
             aliases = tuple(t.alias or t.name for t in tables)
-            return Alias(aliases=aliases),
+            return (Alias(aliases=aliases),)
 
     elif token_v in ('c', 'use', 'database', 'template'):
         # "\c <db", "use <db>", "DROP DATABASE <db>",
         # "CREATE DATABASE <newdb> WITH TEMPLATE <db>"
-        return Database(),
+        return (Database(),)
     elif token_v == 'schema':
         # DROP SCHEMA schema_name
-        return Schema(),
+        return (Schema(),)
     elif token_v.endswith(',') or token_v in ('=', 'and', 'or'):
         prev_keyword, text_before_cursor = find_prev_keyword(text_before_cursor)
         if prev_keyword:
@@ -353,7 +353,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
             suggestions.append(Schema())
         return tuple(suggestions)
     else:
-        return Keyword(),
+        return (Keyword(),)
 
 
 def identifies(id, ref):

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -189,8 +189,8 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
         # 'where foo > 5 and '. We need to look "inside" token.tokens to handle
         # suggestions in complicated where clauses correctly
         prev_keyword, text_before_cursor = find_prev_keyword(text_before_cursor)
-        return suggest_based_on_last_token(prev_keyword, text_before_cursor,
-                                           full_text, identifier)
+        return suggest_based_on_last_token(
+            prev_keyword, text_before_cursor, full_text, identifier)
     elif isinstance(token, Identifier):
         # If the previous token is an identifier, we can suggest datatypes if
         # we're in a parenthesized column/field list, e.g.:
@@ -203,8 +203,8 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
         prev_keyword, _ = find_prev_keyword(text_before_cursor)
         if prev_keyword and prev_keyword.value == '(':
             # Suggest datatypes
-            return suggest_based_on_last_token('type', text_before_cursor,
-                                           full_text, identifier)
+            return suggest_based_on_last_token(
+                'type', text_before_cursor, full_text, identifier)
         else:
             return (Keyword(),)
     else:
@@ -227,8 +227,8 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
             #        Suggest columns/functions AND keywords. (If we wanted to be
             #        really fancy, we could suggest only array-typed columns)
 
-            column_suggestions = suggest_based_on_last_token('where',
-                                    text_before_cursor, full_text, identifier)
+            column_suggestions = suggest_based_on_last_token(
+                'where', text_before_cursor, full_text, identifier)
 
             # Check for a subquery expression (cases 3 & 4)
             where = p.tokens[-1]

--- a/tests/test_parseutils.py
+++ b/tests/test_parseutils.py
@@ -4,142 +4,142 @@ from pgcli.packages.parseutils import find_prev_keyword, is_open_quote
 
 def test_empty_string():
     tables = extract_tables('')
-    assert tables == []
+    assert tables == ()
 
 def test_simple_select_single_table():
     tables = extract_tables('select * from abc')
-    assert tables == [(None, 'abc', None, False)]
+    assert tables == ((None, 'abc', None, False),)
 
 def test_simple_select_single_table_schema_qualified():
     tables = extract_tables('select * from abc.def')
-    assert tables == [('abc', 'def', None, False)]
+    assert tables == (('abc', 'def', None, False),)
 
 def test_simple_select_single_table_double_quoted():
     tables = extract_tables('select * from "Abc"')
-    assert tables == [(None, 'Abc', None, False)]
+    assert tables == ((None, 'Abc', None, False),)
 
 def test_simple_select_multiple_tables():
     tables = extract_tables('select * from abc, def')
-    assert sorted(tables) == [(None, 'abc', None, False),
-                              (None, 'def', None, False)]
+    assert set(tables) == set([(None, 'abc', None, False),
+                               (None, 'def', None, False)])
 
 def test_simple_select_multiple_tables_double_quoted():
     tables = extract_tables('select * from "Abc", "Def"')
-    assert tables == [(None, 'Abc', None, False),
-                      (None, 'Def', None, False)]
+    assert set(tables) == set([(None, 'Abc', None, False),
+                               (None, 'Def', None, False)])
 
 def test_simple_select_single_table_deouble_quoted_aliased():
     tables = extract_tables('select * from "Abc" a')
-    assert tables == [(None, 'Abc', 'a', False)]
+    assert tables == ((None, 'Abc', 'a', False),)
 
 def test_simple_select_multiple_tables_deouble_quoted_aliased():
     tables = extract_tables('select * from "Abc" a, "Def" d')
-    assert tables == [(None, 'Abc', 'a', False),
-                      (None, 'Def', 'd', False)]
+    assert set(tables) == set([(None, 'Abc', 'a', False),
+                               (None, 'Def', 'd', False)])
 
 def test_simple_select_multiple_tables_schema_qualified():
     tables = extract_tables('select * from abc.def, ghi.jkl')
-    assert sorted(tables) == [('abc', 'def', None, False),
-                              ('ghi', 'jkl', None, False)]
+    assert set(tables) == set([('abc', 'def', None, False),
+                               ('ghi', 'jkl', None, False)])
 
 def test_simple_select_with_cols_single_table():
     tables = extract_tables('select a,b from abc')
-    assert tables == [(None, 'abc', None, False)]
+    assert tables == ((None, 'abc', None, False),)
 
 def test_simple_select_with_cols_single_table_schema_qualified():
     tables = extract_tables('select a,b from abc.def')
-    assert tables == [('abc', 'def', None, False)]
+    assert tables == (('abc', 'def', None, False),)
 
 def test_simple_select_with_cols_multiple_tables():
     tables = extract_tables('select a,b from abc, def')
-    assert sorted(tables) == [(None, 'abc', None, False),
-                              (None, 'def', None, False)]
+    assert set(tables) == set([(None, 'abc', None, False),
+                               (None, 'def', None, False)])
 
 def test_simple_select_with_cols_multiple_tables():
     tables = extract_tables('select a,b from abc.def, def.ghi')
-    assert sorted(tables) == [('abc', 'def', None, False),
-                              ('def', 'ghi', None, False)]
+    assert set(tables) == set([('abc', 'def', None, False),
+                               ('def', 'ghi', None, False)])
 
 def test_select_with_hanging_comma_single_table():
     tables = extract_tables('select a, from abc')
-    assert tables == [(None, 'abc', None, False)]
+    assert tables == ((None, 'abc', None, False),)
 
 def test_select_with_hanging_comma_multiple_tables():
     tables = extract_tables('select a, from abc, def')
-    assert sorted(tables) == [(None, 'abc', None, False),
-                              (None, 'def', None, False)]
+    assert set(tables) == set([(None, 'abc', None, False),
+                               (None, 'def', None, False)])
 
 def test_select_with_hanging_period_multiple_tables():
     tables = extract_tables('SELECT t1. FROM tabl1 t1, tabl2 t2')
-    assert sorted(tables) == [(None, 'tabl1', 't1', False),
-                              (None, 'tabl2', 't2', False)]
+    assert set(tables) == set([(None, 'tabl1', 't1', False),
+                               (None, 'tabl2', 't2', False)])
 
 def test_simple_insert_single_table():
     tables = extract_tables('insert into abc (id, name) values (1, "def")')
 
     # sqlparse mistakenly assigns an alias to the table
     # AND mistakenly identifies the field list as
-    # assert tables == [(None, 'abc', None, False)]
+    # assert tables == ((None, 'abc', None, False),)
 
-    assert tables == [(None, 'abc', 'abc', False)]
+    assert tables == ((None, 'abc', 'abc', False),)
 
 @pytest.mark.xfail
 def test_simple_insert_single_table_schema_qualified():
     tables = extract_tables('insert into abc.def (id, name) values (1, "def")')
-    assert tables == [('abc', 'def', None, False)]
+    assert tables == (('abc', 'def', None, False),)
 
 def test_simple_update_table():
     tables = extract_tables('update abc set id = 1')
-    assert tables == [(None, 'abc', None, False)]
+    assert tables == ((None, 'abc', None, False),)
 
 def test_simple_update_table():
     tables = extract_tables('update abc.def set id = 1')
-    assert tables == [('abc', 'def', None, False)]
+    assert tables == (('abc', 'def', None, False),)
 
 @pytest.mark.parametrize('join_type', ['', 'INNER', 'LEFT', 'RIGHT OUTER'])
 def test_join_table(join_type):
     sql = 'SELECT * FROM abc a {0} JOIN def d ON a.id = d.num'.format(join_type)
     tables = extract_tables(sql)
-    assert sorted(tables) == [(None, 'abc', 'a', False),
-                              (None, 'def', 'd', False)]
+    assert set(tables) == set([(None, 'abc', 'a', False),
+                               (None, 'def', 'd', False)])
 
 def test_join_table_schema_qualified():
     tables = extract_tables('SELECT * FROM abc.def x JOIN ghi.jkl y ON x.id = y.num')
-    assert tables == [('abc', 'def', 'x', False),
-                      ('ghi', 'jkl', 'y', False)]
+    assert set(tables) == set([('abc', 'def', 'x', False),
+                               ('ghi', 'jkl', 'y', False)])
 
 def test_join_as_table():
     tables = extract_tables('SELECT * FROM my_table AS m WHERE m.a > 5')
-    assert tables == [(None, 'my_table', 'm', False)]
+    assert tables == ((None, 'my_table', 'm', False),)
 
 
 @pytest.mark.parametrize('arg_list', ['', 'arg1', 'arg1, arg2, arg3'])
 def test_simple_function_as_table(arg_list):
     tables = extract_tables('SELECT * FROM foo({0})'.format(arg_list))
-    assert tables == [(None, 'foo', None, True)]
+    assert tables == ((None, 'foo', None, True),)
 
 
 @pytest.mark.parametrize('arg_list', ['', 'arg1', 'arg1, arg2, arg3'])
 def test_simple_schema_qualified_function_as_table(arg_list):
     tables = extract_tables('SELECT * FROM foo.bar({0})'.format(arg_list))
-    assert tables == [('foo', 'bar', None, True)]
+    assert tables == (('foo', 'bar', None, True),)
 
 @pytest.mark.parametrize('arg_list', ['', 'arg1', 'arg1, arg2, arg3'])
 def test_simple_aliased_function_as_table(arg_list):
     tables = extract_tables('SELECT * FROM foo({0}) bar'.format(arg_list))
-    assert tables == [(None, 'foo', 'bar', True)]
+    assert tables == ((None, 'foo', 'bar', True),)
 
 
 def test_simple_table_and_function():
     tables = extract_tables('SELECT * FROM foo JOIN bar()')
-    assert tables == [(None, 'foo', None, False),
-                      (None, 'bar', None, True)]
+    assert set(tables) == set([(None, 'foo', None, False),
+                               (None, 'bar', None, True)])
 
 def test_complex_table_and_function():
     tables = extract_tables('''SELECT * FROM foo.bar baz
                                JOIN bar.qux(x, y, z) quux''')
-    assert tables == [('foo', 'bar', 'baz', False),
-                      ('bar', 'qux', 'quux', True)]
+    assert set(tables) == set([('foo', 'bar', 'baz', False),
+                               ('bar', 'qux', 'quux', True)])
 
 
 

--- a/tests/test_pgspecial.py
+++ b/tests/test_pgspecial.py
@@ -1,53 +1,68 @@
 import pytest
-from pgcli.packages.sqlcompletion import suggest_type
-from test_sqlcompletion import sorted_dicts
+from pgcli.packages.sqlcompletion import (
+    suggest_type, Special, Database, Schema, Table, View, Function, Datatype)
+
 
 def test_slash_suggests_special():
     suggestions = suggest_type('\\', '\\')
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [{'type': 'special'}])
+    assert set(suggestions) == set(
+        [Special()])
+
 
 def test_slash_d_suggests_special():
     suggestions = suggest_type('\\d', '\\d')
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [{'type': 'special'}])
+    assert set(suggestions) == set(
+        [Special()])
+
 
 def test_dn_suggests_schemata():
     suggestions = suggest_type('\\dn ', '\\dn ')
-    assert suggestions == [{'type': 'schema'}]
+    assert suggestions == (Schema(),)
 
     suggestions = suggest_type('\\dn xxx', '\\dn xxx')
-    assert suggestions == [{'type': 'schema'}]
+    assert suggestions == (Schema(),)
+
 
 def test_d_suggests_tables_views_and_schemas():
     suggestions = suggest_type('\d ', '\d ')
-    assert sorted_dicts(suggestions) == sorted_dicts([
-            {'type': 'schema'},
-            {'type': 'table', 'schema': []},
-            {'type': 'view', 'schema': []}])
+    assert set(suggestions) == set([
+        Schema(),
+        Table(schema=None),
+        View(schema=None),
+    ])
 
     suggestions = suggest_type('\d xxx', '\d xxx')
-    assert sorted_dicts(suggestions) == sorted_dicts([
-            {'type': 'schema'},
-            {'type': 'table', 'schema': []},
-            {'type': 'view', 'schema': []}])
+    assert set(suggestions) == set([
+        Schema(),
+        Table(schema=None),
+        View(schema=None),
+    ])
+
 
 def test_d_dot_suggests_schema_qualified_tables_or_views():
     suggestions = suggest_type('\d myschema.', '\d myschema.')
-    assert suggestions == [{'type': 'table', 'schema': 'myschema'},
-                           {'type': 'view', 'schema': 'myschema'}]
+    assert set(suggestions) == set([
+        Table(schema='myschema'),
+        View(schema='myschema'),
+    ])
 
     suggestions = suggest_type('\d myschema.xxx', '\d myschema.xxx')
-    assert suggestions == [{'type': 'table', 'schema': 'myschema'},
-                           {'type': 'view', 'schema': 'myschema'}]
+    assert set(suggestions) == set([
+        Table(schema='myschema'),
+        View(schema='myschema'),
+    ])
+
 
 def test_df_suggests_schema_or_function():
     suggestions = suggest_type('\\df xxx', '\\df xxx')
-    assert sorted_dicts(suggestions) == sorted_dicts([
-        {'type': 'function', 'schema': []}, {'type': 'schema'}])
+    assert set(suggestions) == set([
+        Function(schema=None),
+        Schema(),
+    ])
 
     suggestions = suggest_type('\\df myschema.xxx', '\\df myschema.xxx')
-    assert suggestions == [{'type': 'function', 'schema': 'myschema'}]
+    assert suggestions == (Function(schema='myschema'),)
+
 
 def test_leading_whitespace_ok():
     cmd = '\\dn '
@@ -59,19 +74,19 @@ def test_leading_whitespace_ok():
 def test_dT_suggests_schema_or_datatypes():
     text = '\\dT '
     suggestions = suggest_type(text, text)
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [{'type': 'schema'},
-         {'type': 'datatype', 'schema': []},
-        ])
+    assert set(suggestions) == set([
+        Schema(),
+        Datatype(schema=None),
+    ])
+
 
 def test_schema_qualified_dT_suggests_datatypes():
     text = '\\dT foo.'
     suggestions = suggest_type(text, text)
-    assert sorted_dicts(suggestions) == sorted_dicts(
-        [{'type': 'datatype', 'schema': 'foo'}])
+    assert suggestions == (Datatype(schema='foo'),)
 
 
 @pytest.mark.parametrize('command', ['\\c ', '\\connect '])
 def test_c_suggests_databases(command):
     suggestions = suggest_type(command, command)
-    assert suggestions == [{'type': 'database'}]
+    assert suggestions == (Database(),)


### PR DESCRIPTION
The main goal here is to make it easier to write regression tests using set-based logic. Before, suggest_type returned lists of dictionaries, whose values were lists. Because mutable data structures aren't hashable, it wasn't possible to create sets of suggestions, and mandated the ugly `sorted_dicts` kludge. Here, I've reworked everything to return tuples instead of lists, and namedtuples instead of dicts. For the most part, I think this leads to more readable code, although admittedly one-element tuples are a bit of an eyesore.