### PR TITLE
Improve filtering of functions for FROM clause

### DIFF
--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -299,7 +299,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
 
         # Suggest set-returning functions in the FROM clause
         if token_v == 'from' or (token_v.endswith('join') and token.is_keyword):
-            suggest.append(Function(schema=schema, filter='is_set_returning'))
+            suggest.append(Function(schema=schema, filter='for_from_clause'))
 
         return tuple(suggest)
 

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -319,9 +319,9 @@ class PGCompleter(Completer):
         return self.find_matches(word_before_cursor, scoped_cols, meta='column')
 
     def get_function_matches(self, suggestion, word_before_cursor):
-        if suggestion.filter == 'is_set_returning':
-            # Only suggest set-returning functions
-            filt = operator.attrgetter('is_set_returning')
+        if suggestion.filter == 'for_from_clause':
+            # Only suggest functions allowed in FROM clause
+            filt = lambda f: not f.is_aggregate and not f.is_window
             funcs = self.populate_functions(suggestion.schema, filt)
         else:
             funcs = self.populate_schema_objects(

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -75,6 +75,8 @@ def test_schema_or_visible_table_completion(completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([
+       Completion(text='func1', start_position=0, display_meta='function'),
+       Completion(text='func2', start_position=0, display_meta='function'),
        Completion(text='public', start_position=0, display_meta='schema'),
        Completion(text='custom', start_position=0, display_meta='schema'),
        Completion(text='users', start_position=0, display_meta='table'),
@@ -185,6 +187,7 @@ def test_suggested_table_names_with_schema_dot(completer, complete_event,
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([
+        Completion(text='func3', start_position=start_pos, display_meta='function'),
         Completion(text='users', start_position=start_pos, display_meta='table'),
         Completion(text='products', start_position=start_pos, display_meta='table'),
         Completion(text='shipments', start_position=start_pos, display_meta='table'),
@@ -280,6 +283,8 @@ def test_table_names_after_from(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
+        Completion(text='func1', start_position=0, display_meta='function'),
+        Completion(text='func2', start_position=0, display_meta='function'),
         Completion(text='public', start_position=0, display_meta='schema'),
         Completion(text='custom', start_position=0, display_meta='schema'),
         Completion(text='users', start_position=0, display_meta='table'),

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -95,6 +95,8 @@ def test_schema_or_visible_table_completion(completer, complete_event):
         Completion(text='"select"', start_position=0, display_meta='table'),
         Completion(text='orders', start_position=0, display_meta='table'),
         Completion(text='user_emails', start_position=0, display_meta='view'),
+        Completion(text='custom_func1', start_position=0, display_meta='function'),
+        Completion(text='custom_func2', start_position=0, display_meta='function'),
         Completion(text='set_returning_func', start_position=0, display_meta='function')])
 
 
@@ -376,6 +378,8 @@ def test_table_names_after_from(completer, complete_event):
         Completion(text='orders', start_position=0, display_meta='table'),
         Completion(text='"select"', start_position=0, display_meta='table'),
         Completion(text='user_emails', start_position=0, display_meta='view'),
+        Completion(text='custom_func1', start_position=0, display_meta='function'),
+        Completion(text='custom_func2', start_position=0, display_meta='function'),
         Completion(text='set_returning_func', start_position=0, display_meta='function')
         ])
 
@@ -386,6 +390,8 @@ def test_table_names_after_from_are_lexical_ordered_by_text(completer, complete_
         Document(text=text, cursor_position=position),
         complete_event)
     assert [c.text for c in result] == [
+        'custom_func1',
+        'custom_func2',
         'orders',
         'public',
         '"select"',

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -106,7 +106,7 @@ def test_suggest_tables_views_schemas_and_set_returning_functions(expression):
     assert set(suggestions) == set([
         Table(schema=None),
         View(schema=None),
-        Function(schema=None, filter='is_set_returning'),
+        Function(schema=None, filter='for_from_clause'),
         Schema(),
     ])
 
@@ -138,7 +138,7 @@ def test_suggest_qualified_tables_views_and_set_returning_functions(expression):
     assert set(suggestions) == set([
         Table(schema='sch'),
         View(schema='sch'),
-        Function(schema='sch', filter='is_set_returning'),
+        Function(schema='sch', filter='for_from_clause'),
     ])
 
 
@@ -175,7 +175,7 @@ def test_table_comma_suggests_tables_and_schemas():
     assert set(suggestions) == set([
         Table(schema=None),
         View(schema=None),
-        Function(schema=None, filter='is_set_returning'),
+        Function(schema=None, filter='for_from_clause'),
         Schema(),
     ])
 
@@ -308,7 +308,7 @@ def test_sub_select_table_name_completion(expression):
     assert set(suggestion) == set([
         Table(schema=None),
         View(schema=None),
-        Function(schema=None, filter='is_set_returning'),
+        Function(schema=None, filter='for_from_clause'),
         Schema(),
     ])
 
@@ -353,7 +353,7 @@ def test_join_suggests_tables_and_schemas(tbl_alias, join_type):
     assert set(suggestion) == set([
         Table(schema=None),
         View(schema=None),
-        Function(schema=None, filter='is_set_returning'),
+        Function(schema=None, filter='for_from_clause'),
         Schema(),
     ])
 
@@ -364,7 +364,7 @@ def test_left_join_with_comma():
     assert set(suggestions) == set([
          Table(schema=None),
          View(schema=None),
-         Function(schema=None, filter='is_set_returning'),
+         Function(schema=None, filter='for_from_clause'),
          Schema(),
     ])
 
@@ -452,14 +452,14 @@ def test_suggest_columns_after_multiple_joins():
     suggestions = suggest_type(sql, sql)
     assert Column(tables=((None, 't3', None, False),)) in set(suggestions)
 
-    
+
 def test_2_statements_2nd_current():
     suggestions = suggest_type('select * from a; select * from ',
                                'select * from a; select * from ')
     assert set(suggestions) == set([
         Table(schema=None),
         View(schema=None),
-        Function(schema=None, filter='is_set_returning'),
+        Function(schema=None, filter='for_from_clause'),
         Schema(),
     ])
 
@@ -477,7 +477,7 @@ def test_2_statements_2nd_current():
     assert set(suggestions) == set([
         Table(schema=None),
         View(schema=None),
-        Function(schema=None, filter='is_set_returning'),
+        Function(schema=None, filter='for_from_clause'),
         Schema(),
     ])
 
@@ -488,7 +488,7 @@ def test_2_statements_1st_current():
     assert set(suggestions) == set([
         Table(schema=None),
         View(schema=None),
-        Function(schema=None, filter='is_set_returning'),
+        Function(schema=None, filter='for_from_clause'),
         Schema(),
     ])
 
@@ -507,7 +507,7 @@ def test_3_statements_2nd_current():
     assert set(suggestions) == set([
         Table(schema=None),
         View(schema=None),
-        Function(schema=None, filter='is_set_returning'),
+        Function(schema=None, filter='for_from_clause'),
         Schema(),
     ])
 


### PR DESCRIPTION
Change from filtering out all non-set-returning functions to only filteirng out windowing functions and aggregate functions.
Non-set-returning functions are legal in the FROM clause and can be quite useful.