### PR TITLE
Fix issue where notices/warnings/... were printed in reverse order

### DIFF
--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -278,7 +278,7 @@ class PGExecute(object):
         # conn.notices persist between queies, we use pop to clear out the list
         title = ''
         while len(self.conn.notices) > 0:
-            title = title + utf8tounicode(self.conn.notices.pop())
+            title = utf8tounicode(self.conn.notices.pop()) + title
 
         # cur.description will be None for operations that do not return
         # rows.


### PR DESCRIPTION
@amjith you want to merge this tiny fix?

Running the function in #430, I noticed the warnings were printed in reverse order.