### PR TITLE
Unquote URI parts prior to using in connection

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -54,9 +54,9 @@ from .__init__ import __version__
 click.disable_unicode_literals_warning = True
 
 try:
-    from urlparse import urlparse
+    from urlparse import urlparse, unquote
 except ImportError:
-    from urllib.parse import urlparse
+    from urllib.parse import urlparse, unquote
 
 from getpass import getuser
 from psycopg2 import OperationalError
@@ -238,8 +238,10 @@ class PGCli(object):
     def connect_uri(self, uri):
         uri = urlparse(uri)
         database = uri.path[1:]  # ignore the leading fwd slash
-        self.connect(database, uri.hostname, uri.username,
-                     uri.port, uri.password)
+        arguments = [database, uri.hostname, uri.username,
+                     uri.port, uri.password]
+        # unquote each URI part (they may be percent encoded)
+        self.connect(*list(map(lambda p: unquote(p) if p else p, arguments)))
 
     def connect(self, database='', host='', user='', port='', passwd='',
                 dsn=''):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import stat
+import mock
 
 import pytest
 try:
@@ -83,3 +84,10 @@ def test_missing_rc_dir(tmpdir):
 
     PGCli(pgclirc_file=rcfile)
     assert os.path.exists(rcfile)
+
+
+def test_quoted_db_uri(tmpdir):
+    with mock.patch.object(PGCli, 'connect') as mock_connect:
+        cli = PGCli(pgclirc_file=str(tmpdir.join("rcfile")))
+        cli.connect_uri('postgres://bar%5E:%5Dfoo@baz.com/testdb%5B')
+    mock_connect.assert_called_with('testdb[', 'baz.com', 'bar^', None, ']foo')


### PR DESCRIPTION
As you may know, [RFC-3986][1] allows passing "disallowed" characters as long as these are percent encoded.
Since PGCLI deals with the url parsing, we should expect this to happen, and use the values after they have been decoded.

(includes a simple test for the parsing and decoding)

[1]: https://tools.ietf.org/html/rfc3986#section-2.1