### PR TITLE
Register a unicode typecaster for record type.

### DIFF
--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -16,6 +16,9 @@ _logger = logging.getLogger(__name__)
 ext.register_type(ext.UNICODE)
 ext.register_type(ext.UNICODEARRAY)
 ext.register_type(ext.new_type((705,), "UNKNOWN", ext.UNICODE))
+# See https://github.com/dbcli/pgcli/issues/426 for more details.
+# This registers a unicode type caster for datatype 'RECORD'.
+ext.register_type(ext.new_type((2249,), "RECORD", ext.UNICODE))
 
 # Cast bytea fields to text. By default, this will render as hex strings with
 # Postgres 9+ and as escaped binary in earlier versions.


### PR DESCRIPTION
This is to address #426. 

Reviewer: @stuartquin 

There are many datatypes in Postgres and we have to register each datatype to be treated as unicode. This PR registers the `record` datatype to be treated as unicode. I wonder what other datatypes have to be explicitly registered. 