### PR TITLE
Issue #448 extension for BC dates

### DIFF
--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -205,6 +205,13 @@ def test_jsonb_renders_without_u_prefix(executor, expanded):
 
     assert u'{"name": "Éowyn"}' in result
 
+@dbtest
+def test_bc_dates(executor):
+    run(executor, "create table bc_date_test(d DATE)")
+    run(executor, "insert into bc_date_test(d) values ('0001-01-01 00:00:00 BC')")
+
+    result = run(executor, "SELECT d FROM bc_date_test LIMIT 1", join=True)
+    assert result.split("\n")[3] == "| 0001-01-01 BC |"
 
 @dbtest
 @pytest.mark.parametrize('value', ['10000000', '10000000.0', '10000000000000'])


### PR DESCRIPTION
Addresses BC date issue by typecasting all `DATE` and `TIMESTAMP` results to string.
