### PR TITLE
Upgrade sqlparse requirement to version 0.1.19

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requirements = [
             'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
             'prompt_toolkit==0.57',
             'psycopg2 >= 2.5.4',
-            'sqlparse == 0.1.16',
+            'sqlparse == 0.1.19',
             'configobj >= 5.0.6',
             'humanize >= 0.5.1',
             'wcwidth >= 0.1.6',


### PR DESCRIPTION
`pgcli` seems to work fine after `sqlparse` version bump.

Found three failing tests, but are the same which fail with previous `sqlparse` version, so I think it's ok:

```
Failing scenarios:
  features/iocommands.feature:3  edit sql in file with external editor

4 features passed, 1 failed, 0 skipped
7 scenarios passed, 1 failed, 0 skipped
57 steps passed, 1 failed, 3 skipped, 0 undefined
```

It seems all are related to editing commands in an external file:

- red: And we start external editor providing a file name
- blue: And we type sql in the editor                      # None
- blue: And we exit the editor                             # None
- blue: Then we see the sql in prompt                      # None
