### PR TITLE
Really sort keywords after everything else

### DIFF
--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -232,9 +232,9 @@ class PGCompleter(Completer):
             def _match(item):
                 match_point = item.lower().find(text, 0, match_end_limit)
                 if match_point >= 0:
-                    # Use negative infinity in second element to force keywords
-                    # to sort after all fuzzy matches
-                    return -match_point, -float('Infinity')
+                    # Use negative infinity to force keywords to sort after all
+                    # fuzzy matches
+                    return -float('Infinity'), -match_point
 
         if meta_collection:
             # Each possible completion in the collection has a corresponding

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -525,3 +525,16 @@ def test_learn_table_names(completer, complete_event):
     orders = Completion(text='orders', start_position=0, display_meta='table')
 
     assert completions.index(users) < completions.index(orders)
+
+
+def test_columns_before_keywords(completer, complete_event):
+    sql = 'SELECT * FROM orders WHERE s'
+    completions = completer.get_completions(
+        Document(text=sql, cursor_position=len(sql)), complete_event)
+
+    column = Completion(text='status', start_position=-1, display_meta='column')
+    keyword = Completion(text='SELECT', start_position=-1, display_meta='keyword')
+
+    assert completions.index(column) < completions.index(keyword)
+
+


### PR DESCRIPTION
As @amjith pointed out in #379 keywords don't sort properly after starting to type an identifier