### PR TITLE
Upgrade to prompt_toolkit 0.59.

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -410,6 +410,9 @@ class PGCli(object):
         def prompt_tokens(_):
             return [(Token.Prompt, '%s> ' % self.pgexecute.dbname)]
 
+        def get_continuation_tokens(cli, width):
+            return [(Token.Continuation, '.' * (width - 1) + ' ')]
+
         get_toolbar_tokens = create_toolbar_tokens_func(
             lambda: self.vi_mode, self.completion_refresher.is_refreshing)
 
@@ -417,6 +420,7 @@ class PGCli(object):
             lexer=PygmentsLexer(PostgresLexer),
             reserve_space_for_menu=4,
             get_prompt_tokens=prompt_tokens,
+            get_continuation_tokens=get_continuation_tokens,
             get_bottom_toolbar_tokens=get_toolbar_tokens,
             display_completions_in_columns=self.wider_completion_menu,
             multiline=True,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requirements = [
             'pgspecial>=1.1.0',
             'click >= 4.1',
             'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
-            'prompt_toolkit==0.57',
+            'prompt_toolkit==0.59',
             'psycopg2 >= 2.5.4',
             'sqlparse == 0.1.16',
             'configobj >= 5.0.6',


### PR DESCRIPTION

Changes (see 0.58 and 0.59.):
https://github.com/jonathanslenders/python-prompt-toolkit/blob/master/CHANGELOG

I also added a simple example of the continuation prompt. This shows dots in front of every next line, when the input is multiline. Feel free to change this.