### PR TITLE
Fix auto-completion breaking for table names with caps

### DIFF
--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -223,7 +223,7 @@ class PGCompleter(Completer):
             pat = re.compile('(%s)' % regex)
 
             def _match(item):
-                r = pat.search(self.unescape_name(item))
+                r = pat.search(self.unescape_name(item.lower()))
                 if r:
                     return -len(r.group()), -r.start()
         else:

--- a/tests/test_fuzzy_completion.py
+++ b/tests/test_fuzzy_completion.py
@@ -74,3 +74,16 @@ def test_should_break_ties_using_lexical_order(completer, collection):
     matches = completer.find_matches(text, collection)
 
     assert matches[1].priority > matches[0].priority
+
+def test_matching_should_be_case_insensitive(completer):
+    """Fuzzy matching should keep matches even if letter casing doesn't match.
+
+    This test checks that variations of the text which have different casing
+    are still matched.
+    """
+
+    text = 'foo'
+    collection = ['Foo', 'FOO', 'fOO']
+    matches = completer.find_matches(text, collection)
+
+    assert len(matches) == 3


### PR DESCRIPTION
Fix for #478

![image](https://cloud.githubusercontent.com/assets/384556/13977032/c444e57a-f082-11e5-80fa-432390563552.png)