### PR TITLE
Handle manually entered double-quote gracefully

### DIFF
--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -46,6 +46,8 @@ def last_word(text, include='alphanum_underscore'):
     '\\\\def;'
     >>> last_word('bac::def', include='most_punctuations')
     'def'
+    >>> last_word('"foo*bar', include='most_punctuations')
+    '"foo*bar'
     """
 
     if not text:   # Empty string

--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -271,7 +271,7 @@ def parse_partial_identifier(word):
     n_tok = len(p.tokens)
     if n_tok == 1 and isinstance(p.tokens[0], Identifier):
         return p.tokens[0]
-    elif (n_tok in (2, 3)) and p.token_next_match(0, Error, '"'):
+    elif p.token_next_match(0, Error, '"'):
         # An unmatched double quote, e.g. '"foo', 'foo."', or 'foo."bar'
         # Close the double quote, then reparse
         return parse_partial_identifier(word + '"')

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -4,7 +4,8 @@ import re
 import sqlparse
 from collections import namedtuple
 from sqlparse.sql import Comparison, Identifier, Where
-from .parseutils import last_word, extract_tables, find_prev_keyword
+from .parseutils import (
+    last_word, extract_tables, find_prev_keyword, parse_partial_identifier)
 from pgspecial.main import parse_special_command
 
 PY2 = sys.version_info[0] == 2
@@ -68,24 +69,13 @@ def suggest_type(full_text, text_before_cursor):
     # partially typed string which renders the smart completion useless because
     # it will always return the list of keywords as completion.
     if word_before_cursor:
-
         if word_before_cursor[-1] == '(' or word_before_cursor[0] == '\\':
             parsed = sqlparse.parse(text_before_cursor)
         else:
             parsed = sqlparse.parse(
                 text_before_cursor[:-len(word_before_cursor)])
 
-            if word_before_cursor[0] == '"':
-                # Assume user is manually escaping an identifier
-                word_before_cursor = word_before_cursor[1:]
-
-            # word_before_cursor may include a schema qualification, like
-            # "schema_name.partial_name" or "schema_name.", so parse it
-            # separately
-            if word_before_cursor:
-                p = sqlparse.parse(word_before_cursor)[0]
-                if p.tokens and isinstance(p.tokens[0], Identifier):
-                    identifier = p.tokens[0]
+            identifier = parse_partial_identifier(word_before_cursor)
     else:
         parsed = sqlparse.parse(text_before_cursor)
 
@@ -367,3 +357,4 @@ def identifies(id, ref):
 
     return id == ref.alias or id == ref.name or (
         ref.schema and (id == ref.schema + '.' + ref.name))
+

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -68,18 +68,24 @@ def suggest_type(full_text, text_before_cursor):
     # partially typed string which renders the smart completion useless because
     # it will always return the list of keywords as completion.
     if word_before_cursor:
+
         if word_before_cursor[-1] == '(' or word_before_cursor[0] == '\\':
             parsed = sqlparse.parse(text_before_cursor)
         else:
             parsed = sqlparse.parse(
-                    text_before_cursor[:-len(word_before_cursor)])
+                text_before_cursor[:-len(word_before_cursor)])
+
+            if word_before_cursor[0] == '"':
+                # Assume user is manually escaping an identifier
+                word_before_cursor = word_before_cursor[1:]
 
             # word_before_cursor may include a schema qualification, like
             # "schema_name.partial_name" or "schema_name.", so parse it
             # separately
-            p = sqlparse.parse(word_before_cursor)[0]
-            if p.tokens and isinstance(p.tokens[0], Identifier):
-                identifier = p.tokens[0]
+            if word_before_cursor:
+                p = sqlparse.parse(word_before_cursor)[0]
+                if p.tokens and isinstance(p.tokens[0], Identifier):
+                    identifier = p.tokens[0]
     else:
         parsed = sqlparse.parse(text_before_cursor)
 

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -197,6 +197,14 @@ class PGCompleter(Completer):
         """
 
         text = last_word(text, include='most_punctuations').lower()
+        text_len = len(text)
+
+        if text and text[0] == '"':
+            # text starts with double quote; user is manually escaping a name
+            # Match on everything that follows the double-quote. Note that
+            # text_len is calculated before removing the quote, so the
+            # Completion.position value is correct
+            text = text[1:]
 
         if mode == 'fuzzy':
             fuzzy = True
@@ -246,13 +254,14 @@ class PGCompleter(Completer):
                     meta = meta[:47] + u'...'
 
                 matches.append(Match(
-                    completion=Completion(item, -len(text), display_meta=meta),
+                    completion=Completion(item, -text_len, display_meta=meta),
                     priority=(sort_key, priority_func(item))))
 
         return matches
 
     def get_completions(self, document, complete_event, smart_completion=None):
         word_before_cursor = document.get_word_before_cursor(WORD=True)
+
         if smart_completion is None:
             smart_completion = self.smart_completion
 

--- a/tests/test_parseutils.py
+++ b/tests/test_parseutils.py
@@ -10,9 +10,17 @@ def test_simple_select_single_table():
     tables = extract_tables('select * from abc')
     assert tables == ((None, 'abc', None, False),)
 
-def test_simple_select_single_table_schema_qualified():
-    tables = extract_tables('select * from abc.def')
+
+@pytest.mark.parametrize('sql', [
+    'select * from abc.def',
+    'select * from "abc".def',
+    'select * from "abc"."def"',
+    'select * from abc."def"',
+])
+def test_simple_select_single_table_schema_qualified(sql):
+    tables = extract_tables(sql)
     assert tables == (('abc', 'def', None, False),)
+
 
 def test_simple_select_single_table_double_quoted():
     tables = extract_tables('select * from "Abc"')

--- a/tests/test_parseutils.py
+++ b/tests/test_parseutils.py
@@ -55,7 +55,7 @@ def test_simple_select_with_cols_multiple_tables():
     assert set(tables) == set([(None, 'abc', None, False),
                                (None, 'def', None, False)])
 
-def test_simple_select_with_cols_multiple_tables():
+def test_simple_select_with_cols_multiple_qualified_tables():
     tables = extract_tables('select a,b from abc.def, def.ghi')
     assert set(tables) == set([('abc', 'def', None, False),
                                ('def', 'ghi', None, False)])

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -81,14 +81,18 @@ def test_schema_or_visible_table_completion(completer, complete_event):
        Completion(text='"select"', start_position=0, display_meta='table'),
        Completion(text='orders', start_position=0, display_meta='table')])
 
-def test_suggested_column_names_from_shadowed_visible_table(completer, complete_event):
+
+@pytest.mark.parametrize('text', [
+    'SELECT  FROM users',
+    'SELECT  FROM "users"',
+    ])
+def test_suggested_column_names_from_shadowed_visible_table(completer, complete_event, text):
     """
     Suggest column and function names when selecting from table
     :param completer:
     :param complete_event:
     :return:
     """
-    text = 'SELECT  from users'
     position = len('SELECT ')
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
@@ -163,17 +167,31 @@ def test_suggested_column_names_in_function(completer, complete_event):
         Completion(text='product_name', start_position=0, display_meta='column'),
         Completion(text='price', start_position=0, display_meta='column')])
 
-def test_suggested_table_names_with_schema_dot(completer, complete_event):
-    text = 'SELECT * FROM custom.'
+
+@pytest.mark.parametrize('text', [
+    'SELECT * FROM custom.',
+    'SELECT * FROM "custom".',
+])
+@pytest.mark.parametrize('use_leading_double_quote', [False, True])
+def test_suggested_table_names_with_schema_dot(completer, complete_event,
+                                               text, use_leading_double_quote):
+    if use_leading_double_quote:
+        text += '"'
+        start_pos = -1
+    else:
+        start_pos = 0
+
     position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([
-        Completion(text='users', start_position=0, display_meta='table'),
-        Completion(text='products', start_position=0, display_meta='table'),
-        Completion(text='shipments', start_position=0, display_meta='table'),
-        Completion(text='set_returning_func', start_position=0, display_meta='function'),
+        Completion(text='users', start_position=start_pos, display_meta='table'),
+        Completion(text='products', start_position=start_pos, display_meta='table'),
+        Completion(text='shipments', start_position=start_pos, display_meta='table'),
+        Completion(text='set_returning_func', start_position=start_pos, display_meta='function'),
     ])
+
+
 def test_suggested_column_names_with_qualified_alias(completer, complete_event):
     """
     Suggest column names on table alias and dot

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -386,6 +386,17 @@ def test_auto_escaped_col_names(completer, complete_event):
         )
 
 
+def test_allow_leading_double_quote_in_last_word(completer, complete_event):
+    text = 'SELECT * from "sele'
+    position = len(text)
+    result = completer.get_completions(
+        Document(text=text, cursor_position=position), complete_event)
+
+    expected = Completion(text='"select"', start_position=-5, display_meta='table')
+
+    assert expected in set(result)
+
+
 @pytest.mark.parametrize('text', [
     'SELECT 1::',
     'CREATE TABLE foo (bar ',

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -24,6 +24,7 @@ def test_select_suggests_cols_with_qualified_table_scope():
 
 @pytest.mark.parametrize('expression', [
     'SELECT * FROM tabl WHERE ',
+    'SELECT * FROM "tabl" WHERE ',
     'SELECT * FROM tabl WHERE (',
     'SELECT * FROM tabl WHERE foo = ',
     'SELECT * FROM tabl WHERE bar OR ',
@@ -126,6 +127,10 @@ def test_suggest_qualified_tables_and_views(expression):
 
 @pytest.mark.parametrize('expression', [
     'SELECT * FROM sch.',
+    'SELECT * FROM sch."',
+    'SELECT * FROM sch."foo',
+    'SELECT * FROM "sch".',
+    'SELECT * FROM "sch"."',
     'SELECT * FROM foo JOIN sch.',
 ])
 def test_suggest_qualified_tables_views_and_set_returning_functions(expression):

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -650,3 +650,13 @@ def test_select_suggests_fields_from_function():
             Function(schema=None),
             Keyword()
             ])
+
+
+@pytest.mark.parametrize('sql', [
+    'select * from "',
+    'select * from "foo',
+])
+def test_ignore_leading_double_quotes(sql):
+    suggestions = suggest_type(sql, sql)
+    assert Table(schema=None) in set(suggestions)
+


### PR DESCRIPTION
Surprisingly, manually entering a double quote, as in `SELECT * FROM "` breaks suggestions. This just allows the suggestion system to ignore it.