### PR TITLE
Fix issue with 'SELECT Foo.*<cursor> FROM Foo'

### DIFF
--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -347,7 +347,7 @@ class PGCompleter(Completer):
               and word_before_cursor[-len(lastword) - 1] == '.'):
                 # User typed x.*; replicate "x." for all columns except the
                 # first, which gets the original (as we only replace the "*"")
-                sep = ', ' + self.escape_name(tables[0].ref) + '.'
+                sep = ', ' + word_before_cursor[:-1]
                 collist = sep.join(c for c in flat_cols)
             elif len(scoped_cols) > 1:
                 # Multiple tables; qualify all columns

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -610,16 +610,19 @@ def test_wildcard_column_expansion_with_alias_qualifier(completer, complete_even
 
     assert expected == completions
 
-
-def test_wildcard_column_expansion_with_table_qualifier(completer, complete_event):
-    sql = 'SELECT users.* FROM users'
+@pytest.mark.parametrize('text,expected', [
+    ('SELECT users.* FROM users',
+        'id, users.email, users.first_name, users.last_name'),
+    ('SELECT Users.* FROM Users',
+        'id, Users.email, Users.first_name, Users.last_name'),
+])
+def test_wildcard_column_expansion_with_table_qualifier(completer, complete_event, text, expected):
     pos = len('SELECT users.*')
 
     completions = completer.get_completions(
-        Document(text=sql, cursor_position=pos), complete_event)
+        Document(text=text, cursor_position=pos), complete_event)
 
-    col_list = 'id, users.email, users.first_name, users.last_name'
-    expected = [Completion(text=col_list, start_position=-1,
+    expected = [Completion(text=expected, start_position=-1,
                           display='*', display_meta='columns')]
 
     assert expected == completions


### PR DESCRIPTION
In the expansion, we got '"Foo".\<col\>' when we should have gotten 'Foo.\<col\>'.