### PR TITLE
Make semicolon not trigger execution in multiline mode

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -121,6 +121,7 @@ class PGCli(object):
         self.pgspecial = PGSpecial()
 
         self.multi_line = c['main'].as_bool('multi_line')
+        self.multiline_mode = c['main'].get('multi_line_mode', 'psql')
         self.vi_mode = c['main'].as_bool('vi')
         self.pgspecial.timing_enabled = c['main'].as_bool('timing')
         if row_limit is not None:
@@ -515,6 +516,7 @@ class PGCli(object):
         with self._completer_lock:
             buf = PGBuffer(
                 always_multiline=self.multi_line,
+                multiline_mode=self.multiline_mode,
                 completer=self.completer,
                 history=history,
                 complete_while_typing=Always(),

--- a/pgcli/pgbuffer.py
+++ b/pgcli/pgbuffer.py
@@ -4,13 +4,20 @@ from .packages.parseutils.utils import is_open_quote
 
 
 class PGBuffer(Buffer):
-    def __init__(self, always_multiline, *args, **kwargs):
+    def __init__(self, always_multiline, multiline_mode, *args, **kwargs):
         self.always_multiline = always_multiline
+        self.multiline_mode = multiline_mode
 
         @Condition
         def is_multiline():
             doc = self.document
-            return self.always_multiline and not _multiline_exception(doc.text)
+            if not self.always_multiline:
+                return False
+            if self.multiline_mode == 'safe':
+                return True
+            else:
+                return not _multiline_exception(doc.text)
+
 
         super(self.__class__, self).__init__(*args, is_multiline=is_multiline,
                                              tempfile_suffix='.sql', **kwargs)

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -15,6 +15,13 @@ wider_completion_menu = False
 # lines. End of line (return) is considered as the end of the statement.
 multi_line = False
 
+# If multi_line_mode is set to "psql", in multi-line mode, [Enter] will execute
+# the current input if the input ends in a semicolon.
+# If multi_line_mode is set to "safe", in multi-line mode, [Enter] will always
+# insert a newline, and [Esc] [Enter] or [Alt]-[Enter] must be used to execute
+# a command.
+multi_line_mode = psql
+
 # If set to True, table suggestions will include a table alias
 generate_aliases = False
 

--- a/pgcli/pgtoolbar.py
+++ b/pgcli/pgtoolbar.py
@@ -25,8 +25,10 @@ def create_toolbar_tokens_func(get_vi_mode_enabled, get_is_refreshing):
             result.append((token.Off, '[F3] Multiline: OFF  '))
 
         if cli.buffers[DEFAULT_BUFFER].always_multiline:
-            result.append((token,
-                ' (Semi-colon [;] will end the line)'))
+            if cli.buffers[DEFAULT_BUFFER].multiline_mode == 'safe':
+                result.append((token,' ([Esc] [Enter] to execute]) '))
+            else:
+                result.append((token,' (Semi-colon [;] will end the line) '))
 
         if get_vi_mode_enabled():
             result.append((token.On, '[F4] Vi-mode'))


### PR DESCRIPTION
Basically, having to go to the end of the input to delete the semicolon, then back to wherever you want to insert your newline, and then back to the end to re-add the semicolon before executing your edited query is way too complicated, and I keep getting it wrong, resulting in half-written queries being executed and me getting frustrated. 
My suggested solution is to (1) remove the power of the semicolon to decide what [Enter] does, and (2) make the UI (toolbar) tell the user about [Esc] [Enter].

The reason it's [Esc] [Enter] and not [Alt]-[Enter] in the toolbar is that [Alt]-[Enter] doesn't work by default on Mac OS (it requires the user to change the settings of the terminal app).

So ... does anyone else use multiline mode and have an opinion on this?