### PR TITLE
Fix link to Click

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,7 +187,7 @@ library rather than listing it as a dependency in setup.py, is because I had to
 make a change to the table format which is merged back into the original repo,
 but not yet released in PyPI.
 
-`Click <http://click.pocoo.org/3/>`_ is used for command line option parsing
+`Click <http://click.pocoo.org/>`_ is used for command line option parsing
 and printing error messages.
 
 Thanks to `psycopg <http://initd.org/psycopg/>`_ for providing a rock solid


### PR DESCRIPTION
Click 3 is no more. I'd suggest linking to the root of the Click website and letting it redirect to the current stable version since they seem to be removing pages for the older versions.