### PR TITLE
Display null values as <null> in expanded output.

### DIFF
--- a/pgcli/packages/expanded.py
+++ b/pgcli/packages/expanded.py
@@ -19,6 +19,7 @@ def expanded_table(rows, headers):
             max_row_len = row_len
 
         for header, value in zip(padded_headers, row):
+            value = '<null>' if value is None else value
             row_result.append((u"%s" % header) + " " + (u"%s" % value).strip())
 
         results.append('\n'.join(row_result))


### PR DESCRIPTION
Reviewer: @stuartquin 

We display the `null` values as `<null>` in the tabular output, this PR makes pgcli do the same for expanded output as well. 

Addresses https://github.com/dbcli/pgcli/issues/450