### PR TITLE
Improved config loading

### DIFF
--- a/pgcli/config.py
+++ b/pgcli/config.py
@@ -9,7 +9,7 @@ def config_location():
     if platform.system() == 'Windows':
         return os.getenv('USERPROFILE') + '\\AppData\\Local\\dbcli\\pgcli\\'
     else:
-        return expanduser('~/.config/pgcli/')
+        return expanduser(os.path.join(os.environ.get('XDG_CONFIG_HOME', '~/.config'),  "pgcli/"))
 
 def load_config(usr_cfg, def_cfg=None):
     cfg = ConfigObj()

--- a/pgcli/config.py
+++ b/pgcli/config.py
@@ -21,7 +21,7 @@ def load_config(usr_cfg, def_cfg=None):
 
 
 def ensure_dir_exists(path):
-    parent_dir = dirname(path)
+    parent_dir = expanduser(dirname(path))
     try:
         os.makedirs(parent_dir)
     except OSError as exc:


### PR DESCRIPTION
I noticed that when I ran pgcli it was leaving a '~' dir in my current working dir. This is because ensure_dir_exists was not calling expanduser()

As long as I was fixing that I noticed you had hardcoded ~/.config, so I went ahead and made it check $XDG_CONFIG_HOME



You might want to change the Windows path to also use os.path.join for consistency, but since I don't have python on windows I did not want to risk breaking it without being able to check that it still works.