### PR TITLE
Repair exception thrown on urls with ports

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -262,7 +262,7 @@ class PGCli(object):
         arguments = [database, uri.hostname, uri.username,
                      uri.port, uri.password]
         # unquote each URI part (they may be percent encoded)
-        self.connect(*list(map(lambda p: unquote(p) if p else p, arguments)))
+        self.connect(*list(map(lambda p: unquote(str(p)) if p else p, arguments)))
 
     def connect(self, database='', host='', user='', port='', passwd='',
                 dsn=''):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -90,3 +90,10 @@ def test_quoted_db_uri(tmpdir):
         cli = PGCli(pgclirc_file=str(tmpdir.join("rcfile")))
         cli.connect_uri('postgres://bar%5E:%5Dfoo@baz.com/testdb%5B')
     mock_connect.assert_called_with('testdb[', 'baz.com', 'bar^', None, ']foo')
+
+
+def test_port_db_uri(tmpdir):
+    with mock.patch.object(PGCli, 'connect') as mock_connect:
+        cli = PGCli(pgclirc_file=str(tmpdir.join("rcfile")))
+        cli.connect_uri('postgres://bar:foo@baz.com:2543/testdb')
+    mock_connect.assert_called_with('testdb', 'baz.com', 'bar', '2543', 'foo')


### PR DESCRIPTION
When the database URL contains a port, uri.port is (at least in Python 2.7.6) an integer, not a string, so urlparse.unquote chokes on it.
Fixes issue #536, but is probably worth verifying on Python 3.