### PR TITLE
Issue #544 Implementation of watch command

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -346,7 +346,7 @@ class PGCli(object):
             continue
         return document
 
-    def execute_command(self, text):
+    def execute_command(self, text, query):
         logger = self.logger
 
         try:
@@ -454,13 +454,13 @@ class PGCli(object):
                 if watch_command:
                     while watch_command:
                         try:
-                            query = self.execute_command(watch_command)
-                            watch_command, timing = special.get_watch_command(document.text)
+                            query = self.execute_command(watch_command, query)
+                            click.echo('Waiting for {0} seconds before repeating'.format(timing))
                             sleep(timing)
                         except KeyboardInterrupt:
                             watch_command = None
                 else:
-                    query = self.execute_command(document.text)
+                    query = self.execute_command(document.text, query)
 
                 # Allow PGCompleter to learn user's preferred keywords, etc.
                 with self._completer_lock:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('pgcli/__init__.py', 'rb') as f:
 description = 'CLI for Postgres Database. With auto-completion and syntax highlighting.'
 
 install_requirements = [
-            'pgspecial>=1.5.0',
+            'pgspecial>=1.6.0',
             'click >= 4.1',
             'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
             'prompt_toolkit>=1.0.0,<1.1.0',


### PR DESCRIPTION
**Note** I don't think the tests will pass until the related https://github.com/dbcli/pgspecial/pull/22 is merged. @amjith what would you normally do in this case?

An implementation of `\watch` from psql.

```
SELECT * FROM titles; \watch 1;
```

If the command can be parsed as a 'watch' command it is executed, then we sleep the specified number of seconds then execute again. Ctrl+C cancels

Any feedback and suggestions on testing welcome