### PR TITLE
pgexecute.foreignkeys() shouldn't explode in postgresql versions < 9

### DIFF
--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -379,6 +379,9 @@ class PGExecute(object):
     def foreignkeys(self):
         """Yields ForeignKey named tuples"""
 
+        if self.conn.server_version < 90000:
+            return
+
         with self.conn.cursor() as cur:
             query = '''
                 SELECT s_p.nspname AS parentschema,


### PR DESCRIPTION
This is trivial enough that I'm going to merge it in myself as soon as the tests pass