### PR TITLE
configurable null format

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -85,7 +85,6 @@ class NullHandler(logging.Handler):
 class PGCli(object):
 
     default_prompt = '\\u@\\h:\\d> '
-    default_null_string = '<null>'
 
     def set_default_pager(self, config):
         configured_pager = config['main'].get('pager')
@@ -133,7 +132,7 @@ class PGCli(object):
         self.cli_style = c['colors']
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
         self.less_chatty = c['main'].as_bool('less_chatty')
-        self.null_string = c['main'].get('null_string', self.default_null_string).decode('utf-8')
+        self.null_string = c['main'].get('null_string', '<null>').decode('utf-8')
         self.prompt_format = c['main'].get('prompt', self.default_prompt)
         self.on_error = c['main']['on_error'].upper()
 
@@ -762,7 +761,7 @@ def obfuscate_process_password():
 
     setproctitle.setproctitle(process_title)
 
-def format_output(title, cur, headers, status, table_format, missingval, expanded=False, max_width=None):
+def format_output(title, cur, headers, status, table_format, missingval='<null>', expanded=False, max_width=None):
     output = []
     if title:  # Only print the title if it's not None.
         output.append(title)

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -132,7 +132,7 @@ class PGCli(object):
         self.cli_style = c['colors']
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
         self.less_chatty = c['main'].as_bool('less_chatty')
-        self.null_string = c['main'].get('null_string', '<null>').decode('utf-8')
+        self.null_string = c['main'].get('null_string', '<null>')
         self.prompt_format = c['main'].get('prompt', self.default_prompt)
         self.on_error = c['main']['on_error'].upper()
 

--- a/pgcli/packages/expanded.py
+++ b/pgcli/packages/expanded.py
@@ -3,7 +3,7 @@ from .tabulate import _text_type
 def pad(field, total, char=u" "):
     return field + (char * (total - len(field)))
 
-def expanded_table(rows, headers):
+def expanded_table(rows, headers, missingval=u""):
     header_len = max([len(x) for x in headers])
     max_row_len = 0
     results = []
@@ -19,7 +19,7 @@ def expanded_table(rows, headers):
             max_row_len = row_len
 
         for header, value in zip(padded_headers, row):
-            value = '<null>' if value is None else value
+            value = missingval if value is None else value
             row_result.append((u"%s" % header) + " " + (u"%s" % value).strip())
 
         results.append('\n'.join(row_result))

--- a/pgcli/packages/tabulate.py
+++ b/pgcli/packages/tabulate.py
@@ -889,7 +889,8 @@ def tabulate(tabular_data, headers=[], tablefmt="simple",
     _text_type_encode = lambda x: _text_type(utf8tounicode(x))
     plain_text = '\n'.join(['\t'.join(map(_text_type_encode, headers))] + \
                             ['\t'.join(map(_text_type_encode, row)) for row in list_of_lists])
-    has_invisible = re.search(_invisible_codes, plain_text)
+    has_invisible = (re.search(_invisible_codes, plain_text) or
+      re.search(_invisible_codes, missingval))
     if has_invisible:
         width_fn = _visible_width
     else:


### PR DESCRIPTION
Allows a configurable string for the null result.

I like to use ⊥ to visually distinguish from normal text, so the config value needs to be decoded to unicode. Such decoding should probably be applied to other formatting options, e.g. the prompt.

Ideally, the output formatting would be themeable to make nulls, and other types, more distinguishable!
