### PR TITLE
Use lexical order to break ties when fuzzy matching

### DIFF
--- a/tests/test_fuzzy_completion.py
+++ b/tests/test_fuzzy_completion.py
@@ -49,3 +49,28 @@ def test_ranking_based_on_shortest_match(completer):
     matches = completer.find_matches(text, collection)
 
     assert matches[1].priority > matches[0].priority
+
+
+@pytest.mark.parametrize('collection', [
+    ['user_action', 'user'],
+    ['user_group', 'user'],
+    ['user_group', 'user_action'],
+])
+def test_should_break_ties_using_lexical_order(completer, collection):
+    """Fuzzy result rank should use lexical order to break ties.
+
+    When fuzzy matching, if multiple matches have the same match length and
+    start position, present them in lexical (rather than arbitrary) order. For
+    example, if we have tables 'user', 'user_action', and 'user_group', a
+    search for the text 'user' should present these tables in this order.
+
+    The input collections to this test are out of order; each run checks that
+    the search text 'user' results in the input tables being reordered
+    lexically.
+
+    """
+
+    text = 'user'
+    matches = completer.find_matches(text, collection)
+
+    assert matches[1].priority > matches[0].priority


### PR DESCRIPTION
Suppose we have a bunch of tables start with the name `user`, e.g. `user`, `user_group`, `user_action`, `user_address`, etc. When searching for the text `user`, where the match group length and position are identical for all of these items, the current master of pgcli produces completion results in arbitrary order:

![pgcli arbitrary order](https://cloud.githubusercontent.com/assets/1424858/13040041/fd36c3e2-d374-11e5-80d3-97317206df27.png)

This PR adds a new priority fallback — after the fuzzy match group length, position, and history priority — such that, if the existing ranking fails to produce a total ordering, lexical order is used to break the ties. Here is the previous example with this change in place:

![pgcli lexical order](https://cloud.githubusercontent.com/assets/1424858/13040087/9b2e6050-d375-11e5-9930-c1bc6addfbd8.png)
