### PR TITLE
Remove duplication from smart completion tests

### DIFF
--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -36,6 +36,14 @@ class MetaData(object):
     def keywords(self, pos=0):
         return [keyword(kw, pos) for kw in self.completer.keywords]
 
+    def columns(self, parent, schema='public', typ='tables', pos=0):
+        if typ == 'functions':
+            fun = [x for x in self.metadata[typ][schema] if x[0] == parent][0]
+            cols = fun[1]
+        else:
+            cols = self.metadata[typ][schema][parent]
+        return [column(escape(col), pos) for col in cols]
+
     def datatypes(self, schema='public', pos=0):
         return [datatype(escape(x), pos)
             for x in self.metadata.get('datatypes', {}).get(schema, [])]

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -48,6 +48,10 @@ class MetaData(object):
         return [view(escape(x), pos)
             for x in self.metadata.get('views', {}).get(schema, [])]
 
+    def functions(self, schema='public', pos=0):
+        return [function(escape(x[0]), pos)
+            for x in self.metadata.get('functions', {}).get(schema, [])]
+
     def schemas(self, pos=0):
         schemas = set(sch for schs in self.metadata.values() for sch in schs)
         return [schema(escape(s), pos=pos) for s in schemas]

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -36,6 +36,10 @@ class MetaData(object):
     def keywords(self, pos=0):
         return [keyword(kw, pos) for kw in self.completer.keywords]
 
+    def datatypes(self, schema='public', pos=0):
+        return [datatype(escape(x), pos)
+            for x in self.metadata.get('datatypes', {}).get(schema, [])]
+
     def schemas(self, pos=0):
         schemas = set(sch for schs in self.metadata.values() for sch in schs)
         return [schema(escape(s), pos=pos) for s in schemas]

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -25,7 +25,6 @@ def wildcard_expansion(cols, pos=-1):
 class MetaData(object):
     def __init__(self, metadata):
         self.metadata = metadata
-        self.get_completer()
 
     def builtin_functions(self, pos=0):
         return [function(f, pos) for f in self.completer.functions]
@@ -64,10 +63,11 @@ class MetaData(object):
         schemas = set(sch for schs in self.metadata.values() for sch in schs)
         return [schema(escape(s), pos=pos) for s in schemas]
 
-    def get_completer(self):
+    @property
+    def completer(self):
         metadata = self.metadata
         import pgcli.pgcompleter as pgcompleter
-        self.completer = comp = pgcompleter.PGCompleter(smart_completion=True)
+        comp = pgcompleter.PGCompleter(smart_completion=True)
 
         schemata, tables, tbl_cols, views, view_cols = [], [], [], [], []
 
@@ -105,3 +105,5 @@ class MetaData(object):
         comp.extend_datatypes(datatypes)
         comp.extend_foreignkeys(foreignkeys)
         comp.set_search_path(['public'])
+
+        return comp

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -40,6 +40,10 @@ class MetaData(object):
         return [datatype(escape(x), pos)
             for x in self.metadata.get('datatypes', {}).get(schema, [])]
 
+    def tables(self, schema='public', pos=0):
+        return [table(escape(x), pos)
+            for x in self.metadata.get('tables', {}).get(schema, [])]
+
     def schemas(self, pos=0):
         schemas = set(sch for schs in self.metadata.values() for sch in schs)
         return [schema(escape(s), pos=pos) for s in schemas]

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -36,6 +36,10 @@ class MetaData(object):
     def keywords(self, pos=0):
         return [keyword(kw, pos) for kw in self.completer.keywords]
 
+    def schemas(self, pos=0):
+        schemas = set(sch for schs in self.metadata.values() for sch in schs)
+        return [schema(escape(s), pos=pos) for s in schemas]
+
     def get_completer(self):
         metadata = self.metadata
         import pgcli.pgcompleter as pgcompleter

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -44,6 +44,10 @@ class MetaData(object):
         return [table(escape(x), pos)
             for x in self.metadata.get('tables', {}).get(schema, [])]
 
+    def views(self, schema='public', pos=0):
+        return [view(escape(x), pos)
+            for x in self.metadata.get('views', {}).get(schema, [])]
+
     def schemas(self, pos=0):
         schemas = set(sch for schs in self.metadata.values() for sch in schs)
         return [schema(escape(s), pos=pos) for s in schemas]

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -1,0 +1,79 @@
+from pgcli.packages.function_metadata import FunctionMetadata, ForeignKey
+from prompt_toolkit.completion import Completion
+from functools import partial
+
+escape = lambda name: ('"' + name + '"' if not name.islower() or name in (
+    'select', 'insert') else name)
+
+def completion(display_meta, text, pos=0):
+    return Completion(text, start_position=pos,
+        display_meta=display_meta)
+
+# The code below is quivalent to
+# def schema(text, pos=0):
+#   return completion('schema', text, pos)
+# and so on
+schema, table, view, function, column, keyword, datatype, alias, name_join,\
+    fk_join, join = [partial(completion, display_meta)
+    for display_meta in('schema', 'table', 'view', 'function', 'column',
+    'keyword', 'datatype', 'table alias', 'name join', 'fk join', 'join')]
+
+def wildcard_expansion(cols, pos=-1):
+        return Completion(cols, start_position=pos, display_meta='columns',
+            display = '*')
+
+class MetaData(object):
+    def __init__(self, metadata):
+        self.metadata = metadata
+        self.get_completer()
+
+    def builtin_functions(self, pos=0):
+        return [function(f, pos) for f in self.completer.functions]
+
+    def builtin_datatypes(self, pos=0):
+        return [datatype(dt, pos) for dt in self.completer.datatypes]
+
+    def keywords(self, pos=0):
+        return [keyword(kw, pos) for kw in self.completer.keywords]
+
+    def get_completer(self):
+        metadata = self.metadata
+        import pgcli.pgcompleter as pgcompleter
+        self.completer = comp = pgcompleter.PGCompleter(smart_completion=True)
+
+        schemata, tables, tbl_cols, views, view_cols = [], [], [], [], []
+
+        for schema, tbls in metadata['tables'].items():
+            schemata.append(schema)
+
+            for table, cols in tbls.items():
+                tables.append((schema, table))
+                # Let all columns be text columns
+                tbl_cols.extend([(schema, table, col, 'text') for col in cols])
+
+        for schema, tbls in metadata.get('views', {}).items():
+            for view, cols in tbls.items():
+                views.append((schema, view))
+                # Let all columns be text columns
+                view_cols.extend([(schema, view, col, 'text') for col in cols])
+
+        functions = [FunctionMetadata(schema, *func_meta)
+                        for schema, funcs in metadata['functions'].items()
+                        for func_meta in funcs]
+
+        datatypes = [(schema, datatype)
+                        for schema, datatypes in metadata['datatypes'].items()
+                        for datatype in datatypes]
+
+        foreignkeys = [ForeignKey(*fk) for fks in metadata['foreignkeys'].values()
+            for fk in fks]
+
+        comp.extend_schemata(schemata)
+        comp.extend_relations(tables, kind='tables')
+        comp.extend_relations(views, kind='views')
+        comp.extend_columns(tbl_cols, kind='tables')
+        comp.extend_columns(view_cols, kind='views')
+        comp.extend_functions(functions)
+        comp.extend_datatypes(datatypes)
+        comp.extend_foreignkeys(foreignkeys)
+        comp.set_search_path(['public'])

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -5,7 +5,6 @@ from metadata import (MetaData, alias, name_join, fk_join, join,
     table,
     function,
     column,
-    schema,
     datatype,
     wildcard_expansion)
 from prompt_toolkit.document import Document
@@ -66,12 +65,9 @@ def test_schema_or_visible_table_completion(completer, complete_event):
     position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
-    assert set(result) == set([
+    assert set(result) == set(testdata.schemas() + [
        function('func1'),
        function('func2'),
-       schema('public'),
-       schema('custom'),
-       schema('"Custom"'),
        table('users'),
        table('"select"'),
        table('orders')])
@@ -149,11 +145,8 @@ def test_suggested_joins(completer, complete_event, query, tbl):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
+    assert set(result) == set(testdata.schemas() + [
         join('custom.shipments ON shipments.user_id = {0}.id'.format(tbl)),
-        schema('public'),
-        schema('custom'),
-        schema('"Custom"'),
         table('orders'),
         table('users'),
         table('"select"'),
@@ -336,10 +329,7 @@ def test_table_names_after_from(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        schema('public'),
-        schema('custom'),
-        schema('"Custom"'),
+    assert set(result) == set(testdata.schemas() + [
         function('func1'),
         function('func2'),
         table('users'),

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 import pytest
 import itertools
 from metadata import (MetaData, alias, name_join, fk_join, join,
-    table,
     function,
     column,
     wildcard_expansion)
@@ -67,9 +66,7 @@ def test_schema_or_visible_table_completion(completer, complete_event):
     assert set(result) == set(testdata.schemas() + [
        function('func1'),
        function('func2'),
-       table('users'),
-       table('"select"'),
-       table('orders')])
+       ] + testdata.tables())
 
 
 @pytest.mark.parametrize('table', [
@@ -144,11 +141,8 @@ def test_suggested_joins(completer, complete_event, query, tbl):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set(testdata.schemas() + [
+    assert set(result) == set(testdata.schemas() + testdata.tables() + [
         join('custom.shipments ON shipments.user_id = {0}.id'.format(tbl)),
-        table('orders'),
-        table('users'),
-        table('"select"'),
         function('func1'),
         function('func2')])
 
@@ -209,12 +203,8 @@ def test_suggested_table_names_with_schema_dot(completer, complete_event,
     position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
-    assert set(result) == set([
+    assert set(result) == set(testdata.tables('custom', start_pos) + [
         function('func3', start_pos),
-        table('users', start_pos),
-        table('"Users"', start_pos),
-        table('products', start_pos),
-        table('shipments', start_pos),
         function('set_returning_func', start_pos),
     ])
 
@@ -234,9 +224,9 @@ def test_suggested_table_names_with_schema_dot2(completer, complete_event,
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([
-        function('func4', start_pos),
-        table('projects', start_pos)
-    ])
+        function('func4', start_pos)]
+        + testdata.tables('Custom', start_pos)
+    )
 
 def test_suggested_column_names_with_qualified_alias(completer, complete_event):
     """
@@ -328,12 +318,9 @@ def test_table_names_after_from(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set(testdata.schemas() + [
+    assert set(result) == set(testdata.schemas() + testdata.tables() + [
         function('func1'),
         function('func2'),
-        table('users'),
-        table('orders'),
-        table('"select"'),
         ])
 
 def test_schema_qualified_function_name(completer, complete_event):
@@ -356,12 +343,8 @@ def test_schema_qualified_type_name(text, completer, complete_event):
     pos = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event)
-    assert set(result) == set(testdata.datatypes('custom') + [
-        table('users'),
-        table('"Users"'),
-        table('products'),
-        table('shipments'),
-        ])
+    assert set(result) == set(testdata.datatypes('custom')
+        + testdata.tables('custom'))
 
 
 def test_suggest_columns_from_aliased_set_returning_function(completer, complete_event):

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -2,9 +2,7 @@ from __future__ import unicode_literals
 import pytest
 import itertools
 from metadata import (MetaData, alias, name_join, fk_join, join,
-    function,
-    column,
-    wildcard_expansion)
+    function, wildcard_expansion)
 from prompt_toolkit.document import Document
 from pgcli.packages.function_metadata import FunctionMetadata, ForeignKey
 
@@ -83,12 +81,8 @@ def test_suggested_column_names_from_shadowed_visible_table(completer, complete_
         Document(text=text, cursor_position=position),
         complete_event))
 
-    assert set(result) == set([
-        column('id'),
-        column('email'),
-        column('first_name'),
-        column('last_name'),
-        ] + testdata.functions() +
+    assert set(result) == set(testdata.columns('users') +
+        testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
         )
@@ -99,10 +93,8 @@ def test_suggested_column_names_from_qualified_shadowed_table(completer, complet
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        column('id'),
-        column('phone_number'),
-        ] + testdata.functions() +
+    assert set(result) == set(testdata.columns('users', 'custom') +
+        testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
         )
@@ -151,11 +143,7 @@ def test_suggested_column_names_from_schema_qualifed_table(completer, complete_e
     position = len('SELECT ')
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position), complete_event))
-    assert set(result) == set([
-        column('id'),
-        column('product_name'),
-        column('price'),
-        ] + testdata.functions() +
+    assert set(result) == set(testdata.columns('products', 'custom') + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
         )
@@ -173,10 +161,7 @@ def test_suggested_column_names_in_function(completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event)
-    assert set(result) == set([
-        column('id'),
-        column('product_name'),
-        column('price')])
+    assert set(result) == set(testdata.columns('products', 'custom'))
 
 
 @pytest.mark.parametrize('text', [
@@ -229,10 +214,7 @@ def test_suggested_column_names_with_qualified_alias(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        column('id'),
-        column('product_name'),
-        column('price')])
+    assert set(result) == set(testdata.columns('products', 'custom'))
 
 def test_suggested_multiple_column_names(completer, complete_event):
     """
@@ -247,11 +229,8 @@ def test_suggested_multiple_column_names(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        column('id'),
-        column('product_name'),
-        column('price'),
-        ] + testdata.functions() +
+    assert set(result) == set(testdata.columns('products', 'custom') +
+        testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
         )
@@ -269,10 +248,7 @@ def test_suggested_multiple_column_names_with_alias(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        column('id'),
-        column('product_name'),
-        column('price')])
+    assert set(result) == set(testdata.columns('products', 'custom'))
 
 @pytest.mark.parametrize('text', [
     'SELECT x.id, y.product_name FROM custom.products x JOIN custom.products y ON ',
@@ -338,8 +314,8 @@ def test_suggest_columns_from_aliased_set_returning_function(completer, complete
     pos = len('select f.')
     result = completer.get_completions(Document(text=sql, cursor_position=pos),
                                        complete_event)
-    assert set(result) == set([
-        column('x')])
+    assert set(result) == set(
+        testdata.columns('set_returning_func', 'custom', 'functions'))
 
 @pytest.mark.parametrize('text', [
     'SELECT * FROM custom.set_returning_func()',
@@ -445,9 +421,7 @@ def test_suggest_columns_from_unquoted_table(completer, complete_event, text):
     pos = len('SELECT U.')
     result = completer.get_completions(Document(text=text, cursor_position=pos),
                                        complete_event)
-    assert set(result) == set([
-        column('id'),
-        column('phone_number')])
+    assert set(result) == set(testdata.columns('users', 'custom'))
 
 @pytest.mark.parametrize('text', [
     'SELECT U. FROM custom."Users" U',
@@ -457,6 +431,4 @@ def test_suggest_columns_from_quoted_table(completer, complete_event, text):
     pos = len('SELECT U.')
     result = completer.get_completions(Document(text=text, cursor_position=pos),
                                        complete_event)
-    assert set(result) == set([
-        column('userid'),
-        column('username')])
+    assert set(result) == set(testdata.columns('Users', 'custom'))

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -63,10 +63,7 @@ def test_schema_or_visible_table_completion(completer, complete_event):
     position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
-    assert set(result) == set(testdata.schemas() + [
-       function('func1'),
-       function('func2'),
-       ] + testdata.tables())
+    assert set(result) == set(testdata.schemas() + testdata.functions() + testdata.tables())
 
 
 @pytest.mark.parametrize('table', [
@@ -91,8 +88,7 @@ def test_suggested_column_names_from_shadowed_visible_table(completer, complete_
         column('email'),
         column('first_name'),
         column('last_name'),
-        function('func1'),
-        function('func2')] +
+        ] + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
         )
@@ -106,8 +102,7 @@ def test_suggested_column_names_from_qualified_shadowed_table(completer, complet
     assert set(result) == set([
         column('id'),
         column('phone_number'),
-        function('func1'),
-        function('func2')] +
+        ] + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
         )
@@ -143,8 +138,7 @@ def test_suggested_joins(completer, complete_event, query, tbl):
         complete_event))
     assert set(result) == set(testdata.schemas() + testdata.tables() + [
         join('custom.shipments ON shipments.user_id = {0}.id'.format(tbl)),
-        function('func1'),
-        function('func2')])
+        ] + testdata.functions())
 
 def test_suggested_column_names_from_schema_qualifed_table(completer, complete_event):
     """
@@ -161,8 +155,7 @@ def test_suggested_column_names_from_schema_qualifed_table(completer, complete_e
         column('id'),
         column('product_name'),
         column('price'),
-        function('func1'),
-        function('func2')] +
+        ] + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
         )
@@ -203,10 +196,8 @@ def test_suggested_table_names_with_schema_dot(completer, complete_event,
     position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
-    assert set(result) == set(testdata.tables('custom', start_pos) + [
-        function('func3', start_pos),
-        function('set_returning_func', start_pos),
-    ])
+    assert set(result) == set(testdata.tables('custom', start_pos)
+        + testdata.functions('custom', start_pos))
 
 @pytest.mark.parametrize('text', [
     'SELECT * FROM "Custom".',
@@ -223,10 +214,8 @@ def test_suggested_table_names_with_schema_dot2(completer, complete_event,
     position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
-    assert set(result) == set([
-        function('func4', start_pos)]
-        + testdata.tables('Custom', start_pos)
-    )
+    assert set(result) == set(testdata.functions('Custom', start_pos) +
+        testdata.tables('Custom', start_pos))
 
 def test_suggested_column_names_with_qualified_alias(completer, complete_event):
     """
@@ -262,8 +251,7 @@ def test_suggested_multiple_column_names(completer, complete_event):
         column('id'),
         column('product_name'),
         column('price'),
-        function('func1'),
-        function('func2')] +
+        ] + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
         )
@@ -318,10 +306,8 @@ def test_table_names_after_from(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set(testdata.schemas() + testdata.tables() + [
-        function('func1'),
-        function('func2'),
-        ])
+    assert set(result) == set(testdata.schemas() + testdata.tables()
+        + testdata.functions())
 
 def test_schema_qualified_function_name(completer, complete_event):
     text = 'SELECT custom.func'

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -7,43 +7,41 @@ from prompt_toolkit.document import Document
 from pgcli.packages.function_metadata import FunctionMetadata, ForeignKey
 
 metadata = {
-            'tables': {
-                'public':   {
-                                'users': ['id', 'email', 'first_name', 'last_name'],
-                                'orders': ['id', 'ordered_date', 'status'],
-                                'select': ['id', 'insert', 'ABC']
-                            },
-                'custom':   {
-                                'users': ['id', 'phone_number'],
-                                'Users': ['userid', 'username'],
-                                'products': ['id', 'product_name', 'price'],
-                                'shipments': ['id', 'address', 'user_id']
-                            },
-                'Custom':   {
-                                'projects': ['projectid', 'name']
-                            }},
-            'functions': {
-                            'public': [
-                                ['func1', [], [], [], '', False, False,
-                                    False],
-                                ['func2', [], [], [], '', False, False,
-                                    False]],
-                            'custom': [
-                                ['func3', [], [], [], '', False, False, False],
-                                ['set_returning_func', ['x'], ['integer'], ['o'],
-                                    'integer', False, False, True]],
-                            'Custom': [
-                                ['func4', [], [], [], '', False, False, False]]
-                         },
-            'datatypes': {
-                            'public':   ['typ1', 'typ2'],
-                            'custom':   ['typ3', 'typ4'],
-                         },
-                'foreignkeys': {
-                    'custom': [
-                    ('public', 'users', 'id', 'custom', 'shipments', 'user_id')
-                ]},
-            }
+    'tables': {
+        'public': {
+            'users': ['id', 'email', 'first_name', 'last_name'],
+            'orders': ['id', 'ordered_date', 'status'],
+            'select': ['id', 'insert', 'ABC']
+        },
+        'custom': {
+            'users': ['id', 'phone_number'],
+            'Users': ['userid', 'username'],
+            'products': ['id', 'product_name', 'price'],
+            'shipments': ['id', 'address', 'user_id']
+        },
+        'Custom': {
+            'projects': ['projectid', 'name']
+        }},
+    'functions': {
+        'public': [
+            ['func1', [], [], [], '', False, False, False],
+            ['func2', [], [], [], '', False, False, False]],
+        'custom': [
+            ['func3', [], [], [], '', False, False, False],
+            ['set_returning_func', ['x'], ['integer'], ['o'],
+                'integer', False, False, True]],
+        'Custom': [
+            ['func4', [], [], [], '', False, False, False]]
+     },
+    'datatypes': {
+        'public': ['typ1', 'typ2'],
+        'custom': ['typ3', 'typ4'],
+     },
+    'foreignkeys': {
+        'custom': [
+            ('public', 'users', 'id', 'custom', 'shipments', 'user_id')
+    ]},
+}
 
 testdata = MetaData(metadata)
 

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -5,7 +5,6 @@ from metadata import (MetaData, alias, name_join, fk_join, join,
     table,
     function,
     column,
-    datatype,
     wildcard_expansion)
 from prompt_toolkit.document import Document
 from pgcli.packages.function_metadata import FunctionMetadata, ForeignKey
@@ -357,9 +356,7 @@ def test_schema_qualified_type_name(text, completer, complete_event):
     pos = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event)
-    assert set(result) == set([
-        datatype('typ3'),
-        datatype('typ4'),
+    assert set(result) == set(testdata.datatypes('custom') + [
         table('users'),
         table('"Users"'),
         table('products'),

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -67,10 +67,7 @@ def test_schema_or_visible_table_completion(completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set(testdata.schemas()
-        + testdata.views() + testdata.tables() + [
-        function('custom_func1'),
-        function('custom_func2'),
-        function('set_returning_func')])
+        + testdata.views() + testdata.tables() + testdata.functions())
 
 
 def test_builtin_function_name_completion(completer, complete_event):
@@ -135,9 +132,7 @@ def test_suggested_column_names_from_visible_table(completer, complete_event):
         column('email'),
         column('first_name'),
         column('last_name'),
-        function('custom_func1'),
-        function('custom_func2'),
-    function('set_returning_func')] +
+        ] + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
         )
@@ -220,9 +215,7 @@ def test_suggested_multiple_column_names(completer, complete_event):
         column('email'),
         column('first_name'),
         column('last_name'),
-        function('custom_func1'),
-        function('custom_func2'),
-        function('set_returning_func')] +
+        ] + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
         )
@@ -377,9 +370,7 @@ def test_suggested_joins(completer, complete_event, text):
         join('"Users" ON "Users".userid = users.id'),
         join('users users2 ON users2.id = users.parentid'),
         join('users users2 ON users2.parentid = users.id'),
-        function('custom_func2'),
-        function('set_returning_func'),
-        function('custom_func1')])
+        ] + testdata.functions())
 
 @pytest.mark.parametrize('text', [
     'SELECT * FROM public."Users" JOIN ',
@@ -396,9 +387,7 @@ def test_suggested_joins_quoted_schema_qualified_table(completer, complete_event
     assert set(result) == set(testdata.schemas() + testdata.tables()
         + testdata.views() + [
         join('public.users ON users.id = "Users".userid'),
-        function('custom_func2'),
-        function('set_returning_func'),
-        function('custom_func1')])
+        ] + testdata.functions())
 
 @pytest.mark.parametrize('text', [
     'SELECT u.name, o.id FROM users u JOIN orders o ON ',
@@ -508,11 +497,7 @@ def test_table_names_after_from(completer, complete_event, text):
         Document(text=text, cursor_position=position),
         complete_event)
     assert set(result) == set(testdata.schemas() + testdata.tables()
-        + testdata.views() + [
-        function('custom_func1'),
-        function('custom_func2'),
-        function('set_returning_func')
-        ])
+        + testdata.views() + testdata.functions())
     assert [c.text for c in result] == [
         '"Users"',
         'custom_func1',
@@ -535,9 +520,7 @@ def test_auto_escaped_col_names(completer, complete_event):
         column('id'),
         column('"insert"'),
         column('"ABC"'),
-        function('custom_func1'),
-        function('custom_func2'),
-        function('set_returning_func')] +
+        ] + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
         )
@@ -588,9 +571,7 @@ def test_suggest_columns_from_set_returning_function(completer, complete_event):
     assert set(result) == set([
         column('x'),
         column('y'),
-        function('custom_func1'),
-        function('custom_func2'),
-        function('set_returning_func')]
+        ] + testdata.functions()
          + list(testdata.builtin_functions()
          + testdata.keywords()))
 

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -6,26 +6,26 @@ from prompt_toolkit.document import Document
 from pgcli.packages.function_metadata import FunctionMetadata, ForeignKey
 
 metadata = {
-                'tables': {
-                    'users': ['id', 'parentid', 'email', 'first_name', 'last_name'],
-                    'Users': ['userid', 'username'],
-                    'orders': ['id', 'ordered_date', 'status', 'email'],
-                    'select': ['id', 'insert', 'ABC']},
-                'views': {
-                    'user_emails': ['id', 'email']},
-                'functions': [
-                    ['custom_func1', [''], [''], [''], '', False, False,
-                        False],
-                    ['custom_func2', [''], [''], [''], '', False, False,
-                        False],
-                    ['set_returning_func', ['x', 'y'], ['integer', 'integer'],
-                        ['o', 'o'], '', False, False, True]],
-                'datatypes': ['custom_type1', 'custom_type2'],
-                'foreignkeys': [
-                    ('public', 'users', 'id', 'public', 'users', 'parentid'),
-                    ('public', 'users', 'id', 'public', 'Users', 'userid')
-                ],
-            }
+    'tables': {
+        'users': ['id', 'parentid', 'email', 'first_name', 'last_name'],
+        'Users': ['userid', 'username'],
+        'orders': ['id', 'ordered_date', 'status', 'email'],
+        'select': ['id', 'insert', 'ABC']},
+    'views': {
+        'user_emails': ['id', 'email']},
+    'functions': [
+        ['custom_func1', [''], [''], [''], '', False, False,
+            False],
+        ['custom_func2', [''], [''], [''], '', False, False,
+            False],
+        ['set_returning_func', ['x', 'y'], ['integer', 'integer'],
+            ['o', 'o'], '', False, False, True]],
+    'datatypes': ['custom_type1', 'custom_type2'],
+    'foreignkeys': [
+        ('public', 'users', 'id', 'public', 'users', 'parentid'),
+        ('public', 'users', 'id', 'public', 'Users', 'userid')
+    ],
+}
 
 metadata = dict((k, {'public': v}) for k, v in metadata.items())
 

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -67,11 +67,7 @@ def test_schema_or_visible_table_completion(completer, complete_event):
     position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
-    assert set(result) == set(testdata.schemas() + [
-        table('users'),
-        table('"Users"'),
-        table('"select"'),
-        table('orders'),
+    assert set(result) == set(testdata.schemas() + testdata.tables() + [
         view('user_emails'),
         function('custom_func1'),
         function('custom_func2'),
@@ -377,14 +373,10 @@ def test_suggested_joins(completer, complete_event, text):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set(testdata.schemas() + [
+    assert set(result) == set(testdata.schemas() + testdata.tables() + [
         join('"Users" ON "Users".userid = users.id'),
         join('users users2 ON users2.id = users.parentid'),
         join('users users2 ON users2.parentid = users.id'),
-        table('"Users"'),
-        table('"select"'),
-        table('orders'),
-        table('users'),
         view('user_emails'),
         function('custom_func2'),
         function('set_returning_func'),
@@ -402,12 +394,8 @@ def test_suggested_joins_quoted_schema_qualified_table(completer, complete_event
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set(testdata.schemas() + [
+    assert set(result) == set(testdata.schemas() + testdata.tables() + [
         join('public.users ON users.id = "Users".userid'),
-        table('"Users"'),
-        table('"select"'),
-        table('orders'),
-        table('users'),
         view('user_emails'),
         function('custom_func2'),
         function('set_returning_func'),
@@ -520,11 +508,7 @@ def test_table_names_after_from(completer, complete_event, text):
     result = completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event)
-    assert set(result) == set(testdata.schemas() + [
-        table('users'),
-        table('"Users"'),
-        table('orders'),
-        table('"select"'),
+    assert set(result) == set(testdata.schemas() + testdata.tables() + [
         view('user_emails'),
         function('custom_func1'),
         function('custom_func2'),
@@ -581,12 +565,8 @@ def test_suggest_datatype(text, completer, complete_event):
     pos = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event)
-    assert set(result) == set(testdata.schemas() + testdata.datatypes() + [
-        table('users'),
-        table('"Users"'),
-        table('orders'),
-        table('"select"')] +
-        list(testdata.builtin_datatypes()))
+    assert set(result) == set(testdata.schemas() + testdata.datatypes() +
+        testdata.tables() + list(testdata.builtin_datatypes()))
 
 
 def test_suggest_columns_from_escaped_table_alias(completer, complete_event):

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -5,7 +5,6 @@ from metadata import (MetaData, alias, name_join, fk_join, join, keyword,
     view,
     function,
     column,
-    schema,
     datatype,
     wildcard_expansion)
 from prompt_toolkit.document import Document
@@ -69,8 +68,7 @@ def test_schema_or_visible_table_completion(completer, complete_event):
     position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
-    assert set(result) == set([
-        schema('public'),
+    assert set(result) == set(testdata.schemas() + [
         table('users'),
         table('"Users"'),
         table('"select"'),
@@ -380,8 +378,7 @@ def test_suggested_joins(completer, complete_event, text):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        schema('public'),
+    assert set(result) == set(testdata.schemas() + [
         join('"Users" ON "Users".userid = users.id'),
         join('users users2 ON users2.id = users.parentid'),
         join('users users2 ON users2.parentid = users.id'),
@@ -406,9 +403,8 @@ def test_suggested_joins_quoted_schema_qualified_table(completer, complete_event
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
+    assert set(result) == set(testdata.schemas() + [
         join('public.users ON users.id = "Users".userid'),
-        schema('public'),
         table('"Users"'),
         table('"select"'),
         table('orders'),
@@ -525,8 +521,7 @@ def test_table_names_after_from(completer, complete_event, text):
     result = completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event)
-    assert set(result) == set([
-        schema('public'),
+    assert set(result) == set(testdata.schemas() + [
         table('users'),
         table('"Users"'),
         table('orders'),
@@ -587,8 +582,7 @@ def test_suggest_datatype(text, completer, complete_event):
     pos = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event)
-    assert set(result) == set([
-        schema('public'),
+    assert set(result) == set(testdata.schemas() + [
         datatype('custom_type1'),
         datatype('custom_type2'),
         table('users'),

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -1,6 +1,13 @@
 from __future__ import unicode_literals
 import pytest
-from prompt_toolkit.completion import Completion
+from metadata import (MetaData, alias, name_join, fk_join, join, keyword,
+    table,
+    view,
+    function,
+    column,
+    schema,
+    datatype,
+    wildcard_expansion)
 from prompt_toolkit.document import Document
 from pgcli.packages.function_metadata import FunctionMetadata, ForeignKey
 
@@ -26,50 +33,13 @@ metadata = {
                 ],
             }
 
+metadata = dict((k, {'public': v}) for k, v in metadata.items())
+
+testdata = MetaData(metadata)
+
 @pytest.fixture
 def completer():
-
-    import pgcli.pgcompleter as pgcompleter
-    comp = pgcompleter.PGCompleter(smart_completion=True)
-
-    schemata = ['public']
-    comp.extend_schemata(schemata)
-
-    # tables
-    tables, columns = [], []
-    for table, cols in metadata['tables'].items():
-        tables.append(('public', table))
-        # Let all columns be text columns
-        columns.extend([('public', table, col, 'text') for col in cols])
-
-    comp.extend_relations(tables, kind='tables')
-    comp.extend_columns(columns, kind='tables')
-
-    # views
-    views, columns = [], []
-    for view, cols in metadata['views'].items():
-        views.append(('public', view))
-        columns.extend([('public', view, col, 'text') for col in cols])
-
-    comp.extend_relations(views, kind='views')
-    comp.extend_columns(columns, kind='views')
-
-    # functions
-    functions = [FunctionMetadata('public', *func_meta)
-                 for func_meta in metadata['functions']]
-    comp.extend_functions(functions)
-
-    # types
-    datatypes = [('public', typ) for typ in metadata['datatypes']]
-    comp.extend_datatypes(datatypes)
-
-    # fks
-    foreignkeys = [ForeignKey(*fk) for fk in metadata['foreignkeys']]
-    comp.extend_foreignkeys(foreignkeys)
-
-    comp.set_search_path(['public'])
-
-    return comp
+    return testdata.completer
 
 @pytest.fixture
 def complete_event():
@@ -83,8 +53,7 @@ def test_empty_string_completion(completer, complete_event):
         completer.get_completions(
             Document(text=text, cursor_position=position),
             complete_event))
-    assert set(map(lambda x: Completion(x, display_meta='keyword'),
-                    completer.keywords)) == result
+    assert set(testdata.keywords()) == result
 
 def test_select_keyword_completion(completer, complete_event):
     text = 'SEL'
@@ -92,8 +61,7 @@ def test_select_keyword_completion(completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event)
-    assert set(result) == set([Completion(text='SELECT', start_position=-3,
-                                          display_meta='keyword')])
+    assert set(result) == set([keyword('SELECT', -3)])
 
 
 def test_schema_or_visible_table_completion(completer, complete_event):
@@ -102,15 +70,15 @@ def test_schema_or_visible_table_completion(completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([
-        Completion(text='public', start_position=0, display_meta='schema'),
-        Completion(text='users', start_position=0, display_meta='table'),
-        Completion(text='"Users"', start_position=0, display_meta='table'),
-        Completion(text='"select"', start_position=0, display_meta='table'),
-        Completion(text='orders', start_position=0, display_meta='table'),
-        Completion(text='user_emails', start_position=0, display_meta='view'),
-        Completion(text='custom_func1', start_position=0, display_meta='function'),
-        Completion(text='custom_func2', start_position=0, display_meta='function'),
-        Completion(text='set_returning_func', start_position=0, display_meta='function')])
+        schema('public'),
+        table('users'),
+        table('"Users"'),
+        table('"select"'),
+        table('orders'),
+        view('user_emails'),
+        function('custom_func1'),
+        function('custom_func2'),
+        function('set_returning_func')])
 
 
 def test_builtin_function_name_completion(completer, complete_event):
@@ -118,8 +86,8 @@ def test_builtin_function_name_completion(completer, complete_event):
     position = len('SELECT MA')
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
-    assert set(result) == set([Completion(text='MAX', start_position=-2, display_meta='function'),
-                               Completion(text='MAXEXTENTS', start_position=-2, display_meta='keyword'),
+    assert set(result) == set([function('MAX', -2),
+                               keyword('MAXEXTENTS', -2),
                               ])
 
 
@@ -140,9 +108,9 @@ def test_user_function_name_completion(completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([
-        Completion(text='custom_func1', start_position=-2, display_meta='function'),
-        Completion(text='custom_func2', start_position=-2, display_meta='function'),
-        Completion(text='CURRENT', start_position=-2, display_meta='keyword'),
+        function('custom_func1', -2),
+        function('custom_func2', -2),
+        keyword('CURRENT', -2),
         ])
 
 
@@ -153,8 +121,8 @@ def test_user_function_name_completion_matches_anywhere(completer,
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([
-        Completion(text='custom_func1', start_position=-2, display_meta='function'),
-        Completion(text='custom_func2', start_position=-2, display_meta='function')])
+        function('custom_func1', -2),
+        function('custom_func2', -2)])
 
 
 def test_suggested_column_names_from_visible_table(completer, complete_event):
@@ -170,16 +138,16 @@ def test_suggested_column_names_from_visible_table(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column'),
-        Completion(text='parentid', start_position=0, display_meta='column'),
-        Completion(text='email', start_position=0, display_meta='column'),
-        Completion(text='first_name', start_position=0, display_meta='column'),
-        Completion(text='last_name', start_position=0, display_meta='column'),
-        Completion(text='custom_func1', start_position=0, display_meta='function'),
-        Completion(text='custom_func2', start_position=0, display_meta='function'),
-    Completion(text='set_returning_func', start_position=0, display_meta='function')] +
-        list(map(lambda f: Completion(f, display_meta='function'), completer.functions)) +
-        list(map(lambda x: Completion(x, display_meta='keyword'), completer.keywords))
+        column('id'),
+        column('parentid'),
+        column('email'),
+        column('first_name'),
+        column('last_name'),
+        function('custom_func1'),
+        function('custom_func2'),
+    function('set_returning_func')] +
+        list(testdata.builtin_functions() +
+        testdata.keywords())
         )
 
 
@@ -197,11 +165,11 @@ def test_suggested_column_names_in_function(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event)
     assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column'),
-        Completion(text='parentid', start_position=0, display_meta='column'),
-        Completion(text='email', start_position=0, display_meta='column'),
-        Completion(text='first_name', start_position=0, display_meta='column'),
-        Completion(text='last_name', start_position=0, display_meta='column')])
+        column('id'),
+        column('parentid'),
+        column('email'),
+        column('first_name'),
+        column('last_name')])
 
 def test_suggested_column_names_with_table_dot(completer, complete_event):
     """
@@ -216,11 +184,11 @@ def test_suggested_column_names_with_table_dot(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column'),
-        Completion(text='parentid', start_position=0, display_meta='column'),
-        Completion(text='email', start_position=0, display_meta='column'),
-        Completion(text='first_name', start_position=0, display_meta='column'),
-        Completion(text='last_name', start_position=0, display_meta='column')])
+        column('id'),
+        column('parentid'),
+        column('email'),
+        column('first_name'),
+        column('last_name')])
 
 def test_suggested_column_names_with_alias(completer, complete_event):
     """
@@ -235,11 +203,11 @@ def test_suggested_column_names_with_alias(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column'),
-        Completion(text='parentid', start_position=0, display_meta='column'),
-        Completion(text='email', start_position=0, display_meta='column'),
-        Completion(text='first_name', start_position=0, display_meta='column'),
-        Completion(text='last_name', start_position=0, display_meta='column')])
+        column('id'),
+        column('parentid'),
+        column('email'),
+        column('first_name'),
+        column('last_name')])
 
 def test_suggested_multiple_column_names(completer, complete_event):
     """
@@ -255,16 +223,16 @@ def test_suggested_multiple_column_names(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column'),
-        Completion(text='parentid', start_position=0, display_meta='column'),
-        Completion(text='email', start_position=0, display_meta='column'),
-        Completion(text='first_name', start_position=0, display_meta='column'),
-        Completion(text='last_name', start_position=0, display_meta='column'),
-        Completion(text='custom_func1', start_position=0, display_meta='function'),
-        Completion(text='custom_func2', start_position=0, display_meta='function'),
-        Completion(text='set_returning_func', start_position=0, display_meta='function')] +
-        list(map(lambda f: Completion(f, display_meta='function'), completer.functions)) +
-        list(map(lambda x: Completion(x, display_meta='keyword'), completer.keywords))
+        column('id'),
+        column('parentid'),
+        column('email'),
+        column('first_name'),
+        column('last_name'),
+        function('custom_func1'),
+        function('custom_func2'),
+        function('set_returning_func')] +
+        list(testdata.builtin_functions() +
+        testdata.keywords())
         )
 
 def test_suggested_multiple_column_names_with_alias(completer, complete_event):
@@ -281,11 +249,11 @@ def test_suggested_multiple_column_names_with_alias(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column'),
-        Completion(text='parentid', start_position=0, display_meta='column'),
-        Completion(text='email', start_position=0, display_meta='column'),
-        Completion(text='first_name', start_position=0, display_meta='column'),
-        Completion(text='last_name', start_position=0, display_meta='column')])
+        column('id'),
+        column('parentid'),
+        column('email'),
+        column('first_name'),
+        column('last_name')])
 
 def test_suggested_multiple_column_names_with_dot(completer, complete_event):
     """
@@ -301,11 +269,11 @@ def test_suggested_multiple_column_names_with_dot(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column'),
-        Completion(text='parentid', start_position=0, display_meta='column'),
-        Completion(text='email', start_position=0, display_meta='column'),
-        Completion(text='first_name', start_position=0, display_meta='column'),
-        Completion(text='last_name', start_position=0, display_meta='column')])
+        column('id'),
+        column('parentid'),
+        column('email'),
+        column('first_name'),
+        column('last_name')])
 
 
 def test_suggest_columns_after_three_way_join(completer, complete_event):
@@ -315,7 +283,7 @@ def test_suggest_columns_after_three_way_join(completer, complete_event):
     position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
-    assert (Completion(text='id', start_position=0, display_meta='column') in
+    assert (column('id') in
             set(result))
 
 @pytest.mark.parametrize('text', [
@@ -338,9 +306,9 @@ def test_suggested_join_conditions(completer, complete_event, text):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='u', start_position=0, display_meta='table alias'),
-        Completion(text='u2', start_position=0, display_meta='table alias'),
-        Completion(text='u2.userid = u.id', start_position=0, display_meta='fk join')])
+        alias('u'),
+        alias('u2'),
+        fk_join('u2.userid = u.id')])
 
 @pytest.mark.parametrize('text', [
     '''SELECT *
@@ -356,14 +324,14 @@ def test_suggested_join_conditions_with_same_table_twice(completer, complete_eve
         Document(text=text, cursor_position=position),
         complete_event)
     assert result == [
-        Completion(text='u2.userid = u.id', start_position=0, display_meta='fk join'),
-        Completion(text='u2.userid = users.id', start_position=0, display_meta='fk join'),
-        Completion(text='u2.userid = "Users".userid', start_position=0, display_meta='name join'),
-        Completion(text='u2.username = "Users".username', start_position=0, display_meta='name join'),
-        Completion(text='"Users"', start_position=0, display_meta='table alias'),
-        Completion(text='u', start_position=0, display_meta='table alias'),
-        Completion(text='u2', start_position=0, display_meta='table alias'),
-        Completion(text='users', start_position=0, display_meta='table alias')]
+        fk_join('u2.userid = u.id'),
+        fk_join('u2.userid = users.id'),
+        name_join('u2.userid = "Users".userid'),
+        name_join('u2.username = "Users".username'),
+        alias('"Users"'),
+        alias('u'),
+        alias('u2'),
+        alias('users')]
 
 @pytest.mark.parametrize('text', [
     'SELECT * FROM users JOIN users u2 on foo.'
@@ -384,9 +352,7 @@ def test_suggested_join_conditions_with_invalid_table(completer, complete_event,
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        Completion(text='users', start_position=0, display_meta='table alias'),
-        Completion(text=ref, start_position=0, display_meta='table alias')])
+    assert set(result) == set([alias('users'), alias(ref)])
 
 @pytest.mark.parametrize('text', [
     'SELECT * FROM "Users" u JOIN u',
@@ -400,8 +366,7 @@ def test_suggested_joins_fuzzy(completer, complete_event, text):
         Document(text=text, cursor_position=position),
         complete_event))
     last_word = text.split()[-1]
-    expected = Completion(text='users ON users.id = u.userid',
-                          start_position=-len(last_word), display_meta='join')
+    expected = join('users ON users.id = u.userid', -len(last_word))
     assert expected in result
 
 @pytest.mark.parametrize('text', [
@@ -416,18 +381,18 @@ def test_suggested_joins(completer, complete_event, text):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='"Users" ON "Users".userid = users.id', start_position=0, display_meta='join'),
-        Completion(text='users users2 ON users2.id = users.parentid', start_position=0, display_meta='join'),
-        Completion(text='users users2 ON users2.parentid = users.id', start_position=0, display_meta='join'),
-        Completion(text='public', start_position=0, display_meta='schema'),
-        Completion(text='"Users"', start_position=0, display_meta='table'),
-        Completion(text='"select"', start_position=0, display_meta='table'),
-        Completion(text='orders', start_position=0, display_meta='table'),
-        Completion(text='users', start_position=0, display_meta='table'),
-        Completion(text='user_emails', start_position=0, display_meta='view'),
-        Completion(text='custom_func2', start_position=0, display_meta='function'),
-        Completion(text='set_returning_func', start_position=0, display_meta='function'),
-        Completion(text='custom_func1', start_position=0, display_meta='function')])
+        schema('public'),
+        join('"Users" ON "Users".userid = users.id'),
+        join('users users2 ON users2.id = users.parentid'),
+        join('users users2 ON users2.parentid = users.id'),
+        table('"Users"'),
+        table('"select"'),
+        table('orders'),
+        table('users'),
+        view('user_emails'),
+        function('custom_func2'),
+        function('set_returning_func'),
+        function('custom_func1')])
 
 @pytest.mark.parametrize('text', [
     'SELECT * FROM public."Users" JOIN ',
@@ -442,16 +407,16 @@ def test_suggested_joins_quoted_schema_qualified_table(completer, complete_event
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='public.users ON users.id = "Users".userid', start_position=0, display_meta='join'),
-        Completion(text='public', start_position=0, display_meta='schema'),
-        Completion(text='"Users"', start_position=0, display_meta='table'),
-        Completion(text='"select"', start_position=0, display_meta='table'),
-        Completion(text='orders', start_position=0, display_meta='table'),
-        Completion(text='users', start_position=0, display_meta='table'),
-        Completion(text='user_emails', start_position=0, display_meta='view'),
-        Completion(text='custom_func2', start_position=0, display_meta='function'),
-        Completion(text='set_returning_func', start_position=0, display_meta='function'),
-        Completion(text='custom_func1', start_position=0, display_meta='function')])
+        join('public.users ON users.id = "Users".userid'),
+        schema('public'),
+        table('"Users"'),
+        table('"select"'),
+        table('orders'),
+        table('users'),
+        view('user_emails'),
+        function('custom_func2'),
+        function('set_returning_func'),
+        function('custom_func1')])
 
 @pytest.mark.parametrize('text', [
     'SELECT u.name, o.id FROM users u JOIN orders o ON ',
@@ -463,10 +428,10 @@ def test_suggested_aliases_after_on(completer, complete_event, text):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='u', start_position=0, display_meta='table alias'),
-        Completion(text='o.id = u.id', start_position=0, display_meta='name join'),
-        Completion(text='o.email = u.email', start_position=0, display_meta='name join'),
-        Completion(text='o', start_position=0, display_meta='table alias')])
+        alias('u'),
+        name_join('o.id = u.id'),
+        name_join('o.email = u.email'),
+        alias('o')])
 
 @pytest.mark.parametrize('text', [
     'SELECT u.name, o.id FROM users u JOIN orders o ON o.user_id = ',
@@ -478,8 +443,8 @@ def test_suggested_aliases_after_on_right_side(completer, complete_event, text):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='u', start_position=0, display_meta='table alias'),
-        Completion(text='o', start_position=0, display_meta='table alias')])
+        alias('u'),
+        alias('o')])
 
 @pytest.mark.parametrize('text', [
     'SELECT users.name, orders.id FROM users JOIN orders ON ',
@@ -491,10 +456,10 @@ def test_suggested_tables_after_on(completer, complete_event, text):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='orders.id = users.id', start_position=0, display_meta='name join'),
-        Completion(text='orders.email = users.email', start_position=0, display_meta='name join'),
-        Completion(text='users', start_position=0, display_meta='table alias'),
-        Completion(text='orders', start_position=0, display_meta='table alias')])
+        name_join('orders.id = users.id'),
+        name_join('orders.email = users.email'),
+        alias('users'),
+        alias('orders')])
 
 @pytest.mark.parametrize('text', [
     'SELECT users.name, orders.id FROM users JOIN orders ON orders.user_id = JOIN orders orders2 ON',
@@ -506,8 +471,8 @@ def test_suggested_tables_after_on_right_side(completer, complete_event, text):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='users', start_position=0, display_meta='table alias'),
-        Completion(text='orders', start_position=0, display_meta='table alias')])
+        alias('users'),
+        alias('orders')])
 
 @pytest.mark.parametrize('text', [
     'SELECT * FROM users INNER JOIN orders USING (',
@@ -518,8 +483,8 @@ def test_join_using_suggests_common_columns(completer, complete_event, text):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event))
     assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column'),
-        Completion(text='email', start_position=0, display_meta='column'),
+        column('id'),
+        column('email'),
         ])
 
 @pytest.mark.parametrize('text', [
@@ -533,8 +498,8 @@ def test_join_using_suggests_from_last_table(completer, complete_event, text):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event))
     assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column'),
-        Completion(text='email', start_position=0, display_meta='column'),
+        column('id'),
+        column('email'),
         ])
 
 @pytest.mark.parametrize('text', [
@@ -546,8 +511,8 @@ def test_join_using_suggests_columns_after_first_column(completer, complete_even
     result = set(completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event))
     assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column'),
-        Completion(text='email', start_position=0, display_meta='column'),
+        column('id'),
+        column('email'),
         ])
 
 @pytest.mark.parametrize('text', [
@@ -561,15 +526,15 @@ def test_table_names_after_from(completer, complete_event, text):
         Document(text=text, cursor_position=position),
         complete_event)
     assert set(result) == set([
-        Completion(text='public', start_position=0, display_meta='schema'),
-        Completion(text='users', start_position=0, display_meta='table'),
-        Completion(text='"Users"', start_position=0, display_meta='table'),
-        Completion(text='orders', start_position=0, display_meta='table'),
-        Completion(text='"select"', start_position=0, display_meta='table'),
-        Completion(text='user_emails', start_position=0, display_meta='view'),
-        Completion(text='custom_func1', start_position=0, display_meta='function'),
-        Completion(text='custom_func2', start_position=0, display_meta='function'),
-        Completion(text='set_returning_func', start_position=0, display_meta='function')
+        schema('public'),
+        table('users'),
+        table('"Users"'),
+        table('orders'),
+        table('"select"'),
+        view('user_emails'),
+        function('custom_func1'),
+        function('custom_func2'),
+        function('set_returning_func')
         ])
     assert [c.text for c in result] == [
         '"Users"',
@@ -590,14 +555,14 @@ def test_auto_escaped_col_names(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column'),
-        Completion(text='"insert"', start_position=0, display_meta='column'),
-        Completion(text='"ABC"', start_position=0, display_meta='column'),
-        Completion(text='custom_func1', start_position=0, display_meta='function'),
-        Completion(text='custom_func2', start_position=0, display_meta='function'),
-        Completion(text='set_returning_func', start_position=0, display_meta='function')] +
-        list(map(lambda f: Completion(f, display_meta='function'), completer.functions)) +
-        list(map(lambda x: Completion(x, display_meta='keyword'), completer.keywords))
+        column('id'),
+        column('"insert"'),
+        column('"ABC"'),
+        function('custom_func1'),
+        function('custom_func2'),
+        function('set_returning_func')] +
+        list(testdata.builtin_functions() +
+        testdata.keywords())
         )
 
 
@@ -607,7 +572,7 @@ def test_allow_leading_double_quote_in_last_word(completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
 
-    expected = Completion(text='"select"', start_position=-5, display_meta='table')
+    expected = table('"select"', -5)
 
     assert expected in set(result)
 
@@ -623,14 +588,14 @@ def test_suggest_datatype(text, completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event)
     assert set(result) == set([
-        Completion(text='custom_type1', start_position=0, display_meta='datatype'),
-        Completion(text='custom_type2', start_position=0, display_meta='datatype'),
-        Completion(text='public', start_position=0, display_meta='schema'),
-        Completion(text='users', start_position=0, display_meta='table'),
-        Completion(text='"Users"', start_position=0, display_meta='table'),
-        Completion(text='orders', start_position=0, display_meta='table'),
-        Completion(text='"select"', start_position=0, display_meta='table')] +
-        list(map(lambda f: Completion(f, display_meta='datatype'), completer.datatypes)))
+        schema('public'),
+        datatype('custom_type1'),
+        datatype('custom_type2'),
+        table('users'),
+        table('"Users"'),
+        table('orders'),
+        table('"select"')] +
+        list(testdata.builtin_datatypes()))
 
 
 def test_suggest_columns_from_escaped_table_alias(completer, complete_event):
@@ -639,9 +604,9 @@ def test_suggest_columns_from_escaped_table_alias(completer, complete_event):
     result = completer.get_completions(Document(text=sql, cursor_position=pos),
                                        complete_event)
     assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column'),
-        Completion(text='"insert"', start_position=0, display_meta='column'),
-        Completion(text='"ABC"', start_position=0, display_meta='column'),
+        column('id'),
+        column('"insert"'),
+        column('"ABC"'),
     ])
 
 
@@ -651,13 +616,13 @@ def test_suggest_columns_from_set_returning_function(completer, complete_event):
     result = completer.get_completions(Document(text=sql, cursor_position=pos),
                                        complete_event)
     assert set(result) == set([
-        Completion(text='x', start_position=0, display_meta='column'),
-        Completion(text='y', start_position=0, display_meta='column'),
-        Completion(text='custom_func1', start_position=0, display_meta='function'),
-        Completion(text='custom_func2', start_position=0, display_meta='function'),
-        Completion(text='set_returning_func', start_position=0, display_meta='function')]
-         + list(map(lambda f: Completion(f, display_meta='function'), completer.functions))
-         + list(map(lambda x: Completion(x, display_meta='keyword'), completer.keywords)))
+        column('x'),
+        column('y'),
+        function('custom_func1'),
+        function('custom_func2'),
+        function('set_returning_func')]
+         + list(testdata.builtin_functions()
+         + testdata.keywords()))
 
 
 def test_suggest_columns_from_aliased_set_returning_function(completer, complete_event):
@@ -666,8 +631,8 @@ def test_suggest_columns_from_aliased_set_returning_function(completer, complete
     result = completer.get_completions(Document(text=sql, cursor_position=pos),
                                        complete_event)
     assert set(result) == set([
-        Completion(text='x', start_position=0, display_meta='column'),
-        Completion(text='y', start_position=0, display_meta='column')])
+        column('x'),
+        column('y')])
 
 
 def test_join_functions_using_suggests_common_columns(completer, complete_event):
@@ -677,8 +642,8 @@ def test_join_functions_using_suggests_common_columns(completer, complete_event)
     result = set(completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event))
     assert set(result) == set([
-         Completion(text='x', start_position=0, display_meta='column'),
-         Completion(text='y', start_position=0, display_meta='column')])
+         column('x'),
+         column('y')])
 
 
 def test_join_functions_on_suggests_columns_and_join_conditions(completer, complete_event):
@@ -688,10 +653,10 @@ def test_join_functions_on_suggests_columns_and_join_conditions(completer, compl
     result = set(completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event))
     assert set(result) == set([
-         Completion(text='y = f2.y', start_position=0, display_meta='name join'),
-         Completion(text='x = f2.x', start_position=0, display_meta='name join'),
-         Completion(text='x', start_position=0, display_meta='column'),
-         Completion(text='y', start_position=0, display_meta='column')])
+         name_join('y = f2.y'),
+         name_join('x = f2.x'),
+         column('x'),
+         column('y')])
 
 
 def test_learn_keywords(completer, complete_event):
@@ -715,8 +680,8 @@ def test_learn_table_names(completer, complete_event):
         Document(text=sql, cursor_position=len(sql)), complete_event)
 
     # `users` should be higher priority than `orders` (used more often)
-    users = Completion(text='users', start_position=0, display_meta='table')
-    orders = Completion(text='orders', start_position=0, display_meta='table')
+    users = table('users')
+    orders = table('orders')
 
     assert completions.index(users) < completions.index(orders)
 
@@ -726,10 +691,10 @@ def test_columns_before_keywords(completer, complete_event):
     completions = completer.get_completions(
         Document(text=sql, cursor_position=len(sql)), complete_event)
 
-    column = Completion(text='status', start_position=-1, display_meta='column')
-    keyword = Completion(text='SELECT', start_position=-1, display_meta='keyword')
+    col = column('status', -1)
+    kw = keyword('SELECT', -1)
 
-    assert completions.index(column) < completions.index(keyword)
+    assert completions.index(col) < completions.index(kw)
 
 
 def test_wildcard_column_expansion(completer, complete_event):
@@ -740,8 +705,7 @@ def test_wildcard_column_expansion(completer, complete_event):
         Document(text=sql, cursor_position=pos), complete_event)
 
     col_list = 'id, parentid, email, first_name, last_name'
-    expected = [Completion(text=col_list, start_position=-1,
-                          display='*', display_meta='columns')]
+    expected = [wildcard_expansion(col_list)]
 
     assert expected == completions
 
@@ -754,8 +718,7 @@ def test_wildcard_column_expansion_with_alias_qualifier(completer, complete_even
         Document(text=sql, cursor_position=pos), complete_event)
 
     col_list = 'id, u.parentid, u.email, u.first_name, u.last_name'
-    expected = [Completion(text=col_list, start_position=-1,
-                          display='*', display_meta='columns')]
+    expected = [wildcard_expansion(col_list)]
 
     assert expected == completions
 
@@ -771,8 +734,7 @@ def test_wildcard_column_expansion_with_table_qualifier(completer, complete_even
     completions = completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event)
 
-    expected = [Completion(text=expected, start_position=-1,
-                          display='*', display_meta='columns')]
+    expected = [wildcard_expansion(expected)]
 
     assert expected == completions
 
@@ -785,8 +747,7 @@ def test_wildcard_column_expansion_with_two_tables(completer, complete_event):
 
     cols = ('"select".id, "select"."insert", "select"."ABC", '
         'u.id, u.parentid, u.email, u.first_name, u.last_name')
-    expected = [Completion(text=cols, start_position=-1,
-        display='*', display_meta='columns')]
+    expected = [wildcard_expansion(cols)]
     assert completions == expected
 
 
@@ -798,8 +759,7 @@ def test_wildcard_column_expansion_with_two_tables_and_parent(completer, complet
         Document(text=sql, cursor_position=pos), complete_event)
 
     col_list = 'id, "select"."insert", "select"."ABC"'
-    expected = [Completion(text=col_list, start_position=-1,
-                          display='*', display_meta='columns')]
+    expected = [wildcard_expansion(col_list)]
 
     assert expected == completions
 
@@ -814,11 +774,11 @@ def test_suggest_columns_from_unquoted_table(completer, complete_event, text):
     result = completer.get_completions(Document(text=text, cursor_position=pos),
                                        complete_event)
     assert set(result) == set([
-        Completion(text='id', start_position=0, display_meta='column'),
-        Completion(text='parentid', start_position=0, display_meta='column'),
-        Completion(text='email', start_position=0, display_meta='column'),
-        Completion(text='first_name', start_position=0, display_meta='column'),
-        Completion(text='last_name', start_position=0, display_meta='column')])
+        column('id'),
+        column('parentid'),
+        column('email'),
+        column('first_name'),
+        column('last_name')])
 
 
 def test_suggest_columns_from_quoted_table(completer, complete_event):
@@ -827,5 +787,5 @@ def test_suggest_columns_from_quoted_table(completer, complete_event):
     result = completer.get_completions(Document(text=text, cursor_position=pos),
                                        complete_event)
     assert set(result) == set([
-        Completion(text='userid', start_position=0, display_meta='column'),
-        Completion(text='username', start_position=0, display_meta='column')])
+        column('userid'),
+        column('username')])

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -1,10 +1,7 @@
 from __future__ import unicode_literals
 import pytest
 from metadata import (MetaData, alias, name_join, fk_join, join, keyword,
-    table,
-    function,
-    column,
-    wildcard_expansion)
+    table, function, column, wildcard_expansion)
 from prompt_toolkit.document import Document
 from pgcli.packages.function_metadata import FunctionMetadata, ForeignKey
 
@@ -126,13 +123,7 @@ def test_suggested_column_names_from_visible_table(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        column('id'),
-        column('parentid'),
-        column('email'),
-        column('first_name'),
-        column('last_name'),
-        ] + testdata.functions() +
+    assert set(result) == set(testdata.columns('users') + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
         )
@@ -151,12 +142,7 @@ def test_suggested_column_names_in_function(completer, complete_event):
     result = completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event)
-    assert set(result) == set([
-        column('id'),
-        column('parentid'),
-        column('email'),
-        column('first_name'),
-        column('last_name')])
+    assert set(result) == set(testdata.columns('users'))
 
 def test_suggested_column_names_with_table_dot(completer, complete_event):
     """
@@ -170,12 +156,7 @@ def test_suggested_column_names_with_table_dot(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        column('id'),
-        column('parentid'),
-        column('email'),
-        column('first_name'),
-        column('last_name')])
+    assert set(result) == set(testdata.columns('users'))
 
 def test_suggested_column_names_with_alias(completer, complete_event):
     """
@@ -189,12 +170,7 @@ def test_suggested_column_names_with_alias(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        column('id'),
-        column('parentid'),
-        column('email'),
-        column('first_name'),
-        column('last_name')])
+    assert set(result) == set(testdata.columns('users'))
 
 def test_suggested_multiple_column_names(completer, complete_event):
     """
@@ -209,13 +185,7 @@ def test_suggested_multiple_column_names(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        column('id'),
-        column('parentid'),
-        column('email'),
-        column('first_name'),
-        column('last_name'),
-        ] + testdata.functions() +
+    assert set(result) == set(testdata.columns('users') + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
         )
@@ -233,12 +203,7 @@ def test_suggested_multiple_column_names_with_alias(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        column('id'),
-        column('parentid'),
-        column('email'),
-        column('first_name'),
-        column('last_name')])
+    assert set(result) == set(testdata.columns('users'))
 
 def test_suggested_multiple_column_names_with_dot(completer, complete_event):
     """
@@ -253,12 +218,7 @@ def test_suggested_multiple_column_names_with_dot(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        column('id'),
-        column('parentid'),
-        column('email'),
-        column('first_name'),
-        column('last_name')])
+    assert set(result) == set(testdata.columns('users'))
 
 
 def test_suggest_columns_after_three_way_join(completer, complete_event):
@@ -516,10 +476,7 @@ def test_auto_escaped_col_names(completer, complete_event):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set([
-        column('id'),
-        column('"insert"'),
-        column('"ABC"'),
+    assert set(result) == set(testdata.columns('select') + [
         ] + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
@@ -556,11 +513,7 @@ def test_suggest_columns_from_escaped_table_alias(completer, complete_event):
     pos = len(sql)
     result = completer.get_completions(Document(text=sql, cursor_position=pos),
                                        complete_event)
-    assert set(result) == set([
-        column('id'),
-        column('"insert"'),
-        column('"ABC"'),
-    ])
+    assert set(result) == set(testdata.columns('select'))
 
 
 def test_suggest_columns_from_set_returning_function(completer, complete_event):
@@ -568,12 +521,11 @@ def test_suggest_columns_from_set_returning_function(completer, complete_event):
     pos = len('select ')
     result = completer.get_completions(Document(text=sql, cursor_position=pos),
                                        complete_event)
-    assert set(result) == set([
-        column('x'),
-        column('y'),
-        ] + testdata.functions()
-         + list(testdata.builtin_functions()
-         + testdata.keywords()))
+    assert set(result) == set(
+        testdata.columns('set_returning_func', typ='functions')
+        + testdata.functions()
+        + list(testdata.builtin_functions()
+        + testdata.keywords()))
 
 
 def test_suggest_columns_from_aliased_set_returning_function(completer, complete_event):
@@ -581,9 +533,7 @@ def test_suggest_columns_from_aliased_set_returning_function(completer, complete
     pos = len('select f.')
     result = completer.get_completions(Document(text=sql, cursor_position=pos),
                                        complete_event)
-    assert set(result) == set([
-        column('x'),
-        column('y')])
+    assert set(result) == set(testdata.columns('set_returning_func', typ='functions'))
 
 
 def test_join_functions_using_suggests_common_columns(completer, complete_event):
@@ -592,9 +542,8 @@ def test_join_functions_using_suggests_common_columns(completer, complete_event)
     pos = len(text)
     result = set(completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event))
-    assert set(result) == set([
-         column('x'),
-         column('y')])
+    assert set(result) == set(
+        testdata.columns('set_returning_func', typ='functions'))
 
 
 def test_join_functions_on_suggests_columns_and_join_conditions(completer, complete_event):
@@ -606,8 +555,7 @@ def test_join_functions_on_suggests_columns_and_join_conditions(completer, compl
     assert set(result) == set([
          name_join('y = f2.y'),
          name_join('x = f2.x'),
-         column('x'),
-         column('y')])
+         ] + testdata.columns('set_returning_func', typ='functions'))
 
 
 def test_learn_keywords(completer, complete_event):
@@ -724,12 +672,7 @@ def test_suggest_columns_from_unquoted_table(completer, complete_event, text):
     pos = len('SELECT U.')
     result = completer.get_completions(Document(text=text, cursor_position=pos),
                                        complete_event)
-    assert set(result) == set([
-        column('id'),
-        column('parentid'),
-        column('email'),
-        column('first_name'),
-        column('last_name')])
+    assert set(result) == set(testdata.columns('users'))
 
 
 def test_suggest_columns_from_quoted_table(completer, complete_event):
@@ -737,6 +680,4 @@ def test_suggest_columns_from_quoted_table(completer, complete_event):
     pos = len('SELECT U.')
     result = completer.get_completions(Document(text=text, cursor_position=pos),
                                        complete_event)
-    assert set(result) == set([
-        column('userid'),
-        column('username')])
+    assert set(result) == set(testdata.columns('Users'))

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -5,7 +5,6 @@ from metadata import (MetaData, alias, name_join, fk_join, join, keyword,
     view,
     function,
     column,
-    datatype,
     wildcard_expansion)
 from prompt_toolkit.document import Document
 from pgcli.packages.function_metadata import FunctionMetadata, ForeignKey
@@ -582,9 +581,7 @@ def test_suggest_datatype(text, completer, complete_event):
     pos = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=pos), complete_event)
-    assert set(result) == set(testdata.schemas() + [
-        datatype('custom_type1'),
-        datatype('custom_type2'),
+    assert set(result) == set(testdata.schemas() + testdata.datatypes() + [
         table('users'),
         table('"Users"'),
         table('orders'),

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 import pytest
 from metadata import (MetaData, alias, name_join, fk_join, join, keyword,
     table,
-    view,
     function,
     column,
     wildcard_expansion)
@@ -67,8 +66,8 @@ def test_schema_or_visible_table_completion(completer, complete_event):
     position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
-    assert set(result) == set(testdata.schemas() + testdata.tables() + [
-        view('user_emails'),
+    assert set(result) == set(testdata.schemas()
+        + testdata.views() + testdata.tables() + [
         function('custom_func1'),
         function('custom_func2'),
         function('set_returning_func')])
@@ -373,11 +372,11 @@ def test_suggested_joins(completer, complete_event, text):
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set(testdata.schemas() + testdata.tables() + [
+    assert set(result) == set(testdata.schemas() + testdata.tables()
+        + testdata.views() + [
         join('"Users" ON "Users".userid = users.id'),
         join('users users2 ON users2.id = users.parentid'),
         join('users users2 ON users2.parentid = users.id'),
-        view('user_emails'),
         function('custom_func2'),
         function('set_returning_func'),
         function('custom_func1')])
@@ -394,9 +393,9 @@ def test_suggested_joins_quoted_schema_qualified_table(completer, complete_event
     result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
-    assert set(result) == set(testdata.schemas() + testdata.tables() + [
+    assert set(result) == set(testdata.schemas() + testdata.tables()
+        + testdata.views() + [
         join('public.users ON users.id = "Users".userid'),
-        view('user_emails'),
         function('custom_func2'),
         function('set_returning_func'),
         function('custom_func1')])
@@ -508,8 +507,8 @@ def test_table_names_after_from(completer, complete_event, text):
     result = completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event)
-    assert set(result) == set(testdata.schemas() + testdata.tables() + [
-        view('user_emails'),
+    assert set(result) == set(testdata.schemas() + testdata.tables()
+        + testdata.views() + [
         function('custom_func1'),
         function('custom_func2'),
         function('set_returning_func')


### PR DESCRIPTION
@darikg you mind taking a look at this?

This PR has two parts (plus some cosmetic changes):
1. The first commit just consolidates existing duplicated logic in the two test_smart_completion* files into a new file. 
2. Then there are a six commits that make it so that, for some type of completion (table, column, ...), instead of listing every individual completion we expect to get, we just say what kind of completions to get from the test `metadata` dict. E.g. instead of listing every table in the schema `foo` (say for `SELECT * FROM foo.<cursor>`), we simply say we expect `testdata.tables('foo')`. This means we get to write less test code and that fewer tests will break when we expand the test data. 