### PR TITLE
Custom casing of table/column/function/view names

### DIFF
--- a/pgcli/config.py
+++ b/pgcli/config.py
@@ -54,3 +54,10 @@ def get_config(pgclirc_file=None):
     write_default_config(default_config, pgclirc_file)
 
     return load_config(pgclirc_file, default_config)
+
+
+def get_casing_file(config):
+    casing_file = config['main']['casing_file']
+    if casing_file == 'default':
+        casing_file = config_location() + 'casing'
+    return casing_file

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -128,7 +128,7 @@ class PGCli(object):
         # Initialize completer
         smart_completion = c['main'].as_bool('smart_completion')
         settings = {'casing_file': get_casing_file(c),
-            'generate_casing_file': c['main']['generate_casing_file'],
+            'generate_casing_file': c['main'].as_bool('generate_casing_file'),
             'asterisk_column_order': c['main']['asterisk_column_order']}
         completer = PGCompleter(smart_completion, pgspecial=self.pgspecial,
             settings=settings)
@@ -571,10 +571,10 @@ class PGCli(object):
 
         callback = functools.partial(self._on_completions_refreshed,
                                      persist_priorities=persist_priorities)
-        config = self.config
-        settings = {'casing_file': get_casing_file(config),
-          'generate_casing_file': config['main']['generate_casing_file'],
-          'asterisk_column_order': config['main']['asterisk_column_order']}
+        c = self.config
+        settings = {'casing_file': get_casing_file(c),
+          'generate_casing_file': c['main'].as_bool('generate_casing_file'),
+          'asterisk_column_order': c['main']['asterisk_column_order']}
         self.completion_refresher.refresh(self.pgexecute, self.pgspecial,
             callback, history=history, settings=settings)
         return [(None, None, None,

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -21,6 +21,16 @@ multi_line = False
 # %USERPROFILE% is typically C:\Users\{username}
 log_file = default
 
+# casing_file location.
+# In Unix/Linux: ~/.config/pgcli/casing
+# In Windows: %USERPROFILE%\AppData\Local\dbcli\pgcli\casing
+# %USERPROFILE% is typically C:\Users\{username}
+casing_file = default
+
+# If generate_casing_file is set to True and there is no file in the above
+# location, one will be generated based on usage in SQL/PLPGSQL functions.
+generate_casing_file = False
+
 # history_file location.
 # In Unix/Linux: ~/.config/pgcli/history
 # In Windows: %USERPROFILE%\AppData\Local\dbcli\pgcli\history

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -43,8 +43,7 @@ class PGCompleter(Completer):
         self.prioritizer = PrevalenceCounter()
         settings = settings or {}
         self.casing_file = settings.get('casing_file')
-        self.generate_casing_file = (
-            settings.get('generate_casing_file') == 'True')
+        self.generate_casing_file = settings.get('generate_casing_file')
         self.asterisk_column_order = settings.get(
             'asterisk_column_order', 'table_order')
 

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -41,8 +41,13 @@ class PGCompleter(Completer):
         self.smart_completion = smart_completion
         self.pgspecial = pgspecial
         self.prioritizer = PrevalenceCounter()
-        self.asterisk_column_order = (settings or {}).get(
+        settings = settings or {}
+        self.casing_file = settings.get('casing_file')
+        self.generate_casing_file = (
+            settings.get('generate_casing_file') == 'True')
+        self.asterisk_column_order = settings.get(
             'asterisk_column_order', 'table_order')
+
         self.reserved_words = set()
         for x in self.keywords:
             self.reserved_words.update(x.split())
@@ -52,6 +57,7 @@ class PGCompleter(Completer):
         self.dbmetadata = {'tables': {}, 'views': {}, 'functions': {},
                            'datatypes': {}}
         self.search_path = []
+        self.casing = {}
 
         self.all_completions = set(self.keywords + self.functions)
 
@@ -95,6 +101,14 @@ class PGCompleter(Completer):
                 metadata[schema] = {}
 
         self.all_completions.update(schemata)
+
+    def extend_casing(self, words):
+        """ extend casing data
+
+        :return:
+        """
+        # casing should be a dict {lowercasename:PreferredCasingName}
+        self.casing = dict((word.lower(), word) for word in words)
 
     def extend_relations(self, data, kind):
         """ extend metadata for tables or views
@@ -289,12 +303,16 @@ class PGCompleter(Completer):
                 # the same priority as unquoted names.
                 lexical_priority = tuple(-ord(c) for c in self.unescape_name(item)) + (1,)
 
+                item = self.case(item)
                 priority = type_priority, prio, sort_key, priority_func(item), lexical_priority
 
                 matches.append(Match(
                     completion=Completion(item, -text_len, display_meta=meta),
                     priority=priority))
         return matches
+
+    def case(self, word):
+        return self.casing.get(word, word)
 
     def get_completions(self, document, complete_event, smart_completion=None):
         word_before_cursor = document.get_word_before_cursor(WORD=True)
@@ -353,14 +371,14 @@ class PGCompleter(Completer):
                 # User typed x.*; replicate "x." for all columns except the
                 # first, which gets the original (as we only replace the "*"")
                 sep = ', ' + word_before_cursor[:-1]
-                collist = sep.join(c for c in flat_cols)
+                collist = sep.join(self.case(c) for c in flat_cols)
             elif len(scoped_cols) > 1:
                 # Multiple tables; qualify all columns
-                collist = ', '.join(t.ref + '.' + c.name for t, cs in colit()
-                    for c in cs)
+                collist = ', '.join(t.ref + '.' + self.case(c.name)
+                    for t, cs in colit() for c in cs)
             else:
                 # Plain columns
-                collist = ', '.join(c for c in flat_cols)
+                collist = ', '.join(self.case(c) for c in flat_cols)
 
             return [Match(completion=Completion(collist, -1,
                 display_meta='columns', display='*'), priority=(1,1,1))]
@@ -373,7 +391,8 @@ class PGCompleter(Completer):
 
         def make_cond(tbl1, tbl2, col1, col2):
             prefix = '' if suggestion.parent else tbl1 + '.'
-            return prefix + col1 + ' = ' + tbl2 + '.' + col2
+            case = self.case
+            return prefix + case(col1) + ' = ' + tbl2 + '.' + case(col2)
 
         # Tables that are closer to the cursor get higher prio
         refprio = dict((tbl.ref, num) for num, tbl

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -506,3 +506,50 @@ class PGExecute(object):
             for row in cur:
                 yield row
 
+
+    def casing(self):
+        """Yields the most common casing for names used in db functions"""
+        with self.conn.cursor() as cur:
+            query = '''
+          WITH Words AS (
+                SELECT regexp_split_to_table(prosrc, '\W+') AS Word, COUNT(1)
+                FROM pg_catalog.pg_proc P
+                JOIN pg_catalog.pg_namespace N ON N.oid = P.pronamespace
+                JOIN pg_catalog.pg_language L ON L.oid = P.prolang
+                WHERE L.lanname IN ('sql', 'plpgsql')
+                AND N.nspname NOT IN ('pg_catalog', 'information_schema')
+                GROUP BY Word
+            ),
+            OrderWords AS (
+                SELECT Word,
+                    ROW_NUMBER() OVER(PARTITION BY LOWER(Word) ORDER BY Count DESC)
+                FROM Words
+                WHERE Word ~* '.*[a-z].*'
+            ),
+            Names AS (
+                --Column names
+                SELECT attname AS Name
+                FROM pg_catalog.pg_attribute
+                UNION -- Table/view names
+                SELECT relname
+                FROM pg_catalog.pg_class
+                UNION -- Function names
+                SELECT proname
+                FROM pg_catalog.pg_proc
+                UNION -- Type names
+                SELECT typname
+                FROM pg_catalog.pg_type
+                UNION -- Schema names
+                SELECT nspname
+                FROM pg_catalog.pg_namespace
+            )
+            SELECT Word
+            FROM OrderWords
+            WHERE LOWER(Word) IN (SELECT Name FROM Names)
+            AND Row_Number = 1;
+            '''
+            _logger.debug('Casing Query. sql: %r', query)
+            cur.execute(query)
+            for row in cur:
+                yield row[0]
+

--- a/tests/test_completion_refresher.py
+++ b/tests/test_completion_refresher.py
@@ -18,7 +18,7 @@ def test_ctor(refresher):
     assert len(refresher.refreshers) > 0
     actual_handlers = list(refresher.refreshers.keys())
     expected_handlers = ['schemata', 'tables', 'views', 'functions',
-                         'types', 'databases']
+                         'types', 'databases', 'casing']
     assert expected_handlers == actual_handlers
 
 


### PR DESCRIPTION
This is for those of us need/want to use unescaped names in CamelCase or whatever. This means we can use pgcli to edit our functions without having to correct the casing all the time!

**Original commit message:**
This adds support for defining the casing to be used in completions (for unquoted names). The casing is determined by the casing file, which consists of a \n-separated list of names using the preferred casing. This file is initially populated based on usage in SQL and PLPGSQL database functions but can then be modified by the user.