### PR TITLE
Fix suggestions in multi-way joins

### DIFF
--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -103,12 +103,14 @@ def extract_from_part(parsed, stop_at_punctuation=True):
             elif item.ttype is Keyword and (
                     not item.value.upper() == 'FROM') and (
                     not item.value.upper().endswith('JOIN')):
-                raise StopIteration
+                tbl_prefix_seen = False
             else:
                 yield item
-        elif ((item.ttype is Keyword or item.ttype is Keyword.DML) and
-                item.value.upper() in ('COPY', 'FROM', 'INTO', 'UPDATE', 'TABLE', 'JOIN',)):
-            tbl_prefix_seen = True
+        elif item.ttype is Keyword or item.ttype is Keyword.DML:
+            item_val = item.value.upper()
+            if (item_val in ('COPY', 'FROM', 'INTO', 'UPDATE', 'TABLE') or
+                    item_val.endswith('JOIN')):
+                tbl_prefix_seen = True
         # 'SELECT a, FROM abc' will detect FROM as part of the column list.
         # So this check here is necessary.
         elif isinstance(item, IdentifierList):

--- a/tests/test_parseutils.py
+++ b/tests/test_parseutils.py
@@ -116,9 +116,38 @@ def test_join_table_schema_qualified():
     assert set(tables) == set([('abc', 'def', 'x', False),
                                ('ghi', 'jkl', 'y', False)])
 
+
+def test_incomplete_join_clause():
+    sql = '''select a.x, b.y
+             from abc a join bcd b
+             on a.id = '''
+    tables = extract_tables(sql)
+    assert tables == ((None, 'abc', 'a', False),
+                      (None, 'bcd', 'b', False))
+
+
 def test_join_as_table():
     tables = extract_tables('SELECT * FROM my_table AS m WHERE m.a > 5')
     assert tables == ((None, 'my_table', 'm', False),)
+
+
+def test_multiple_joins():
+    sql = '''select * from t1
+            inner join t2 ON
+              t1.id = t2.t1_id
+            inner join t3 ON
+              t2.id = t3.'''
+    tables = extract_tables(sql)
+    assert tables == (
+        (None, 't1', None, False),
+        (None, 't2', None, False),
+        (None, 't3', None, False))
+
+
+def test_subselect_tables():
+    sql = 'SELECT * FROM (SELECT  FROM abc'
+    tables = extract_tables(sql)
+    assert tables == ((None, 'abc', None, False),)
 
 
 @pytest.mark.parametrize('arg_list', ['', 'arg1', 'arg1, arg2, arg3'])

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -292,6 +292,18 @@ def test_suggested_multiple_column_names_with_dot(completer, complete_event):
         Completion(text='first_name', start_position=0, display_meta='column'),
         Completion(text='last_name', start_position=0, display_meta='column')])
 
+
+def test_suggest_columns_after_three_way_join(completer, complete_event):
+    text = '''SELECT * FROM users u1
+              INNER JOIN users u2 ON u1.id = u2.id
+              INNER JOIN users u3 ON u2.id = u3.'''
+    position = len(text)
+    result = completer.get_completions(
+        Document(text=text, cursor_position=position), complete_event)
+    assert (Completion(text='id', start_position=0, display_meta='column') in
+            set(result))
+
+
 def test_suggested_aliases_after_on(completer, complete_event):
     text = 'SELECT u.name, o.id FROM users u JOIN orders o ON '
     position = len('SELECT u.name, o.id FROM users u JOIN orders o ON ')

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -443,6 +443,16 @@ def test_join_using_suggests_common_columns(col_list):
     ])
 
 
+def test_suggest_columns_after_multiple_joins():
+    sql = '''select * from t1
+            inner join t2 ON
+              t1.id = t2.t1_id
+            inner join t3 ON
+              t2.id = t3.'''
+    suggestions = suggest_type(sql, sql)
+    assert Column(tables=((None, 't3', None, False),)) in set(suggestions)
+
+    
 def test_2_statements_2nd_current():
     suggestions = suggest_type('select * from a; select * from ',
                                'select * from a; select * from ')


### PR DESCRIPTION
`extract_tables` was stopping as soon as it hit the `ON` keyword in the first join clause

Thanks to @jamiely for reporting this issue