### PR TITLE
Fix lexical order tiebreaking

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -12,19 +12,19 @@ the changes and create the commits in your local machine. Then push those
 changes to your fork. Then click on the pull request icon on github and create
 a new pull request. Add a description about the change and send it along. I
 promise to review the pull request in a reasonable window of time and get back
-to you. 
+to you.
 
 In order to keep your fork up to date with any changes from mainline, add a new
 git remote to your local copy called 'upstream' and point it to the main pgcli
 repo.
 
-:: 
+::
 
    $ git remote add upstream git@github.com:dbcli/pgcli.git
 
 Once the 'upstream' end point is added you can then periodically do a ``git
 pull upstream master`` to update your local copy and then do a ``git push
-origin master`` to keep your own fork up to date. 
+origin master`` to keep your own fork up to date.
 
 Local Setup
 -----------
@@ -60,7 +60,7 @@ working folder into the virtualenv. By installing it using `pip install -e`
 we've linked the pgcli installation with the working copy. So any changes made
 to the code is immediately available in the installed version of pgcli. This
 makes it easy to change something in the code, launch pgcli and check the
-effects of your change. 
+effects of your change.
 
 Adding PostgreSQL Special (Meta) Commands
 -----------------------------------------
@@ -90,7 +90,7 @@ Building RPM and DEB packages
 
 You will need Vagrant 1.7.2 or higher. In the project root there is a
 Vagrantfile that is setup to do multi-vm provisioning. If you're setting things
-up for the first time, then do: 
+up for the first time, then do:
 
 ::
 
@@ -98,21 +98,21 @@ up for the first time, then do:
     $ version=x.y.z vagrant up centos
 
 If you already have those VMs setup and you're merely creating a new version of
-DEB or RPM package, then you can do: 
+DEB or RPM package, then you can do:
 
 ::
 
     $ version=x.y.z vagrant provision
 
-That will create a .deb file and a .rpm file. 
+That will create a .deb file and a .rpm file.
 
 The deb package can be installed as follows:
 
 ::
 
     $ sudo dpkg -i pgcli*.deb   # if dependencies are available.
-    
-    or 
+
+    or
 
     $ sudo apt-get install -f pgcli*.deb  # if dependencies are not available.
 
@@ -131,7 +131,7 @@ Configuration settings for this package are provided via ``behave.ini`` file
 in root directory.
 
 The database user (``pg_test_user = postgres`` in .ini file) has to have
-permissions to create and drop test database. Dafault user is ``postgres``
+permissions to create and drop test database. Default user is ``postgres``
 at ``localhost``, without the password (authentication mode trust).
 
 First, install the requirements for testing:

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -257,8 +257,10 @@ class PGCompleter(Completer):
                 # tiebreaking items with the same match group length and start
                 # position. Since we use *higher* priority to mean "more
                 # important," we use -ord(c) to prioritize "aa" > "ab" and end
-                # with 1 to prioritize shorter strings (ie "user" > "users")
-                lexical_priority = tuple(-ord(c) for c in item) + (1,)
+                # with 1 to prioritize shorter strings (ie "user" > "users").
+                # We also use the unescape_name to make sure quoted names have
+                # the same priority as unquoted names.
+                lexical_priority = tuple(-ord(c) for c in self.unescape_name(item)) + (1,)
 
                 priority = sort_key, priority_func(item), lexical_priority
 

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -385,7 +385,14 @@ def test_table_names_after_from_are_lexical_ordered_by_text(completer, complete_
     result = completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event)
-    assert result == sorted(result, key=lambda c: c.text)
+    assert [c.text for c in result] == [
+        'orders',
+        'public',
+        '"select"',
+        'set_returning_func',
+        'user_emails',
+        'users'
+        ]
 
 def test_auto_escaped_col_names(completer, complete_event):
     text = 'SELECT  from "select"'

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -379,6 +379,14 @@ def test_table_names_after_from(completer, complete_event):
         Completion(text='set_returning_func', start_position=0, display_meta='function')
         ])
 
+def test_table_names_after_from_are_lexical_ordered_by_text(completer, complete_event):
+    text = 'SELECT * FROM '
+    position = len('SELECT * FROM ')
+    result = completer.get_completions(
+        Document(text=text, cursor_position=position),
+        complete_event)
+    assert result == sorted(result, key=lambda c: c.text)
+
 def test_auto_escaped_col_names(completer, complete_event):
     text = 'SELECT  from "select"'
     position = len('SELECT ')
@@ -498,8 +506,8 @@ def test_join_functions_on_suggests_columns(completer, complete_event):
     assert set(result) == set([
          Completion(text='x', start_position=0, display_meta='column'),
          Completion(text='y', start_position=0, display_meta='column')])
-    
-    
+
+
 def test_learn_keywords(completer, complete_event):
     sql = 'CREATE VIEW v AS SELECT 1'
     completer.extend_query_history(sql)


### PR DESCRIPTION
Fix for #475.

The lexical priority was originally implemented as the `-index` of a match text within the lexically sorted collection in `find_matches`.
The problem is when `get_completions` combines results from multiple `find_matches` calls.
As the `-index` is the priority only within the scope of a single `find_matches` call, we end up with jumbling (especially in the case `SELECT * FROM `) because `get_completions` has only the lexical priority to do tie breaking, so it orders the completions as the first elem from all the get_X_matches, second elem from all get_X_matches, etc.

The new lexical_priority is properly comparable when we're combining multiple `find_matches` calls.
I've also added a test for making sure the `SELECT * FROM ` results are ordered.

It looks like this for me:
![image](https://cloud.githubusercontent.com/assets/384556/13896691/eaa6af1a-ed52-11e5-9012-b2ea57f19945.png)