### PR TITLE
Added humanized time display. Connect #396.

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -341,8 +341,12 @@ class PGCli(object):
                         pass
 
                     if self.pgspecial.timing_enabled:
-                        print('Time: %0.03fs (%s)' % (query.total_time,
-                              humanize.time.naturaldelta(query.total_time)))
+                        # Only add humanized time display if > 1 second
+                        if query.total_time > 1:
+                            print('Time: %0.03fs (%s)' % (query.total_time,
+                                  humanize.time.naturaldelta(query.total_time)))
+                        else:
+                            print('Time: %0.03fs' % query.total_time)
 
                     # Check if we need to update completions, in order of most
                     # to least drastic changes

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -10,6 +10,7 @@ import logging
 import threading
 import shutil
 import functools
+import humanize
 from time import time
 from codecs import open
 
@@ -340,7 +341,8 @@ class PGCli(object):
                         pass
 
                     if self.pgspecial.timing_enabled:
-                        print('Time: %0.03fs' % query.total_time)
+                        print('Time: %0.03fs (%s)' % (query.total_time,
+                              humanize.time.naturaldelta(query.total_time)))
 
                     # Check if we need to update completions, in order of most
                     # to least drastic changes

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ install_requirements = [
             'psycopg2 >= 2.5.4',
             'sqlparse == 0.1.16',
             'configobj >= 5.0.6',
+            'humanize >= 0.5.1',
             ]
 
 


### PR DESCRIPTION
This is a small change to add humanized time display in parentheses.

Examples:

```
Time: 0.006s (a moment)
Time: 10.005s (10 seconds)
Time: 120.011s (2 minutes)
```