### PR TITLE
For 'JOIN <cursor>', suggest 'foo on foo.fooid = bar.fooid'

### DIFF
--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -197,7 +197,8 @@ def extract_tables(sql):
     # to have is_function=True
     identifiers = extract_table_identifiers(stream,
                                             allow_functions=not insert_stmt)
-    return tuple(identifiers)
+    # In the case 'sche.<cursor>', we get an empty TableReference; remove that
+    return tuple(i for i in identifiers if i.ref)
 
 
 def find_prev_keyword(sql):

--- a/pgcli/packages/parseutils.py
+++ b/pgcli/packages/parseutils.py
@@ -66,7 +66,9 @@ def last_word(text, include='alphanum_underscore'):
 
 TableReference = namedtuple('TableReference', ['schema', 'name', 'alias',
                                                'is_function'])
-TableReference.ref = property(lambda self: self.alias or self.name)
+TableReference.ref = property(lambda self: self.alias or (
+  self.name if self.name.islower() or self.name[0] == '"'
+  else '"' + self.name + '"'))
 
 
 # This code is borrowed from sqlparse example script.
@@ -140,7 +142,10 @@ def extract_table_identifiers(token_stream, allow_functions=True):
             schema_name = schema_name.lower()
         quote_count = item.value.count('"')
         name_quoted = quote_count > 2 or (quote_count and not schema_quoted)
-        if name and not name_quoted and name != name.lower():
+        alias_quoted = alias and item.value[-1] == '"'
+        if alias_quoted or name_quoted and not alias and name.islower():
+            alias = '"' + (alias or name) + '"'
+        if name and not name_quoted and not name.islower():
             if not alias:
                 alias = name
             name = name.lower()
@@ -198,7 +203,8 @@ def extract_tables(sql):
     identifiers = extract_table_identifiers(stream,
                                             allow_functions=not insert_stmt)
     # In the case 'sche.<cursor>', we get an empty TableReference; remove that
-    return tuple(i for i in identifiers if i.ref)
+    return tuple(i for i in identifiers if i.name)
+
 
 
 def find_prev_keyword(sql):

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -22,6 +22,7 @@ Database = namedtuple('Database', [])
 Schema = namedtuple('Schema', [])
 Table = namedtuple('Table', ['schema'])
 JoinCondition = namedtuple('JoinCondition', ['tables', 'parent'])
+Join = namedtuple('Join', ['tables', 'schema'])
 
 Function = namedtuple('Function', ['schema', 'filter'])
 # For convenience, don't require the `filter` argument in Function constructor
@@ -68,6 +69,7 @@ def suggest_type(full_text, text_before_cursor):
 
     full_text = strip_named_query(full_text)
     text_before_cursor = strip_named_query(text_before_cursor)
+    text_before_cursor_including_last_word = text_before_cursor
 
     # If we've partially typed a word then word_before_cursor won't be an empty
     # string. In that case we want to remove the partially typed string before
@@ -78,8 +80,8 @@ def suggest_type(full_text, text_before_cursor):
         if word_before_cursor[-1] == '(' or word_before_cursor[0] == '\\':
             parsed = sqlparse.parse(text_before_cursor)
         else:
-            parsed = sqlparse.parse(
-                text_before_cursor[:-len(word_before_cursor)])
+            text_before_cursor = text_before_cursor[:-len(word_before_cursor)]
+            parsed = sqlparse.parse(text_before_cursor)
 
             identifier = parse_partial_identifier(word_before_cursor)
     else:
@@ -114,7 +116,7 @@ def suggest_type(full_text, text_before_cursor):
         # but the statement won't have a first token
         tok1 = statement.token_first()
         if tok1 and tok1.value == '\\':
-            return suggest_special(text_before_cursor)
+            return suggest_special(text_before_cursor_including_last_word)
 
     last_token = statement and statement.token_prev(len(statement.tokens)) or ''
 
@@ -310,6 +312,11 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text,
         if token_v == 'from' or (token_v.endswith('join') and token.is_keyword):
             suggest.append(Function(schema=schema, filter='for_from_clause'))
 
+        if (token_v.endswith('join') and token.is_keyword
+          and _allow_join_suggestion(parsed_statement)):
+            tables = extract_tables(text_before_cursor)
+            suggest.append(Join(tables=tables, schema=schema))
+
         return tuple(suggest)
 
     elif token_v in ('table', 'view', 'function'):
@@ -337,7 +344,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text,
                     View(schema=parent),
                     Function(schema=parent)]
             last_token = parsed_statement
-            if _allow_join_suggestion(parsed_statement):
+            if _allow_join_condition_suggestion(parsed_statement):
                 sugs.append(JoinCondition(tables=tables,
                     parent=filteredtables[-1]))
             return tuple(sugs)
@@ -345,7 +352,7 @@ def suggest_based_on_last_token(token, text_before_cursor, full_text,
             # ON <suggestion>
             # Use table alias if there is one, otherwise the table name
             aliases = tuple(t.alias or t.name for t in tables)
-            if _allow_join_suggestion(parsed_statement):
+            if _allow_join_condition_suggestion(parsed_statement):
                 return (Alias(aliases=aliases), JoinCondition(
                     tables=tables, parent=None))
             else:
@@ -388,7 +395,7 @@ def identifies(id, ref):
         ref.schema and (id == ref.schema + '.' + ref.name))
 
 
-def _allow_join_suggestion(statement):
+def _allow_join_condition_suggestion(statement):
     """
     Tests if a join condition should be suggested
 
@@ -406,3 +413,22 @@ def _allow_join_suggestion(statement):
 
     last_tok = statement.token_prev(len(statement.tokens))
     return last_tok.value.lower() in ('on', 'and', 'or')
+
+
+def _allow_join_suggestion(statement):
+    """
+    Tests if a join should be suggested
+
+    We need this to avoid bad suggestions when entering e.g.
+        select * from tbl1 a join tbl2 b <cursor>
+    So check that the preceding token is a JOIN keyword
+
+    :param statement: an sqlparse.sql.Statement
+    :return: boolean
+    """
+
+    if not statement or not statement.tokens:
+        return False
+
+    last_tok = statement.token_prev(len(statement.tokens))
+    return last_tok.value.lower().endswith('join')

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -21,7 +21,9 @@ Special = namedtuple('Special', [])
 Database = namedtuple('Database', [])
 Schema = namedtuple('Schema', [])
 Table = namedtuple('Table', ['schema'])
+# JoinConditions are suggested after ON, e.g. 'foo.barid = bar.barid'
 JoinCondition = namedtuple('JoinCondition', ['tables', 'parent'])
+# Joins are suggested after JOIN, e.g. 'foo ON foo.barid = bar.barid'
 Join = namedtuple('Join', ['tables', 'schema'])
 
 Function = namedtuple('Function', ['schema', 'filter'])
@@ -431,4 +433,5 @@ def _allow_join_suggestion(statement):
         return False
 
     last_tok = statement.token_prev(len(statement.tokens))
-    return last_tok.value.lower().endswith('join')
+    return (last_tok.value.lower().endswith('join')
+        and last_tok.value.lower() != 'cross join')

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -434,4 +434,4 @@ def _allow_join_suggestion(statement):
 
     last_tok = statement.token_prev(len(statement.tokens))
     return (last_tok.value.lower().endswith('join')
-        and last_tok.value.lower() != 'cross join')
+        and last_tok.value.lower() not in('cross join', 'natural join'))

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -392,10 +392,9 @@ class PGCompleter(Completer):
         tblprio = dict((t.ref, n) for n, t in enumerate(suggestion.tables))
         joins, prios = [], []
         # Iterate over FKs in existing tables to find potential joins
-        for fk, rtbl, rcol in ((fk, rtbl, rcol)
-          for rtbl, rcols in scoped_cols.items()
-          for rcol in rcols
-          for fk in rcol.foreignkeys):
+        fks = ((fk, rtbl, rcol) for rtbl, rcols in scoped_cols.items()
+            for rcol in rcols for fk in rcol.foreignkeys)
+        for fk, rtbl, rcol in fks:
             if (fk.childschema, fk.childtable, fk.childcolumn) == (
               rtbl.schema, rtbl.name, rcol.name):
                 lsch = fk.parentschema

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -390,7 +390,7 @@ class PGCompleter(Completer):
             aliases = ('"' + tbl[1:-1] + str(i) + '"' for i in itertools.count(2))
         else:
             aliases = (self.case(tbl) + str(i) for i in itertools.count(2))
-        return (a for a in aliases if normalize_ref(a) not in tbls).next()
+        return next(a for a in aliases if normalize_ref(a) not in tbls)
 
     def get_join_matches(self, suggestion, word_before_cursor):
         tbls = suggestion.tables
@@ -399,7 +399,8 @@ class PGCompleter(Completer):
         qualified = dict((normalize_ref(t.ref), t.schema) for t in tbls)
         ref_prio = dict((normalize_ref(t.ref), n) for n, t in enumerate(tbls))
         refs = set(normalize_ref(t.ref) for t in tbls)
-        other_tbls = set((t.schema, t.name) for t in cols.keys()[:-1])
+        other_tbls = set((t.schema, t.name)
+            for t in list(cols)[:-1])
         joins, prios = [], []
         # Iterate over FKs in existing tables to find potential joins
         fks = ((fk, rtbl, rcol) for rtbl, rcols in cols.items()

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -386,6 +386,10 @@ class PGCompleter(Completer):
         return self.find_matches(word_before_cursor, flat_cols, meta='column')
 
     def generate_alias(self, tbl, tbls):
+        """ Generate a unique table alias
+        tbl - name of the table to alias, quoted if it needs to be
+        tbls - set of table refs already in use, normalized with normalize_ref
+        """
         if tbl[0] == '"':
             aliases = ('"' + tbl[1:-1] + str(i) + '"' for i in itertools.count(2))
         else:

--- a/tests/test_parseutils.py
+++ b/tests/test_parseutils.py
@@ -149,12 +149,15 @@ def test_subselect_tables():
     tables = extract_tables(sql)
     assert tables == ((None, 'abc', None, False),)
 
+@pytest.mark.parametrize('text', ['SELECT * FROM foo.', 'SELECT 123 AS foo'])
+def test_extract_no_tables(text):
+    tables = extract_tables(text)
+    assert tables == tuple()
 
 @pytest.mark.parametrize('arg_list', ['', 'arg1', 'arg1, arg2, arg3'])
 def test_simple_function_as_table(arg_list):
     tables = extract_tables('SELECT * FROM foo({0})'.format(arg_list))
     assert tables == ((None, 'foo', None, True),)
-
 
 @pytest.mark.parametrize('arg_list', ['', 'arg1', 'arg1, arg2, arg3'])
 def test_simple_schema_qualified_function_as_table(arg_list):

--- a/tests/test_parseutils.py
+++ b/tests/test_parseutils.py
@@ -12,10 +12,17 @@ def test_simple_select_single_table():
 
 
 @pytest.mark.parametrize('sql', [
-    'select * from abc.def',
-    'select * from "abc".def',
     'select * from "abc"."def"',
     'select * from abc."def"',
+])
+def test_simple_select_single_table_schema_qualified_quoted_table(sql):
+    tables = extract_tables(sql)
+    assert tables == (('abc', 'def', '"def"', False),)
+
+
+@pytest.mark.parametrize('sql', [
+    'select * from abc.def',
+    'select * from "abc".def',
 ])
 def test_simple_select_single_table_schema_qualified(sql):
     tables = extract_tables(sql)

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 import pytest
 from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
-from pgcli.packages.function_metadata import FunctionMetadata
+from pgcli.packages.function_metadata import FunctionMetadata, ForeignKey
 
 metadata = {
             'tables': {
@@ -37,6 +37,9 @@ metadata = {
                             'public':   ['typ1', 'typ2'],
                             'custom':   ['typ3', 'typ4'],
                          },
+                'foreignkeys': [
+                    ('public', 'users', 'id', 'custom', 'shipments', 'user_id')
+                ],
             }
 
 @pytest.fixture
@@ -63,11 +66,14 @@ def completer():
                     for schema, datatypes in metadata['datatypes'].items()
                     for datatype in datatypes]
 
+    foreignkeys = [ForeignKey(*fk) for fk in metadata['foreignkeys']]
+
     comp.extend_schemata(schemata)
     comp.extend_relations(tables, kind='tables')
     comp.extend_columns(columns, kind='tables')
     comp.extend_functions(functions)
     comp.extend_datatypes(datatypes)
+    comp.extend_foreignkeys(foreignkeys)
     comp.set_search_path(['public'])
 
     return comp
@@ -134,6 +140,45 @@ def test_suggested_column_names_from_qualified_shadowed_table(completer, complet
         list(map(lambda f: Completion(f, display_meta='function'), completer.functions)) +
         list(map(lambda x: Completion(x, display_meta='keyword'), completer.keywords))
         )
+
+@pytest.mark.parametrize('text', [
+    'SELECT * FROM users JOIN custom.shipments ON ',
+    '''SELECT *
+    FROM public.users
+    JOIN custom.shipments ON '''
+])
+def test_suggested_join_conditions(completer, complete_event, text):
+    position = len(text)
+    result = set(completer.get_completions(
+        Document(text=text, cursor_position=position),
+        complete_event))
+    assert set(result) == set([
+        Completion(text='users', start_position=0, display_meta='table alias'),
+        Completion(text='shipments', start_position=0, display_meta='table alias'),
+        Completion(text='shipments.id = users.id', start_position=0, display_meta='name join'),
+        Completion(text='shipments.user_id = users.id', start_position=0, display_meta='fk join')])
+
+@pytest.mark.parametrize('text', [
+    'SELECT * FROM public.users RIGHT OUTER JOIN ',
+    '''SELECT *
+    FROM users
+    JOIN '''
+])
+def test_suggested_joins(completer, complete_event, text):
+    position = len(text)
+    result = set(completer.get_completions(
+        Document(text=text, cursor_position=position),
+        complete_event))
+    assert set(result) == set([
+        Completion(text='custom.shipments ON shipments.user_id = users.id', start_position=0, display_meta='join'),
+        Completion(text='public', start_position=0, display_meta='schema'),
+        Completion(text='custom', start_position=0, display_meta='schema'),
+        Completion(text='"Custom"', start_position=0, display_meta='schema'),
+        Completion(text='orders', start_position=0, display_meta='table'),
+        Completion(text='users', start_position=0, display_meta='table'),
+        Completion(text='"select"', start_position=0, display_meta='table'),
+        Completion(text='func1', start_position=0, display_meta='function'),
+        Completion(text='func2', start_position=0, display_meta='function')])
 
 def test_suggested_column_names_from_schema_qualifed_table(completer, complete_event):
     """

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -343,6 +343,22 @@ def test_suggested_join_conditions(completer, complete_event, text):
         Completion(text='u2.userid = u.id', start_position=0, display_meta='fk join')])
 
 @pytest.mark.parametrize('text', [
+    'SELECT * FROM "Users" u JOIN u',
+    'SELECT * FROM "Users" u JOIN uid',
+    'SELECT * FROM "Users" u JOIN userid',
+    'SELECT * FROM "Users" u JOIN id',
+])
+def test_suggested_joins_fuzzy(completer, complete_event, text):
+    position = len(text)
+    result = set(completer.get_completions(
+        Document(text=text, cursor_position=position),
+        complete_event))
+    last_word = text.split()[-1]
+    expected = Completion(text='users ON users.id = u.userid',
+                          start_position=-len(last_word), display_meta='join')
+    assert expected in result
+
+@pytest.mark.parametrize('text', [
     'SELECT * FROM users JOIN ',
     '''SELECT *
     FROM users

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -455,7 +455,8 @@ def test_join_using_suggests_columns_after_first_column(completer, complete_even
 
 @pytest.mark.parametrize('text', [
     'SELECT * FROM ',
-    'SELECT * FROM users CROSS JOIN '
+    'SELECT * FROM users CROSS JOIN ',
+    'SELECT * FROM users natural join '
 ])
 def test_table_names_after_from(completer, complete_event, text):
     position = len(text)

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -111,9 +111,24 @@ def test_suggest_tables_views_schemas_and_functions(expression):
 
 
 @pytest.mark.parametrize('expression', [
-    'SELECT * FROM foo JOIN ',
+    'SELECT * FROM foo JOIN bar on bar.barid = foo.barid JOIN ',
+    'SELECT * FROM foo JOIN bar USING (barid) JOIN ',
 ])
-def test_suggest_tables_views_schemas_functions_and_joins(expression):
+def test_suggest_after_join_with_two_tables(expression):
+    suggestions = suggest_type(expression, expression)
+    assert set(suggestions) == set([
+        Table(schema=None),
+        View(schema=None),
+        Function(schema=None, filter='for_from_clause'),
+        Join(((None, 'foo', None, False), (None, 'bar', None, False)), None),
+        Schema(),
+    ])
+
+
+@pytest.mark.parametrize('expression', [
+    'SELECT * FROM foo JOIN '
+])
+def test_suggest_after_join_with_one_table(expression):
     suggestions = suggest_type(expression, expression)
     assert set(suggestions) == set([
         Table(schema=None),

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -123,7 +123,7 @@ def test_suggest_tables_views_schemas_and_functions(expression):
 
 @pytest.mark.parametrize('expression', [
     'SELECT * FROM foo JOIN bar on bar.barid = foo.barid JOIN ',
-    'SELECT * FROM foo JOIN bar USING (barid) JOIN ',
+    'SELECT * FROM foo JOIN bar USING (barid) JOIN '
 ])
 def test_suggest_after_join_with_two_tables(expression):
     suggestions = suggest_type(expression, expression)
@@ -137,7 +137,8 @@ def test_suggest_after_join_with_two_tables(expression):
 
 
 @pytest.mark.parametrize('expression', [
-    'SELECT * FROM foo JOIN '
+    'SELECT * FROM foo JOIN ',
+    'SELECT * FROM foo JOIN bar'
 ])
 def test_suggest_after_join_with_one_table(expression):
     suggestions = suggest_type(expression, expression)

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -23,8 +23,19 @@ def test_select_suggests_cols_with_qualified_table_scope():
 
 
 @pytest.mark.parametrize('expression', [
-    'SELECT * FROM tabl WHERE ',
     'SELECT * FROM "tabl" WHERE ',
+])
+def test_where_suggests_columns_functions_quoted_table(expression):
+    suggestions = suggest_type(expression, expression)
+    assert set(suggestions) == set([
+        Column(tables=((None, 'tabl', '"tabl"', False),)),
+        Function(schema=None),
+        Keyword(),
+    ])
+
+
+@pytest.mark.parametrize('expression', [
+    'SELECT * FROM tabl WHERE ',
     'SELECT * FROM tabl WHERE (',
     'SELECT * FROM tabl WHERE foo = ',
     'SELECT * FROM tabl WHERE bar OR ',


### PR DESCRIPTION
@darikg  you feel like taking a look at this?

**Original commit message:**
This is based on my previous work on suggesting join conditions, but here instead we suggest the whole join. What we do is simply check all the tables in the statement for FK relationships and then suggest joins based on those. I think this will not only save key presses, but also be rather useful when exploring an unfamiliar (part of a) database.

There's one non-obvious change in this commit (that I can think of): When calling **sqlcompletion.text_before_cursor**, the **text_before_cursor** argument now no longer includes **word_before_cursor**. This is because for 'SELECT * FROM foo JOIN bar<cursor>', we would otherwise consider the table **bar** already included in the statement and thus suggest e.g. 'baz on baz.barid = bar.barid'.