### PR TITLE
Add EXPLAIN keyword to the completion list.

### DIFF
--- a/pgcli/packages/pgliterals/pgliterals.json
+++ b/pgcli/packages/pgliterals/pgliterals.json
@@ -33,6 +33,7 @@
         "DESCRIBE",
         "DISTINCT",
         "DROP",
+        "EXPLAIN",
         "ELSE",
         "ENCODING",
         "ESCAPE",


### PR DESCRIPTION
Reviewer: @stuartquin 

Trivial change to add EXPLAIN keyword to the suggestions. 

This is to address issue #415. 