### PR TITLE
configurable null format

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -85,6 +85,7 @@ class NullHandler(logging.Handler):
 class PGCli(object):
 
     default_prompt = '\\u@\\h:\\d> '
+    default_null_string = '<null>'
 
     def set_default_pager(self, config):
         configured_pager = config['main'].get('pager')
@@ -132,8 +133,8 @@ class PGCli(object):
         self.cli_style = c['colors']
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
         self.less_chatty = c['main'].as_bool('less_chatty')
+        self.null_string = c['main'].get('null_string', self.default_null_string).decode('utf-8')
         self.prompt_format = c['main'].get('prompt', self.default_prompt)
-
         self.on_error = c['main']['on_error'].upper()
 
         self.completion_refresher = CompletionRefresher()
@@ -407,6 +408,7 @@ class PGCli(object):
                     logger.error("sql: %r, error: %r", document.text, e)
                     logger.error("traceback: %r", traceback.format_exc())
                     click.secho(str(e), err=True, fg='red')
+                    traceback.print_exc()
                 else:
                     try:
                         if self.output_file and not document.text.startswith(('\\o ', '\\? ')):
@@ -561,7 +563,7 @@ class PGCli(object):
                 max_width = None
 
             formatted = format_output(
-                title, cur, headers, status, self.table_format,
+                title, cur, headers, status, self.table_format, self.null_string,
                 self.pgspecial.expanded_output, max_width)
 
             output.extend(formatted)
@@ -761,21 +763,21 @@ def obfuscate_process_password():
 
     setproctitle.setproctitle(process_title)
 
-def format_output(title, cur, headers, status, table_format, expanded=False, max_width=None):
+def format_output(title, cur, headers, status, table_format, missingval, expanded=False, max_width=None):
     output = []
     if title:  # Only print the title if it's not None.
         output.append(title)
     if cur:
         headers = [utf8tounicode(x) for x in headers]
         if expanded and headers:
-            output.append(expanded_table(cur, headers))
+            output.append(expanded_table(cur, headers, missingval))
         else:
             tabulated, rows = tabulate(cur, headers, tablefmt=table_format,
-                missingval='<null>')
+                missingval=missingval)
             if (max_width and rows and
                     content_exceeds_width(rows[0], max_width) and
                     headers):
-                output.append(expanded_table(rows, headers))
+                output.append(expanded_table(rows, headers, missingval))
             else:
                 output.append(tabulated)
     if status:  # Only print the status if it's not None.

--- a/pgcli/packages/expanded.py
+++ b/pgcli/packages/expanded.py
@@ -3,7 +3,7 @@ from .tabulate import _text_type
 def pad(field, total, char=u" "):
     return field + (char * (total - len(field)))
 
-def expanded_table(rows, headers):
+def expanded_table(rows, headers, missingval=u""):
     header_len = max([len(x) for x in headers])
     max_row_len = 0
     results = []
@@ -19,7 +19,7 @@ def expanded_table(rows, headers):
             max_row_len = row_len
 
         for header, value in zip(padded_headers, row):
-            value = '<null>' if value is None else value
+            value = missingval if value is None else value
             row_result.append((u"%s" % header) + " " + (u"%s" % value).strip())
 
         results.append('\n'.join(row_result))


### PR DESCRIPTION
Allows a configurable string for the null result. 

I like to use `⊥` to visually distinguish from normal text, so the config value needs to be decoded to unicode.  Such decoding should probably be applied to other formatting options, e.g. the prompt.

Ideally, the output formatting would be themeable to make nulls, and other types, more distinguishable!
