### PR TITLE
Add fallback queries so that redshift auto-complete indexing doesn't exception out

### DIFF
--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -109,50 +109,10 @@ class PGExecute(object):
                 AND att.attnum  > 0
         ORDER BY 1, 2, 3'''
 
-    functions_query = '''
-        SELECT n.nspname schema_name,
-                p.proname func_name,
-                pg_catalog.pg_get_function_arguments(p.oid) arg_list,
-                pg_catalog.pg_get_function_result(p.oid) return_type,
-                p.proisagg is_aggregate,
-                p.proiswindow is_window,
-                p.proretset is_set_returning
-        FROM pg_catalog.pg_proc p
-                INNER JOIN pg_catalog.pg_namespace n
-                    ON n.oid = p.pronamespace
-        ORDER BY 1, 2'''
-
-
-    databases_query = """SELECT d.datname as "Name",
-       pg_catalog.pg_get_userbyid(d.datdba) as "Owner",
-       pg_catalog.pg_encoding_to_char(d.encoding) as "Encoding",
-       d.datcollate as "Collate",
-       d.datctype as "Ctype",
-       pg_catalog.array_to_string(d.datacl, E'\n') AS "Access privileges"
-    FROM pg_catalog.pg_database d
-    ORDER BY 1;"""
-
-    datatypes_query = '''
-        SELECT n.nspname schema_name,
-               t.typname type_name
-        FROM   pg_catalog.pg_type t
-               INNER JOIN pg_catalog.pg_namespace n
-                  ON n.oid = t.typnamespace
-        WHERE ( t.typrelid = 0  -- non-composite types
-                OR (  -- composite type, but not a table
-                      SELECT c.relkind = 'c'
-                      FROM pg_catalog.pg_class c
-                      WHERE c.oid = t.typrelid
-                    )
-              )
-              AND NOT EXISTS( -- ignore array types
-                    SELECT  1
-                    FROM    pg_catalog.pg_type el
-                    WHERE   el.oid = t.typelem AND el.typarray = t.oid
-                  )
-              AND n.nspname <> 'pg_catalog'
-              AND n.nspname <> 'information_schema'
-        ORDER BY 1, 2;'''
+    databases_query = '''
+        SELECT d.datname
+        FROM pg_catalog.pg_database d
+        ORDER BY 1'''
 
     def __init__(self, database, user, password, host, port, dsn):
         self.dbname = database
@@ -384,53 +344,53 @@ class PGExecute(object):
             yield row
 
     def databases(self):
-        try:
-            with self.conn.cursor() as cur:
-                _logger.debug('Databases Query. sql: %r', self.databases_query)
-                cur.execute(self.databases_query)
-                return [x[0] for x in cur.fetchall()]
-        except psycopg2.ProgrammingError:
-            fallback = '''
-                SELECT d.datname as "Name"
-                FROM pg_catalog.pg_database d
-                ORDER BY 1
-            '''
-            with self.conn.cursor() as cur:
-                _logger.debug('Databases Query. sql: %r', fallback)
-                cur.execute(fallback)
-                return [x[0] for x in cur.fetchall()]
-
+        with self.conn.cursor() as cur:
+            _logger.debug('Databases Query. sql: %r', self.databases_query)
+            cur.execute(self.databases_query)
+            return [x[0] for x in cur.fetchall()]
 
     def functions(self):
         """Yields FunctionMetadata named tuples"""
 
-        try:
-            with self.conn.cursor() as cur:
-                _logger.debug('Functions Query. sql: %r', self.functions_query)
-                cur.execute(self.functions_query)
+        with self.conn.cursor() as cur:
+            if self.conn.server_version > 90000:
+                query = '''
+                    SELECT n.nspname schema_name,
+                            p.proname func_name,
+                            pg_catalog.pg_get_function_arguments(p.oid) arg_list,
+                            pg_catalog.pg_get_function_result(p.oid) return_type,
+                            p.proisagg is_aggregate,
+                            p.proiswindow is_window,
+                            p.proretset is_set_returning
+                    FROM pg_catalog.pg_proc p
+                            INNER JOIN pg_catalog.pg_namespace n
+                                ON n.oid = p.pronamespace
+                    ORDER BY 1, 2
+                    '''
+                _logger.debug('Functions Query. sql: %r', query)
+                cur.execute(query)
                 for row in cur:
                     yield FunctionMetadata(*row)
-        except psycopg2.ProgrammingError:
-            fallback = '''
-                SELECT n.nspname schema_name,
-                        p.proname func_name,
-                        p.proargnames,
-                        oidvectortypes(p.proargtypes) proargtypes,
-                        t.typname return_type,
-                        p.proisagg is_aggregate,
-                        false is_window,
-                        p.proretset is_set_returning
-                FROM pg_catalog.pg_proc p
-                INNER JOIN pg_catalog.pg_namespace n
-                ON n.oid = p.pronamespace
-                INNER JOIN pg_catalog.pg_type t
-                ON p.prorettype = t.oid
-                ORDER BY 1, 2'''
-            with self.conn.cursor() as cur:
-                _logger.debug('Functions Query. sql: %r', fallback)
-                cur.execute(fallback)
+            else:
+                query = '''
+                    SELECT n.nspname schema_name,
+                            p.proname func_name,
+                            p.proargnames,
+                            oidvectortypes(p.proargtypes) proargtypes,
+                            t.typname return_type,
+                            p.proisagg is_aggregate,
+                            false is_window,
+                            p.proretset is_set_returning
+                    FROM pg_catalog.pg_proc p
+                    INNER JOIN pg_catalog.pg_namespace n
+                    ON n.oid = p.pronamespace
+                    INNER JOIN pg_catalog.pg_type t
+                    ON p.prorettype = t.oid
+                    ORDER BY 1, 2
+                    '''
+                _logger.debug('Functions Query. sql: %r', query)
+                cur.execute(query)
                 for row in cur:
-                    _logger.debug(pprint.pformat(row))
                     names = row[2] if row[2] is not None else []
                     args = itertools.izip_longest(names, row[3].split(', '), '')
                     _logger.debug(list(args))
@@ -439,33 +399,48 @@ class PGExecute(object):
                     _logger.debug(arg_list)
                     yield FunctionMetadata(row[0], row[1], arg_list, row[4], row[5], row[6], row[7])
 
-
-
     def datatypes(self):
         """Yields tuples of (schema_name, type_name)"""
-        try:
-            with self.conn.cursor() as cur:
-                _logger.debug('Datatypes Query. sql: %r', self.datatypes_query)
-                cur.execute(self.datatypes_query)
-                for row in cur:
-                    yield row
-        except psycopg2.ProgrammingError:
-            fallback = '''
-                SELECT n.nspname AS "schema",
-                  pg_catalog.format_type(t.oid, NULL) AS "name",
-                  pg_catalog.obj_description(t.oid, 'pg_type') AS "description"
-                FROM pg_catalog.pg_type t
-                     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-                WHERE (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid))
-                  AND t.typname !~ '^_'
-                      AND n.nspname <> 'pg_catalog'
-                      AND n.nspname <> 'information_schema'
-                  AND pg_catalog.pg_type_is_visible(t.oid)
-                ORDER BY 1, 2;
-            '''
-            with self.conn.cursor() as cur:
-                _logger.debug('Datatypes Query. sql: %r', fallback)
-                cur.execute(fallback)
-                for row in cur:
-                    yield row
+
+        with self.conn.cursor() as cur:
+            if self.conn.server_version > 90000:
+                query = '''
+                    SELECT n.nspname schema_name,
+                           t.typname type_name
+                    FROM   pg_catalog.pg_type t
+                           INNER JOIN pg_catalog.pg_namespace n
+                              ON n.oid = t.typnamespace
+                    WHERE ( t.typrelid = 0  -- non-composite types
+                            OR (  -- composite type, but not a table
+                                  SELECT c.relkind = 'c'
+                                  FROM pg_catalog.pg_class c
+                                  WHERE c.oid = t.typrelid
+                                )
+                          )
+                          AND NOT EXISTS( -- ignore array types
+                                SELECT  1
+                                FROM    pg_catalog.pg_type el
+                                WHERE   el.oid = t.typelem AND el.typarray = t.oid
+                              )
+                          AND n.nspname <> 'pg_catalog'
+                          AND n.nspname <> 'information_schema'
+                    ORDER BY 1, 2;
+                    '''
+            else:
+                query = '''
+                    SELECT n.nspname schema_name,
+                      pg_catalog.format_type(t.oid, NULL) type_name
+                    FROM pg_catalog.pg_type t
+                         LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+                    WHERE (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid))
+                      AND t.typname !~ '^_'
+                          AND n.nspname <> 'pg_catalog'
+                          AND n.nspname <> 'information_schema'
+                      AND pg_catalog.pg_type_is_visible(t.oid)
+                    ORDER BY 1, 2;
+                '''
+            _logger.debug('Datatypes Query. sql: %r', query)
+            cur.execute(query)
+            for row in cur:
+                yield row
 


### PR DESCRIPTION
I have added fallback queries that allow the auto-completion indexing to not exception out with the current version of Amazon Redshift. Only tested to a "works for me" state.  