### PR TITLE
Fix bug where "USING(<cursor>" wasn't detected properly + add test case

### DIFF
--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -247,7 +247,9 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text, identifier
 
         # Get the token before the parens
         prev_tok = p.token_prev(len(p.tokens) - 1)
-        if prev_tok and prev_tok.value and prev_tok.value.lower() == 'using':
+
+        if (prev_tok and prev_tok.value
+          and prev_tok.value.lower().split(' ')[-1] == 'using'):
             # tbl1 INNER JOIN tbl2 USING (col1, col2)
             tables = extract_tables(full_text)
 

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -323,11 +323,3 @@ def test_suggest_columns_from_aliased_set_returning_function(completer, complete
                                        complete_event)
     assert set(result) == set([
         Completion(text='x', start_position=0, display_meta='column')])
-
-def test_using(completer, complete_event):
-    sql = 'select * from public.users join custom.shipments using('
-    pos = len(sql)
-    result = completer.get_completions(Document(text=sql, cursor_position=pos),
-                                       complete_event)
-    assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column')])

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -323,3 +323,11 @@ def test_suggest_columns_from_aliased_set_returning_function(completer, complete
                                        complete_event)
     assert set(result) == set([
         Completion(text='x', start_position=0, display_meta='column')])
+
+def test_using(completer, complete_event):
+    sql = 'select * from public.users join custom.shipments using('
+    pos = len(sql)
+    result = completer.get_completions(Document(text=sql, cursor_position=pos),
+                                       complete_event)
+    assert set(result) == set([
+        Completion(text='id', start_position=0, display_meta='column')])

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -344,8 +344,11 @@ def test_suggested_tables_after_on_right_side(completer, complete_event):
         Completion(text='users', start_position=0, display_meta='table alias'),
         Completion(text='orders', start_position=0, display_meta='table alias')])
 
-def test_join_using_suggests_common_columns(completer, complete_event):
-    text = 'SELECT * FROM users INNER JOIN orders USING ('
+@pytest.mark.parametrize('text', [
+    'SELECT * FROM users INNER JOIN orders USING (',
+    'SELECT * FROM users INNER JOIN orders USING(',
+])
+def test_join_using_suggests_common_columns(completer, complete_event, text):
     pos = len(text)
     result = set(completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event))
@@ -354,8 +357,11 @@ def test_join_using_suggests_common_columns(completer, complete_event):
         Completion(text='email', start_position=0, display_meta='column'),
         ])
 
-def test_join_using_suggests_columns_after_first_column(completer, complete_event):
-    text = 'SELECT * FROM users INNER JOIN orders USING (id,'
+@pytest.mark.parametrize('text', [
+    'SELECT * FROM users INNER JOIN orders USING (id,',
+    'SELECT * FROM users INNER JOIN orders USING(id,',
+])
+def test_join_using_suggests_columns_after_first_column(completer, complete_event, text):
     pos = len(text)
     result = set(completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event))


### PR DESCRIPTION
prev_tok is something like '[table name] [table alias] USING' where we expect it to be 'USING', so I just added a quick fix where we check the last word in prev_token instead of the whole string.