### PR TITLE
Remove cumulative addition of timing data.

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -583,8 +583,7 @@ class PGCli(object):
                 self.pgspecial.expanded_output, max_width)
 
             output.extend(formatted)
-            end = time()
-            total += end - start
+            total = time() - start
 
             # Keep track of whether any of the queries are mutating or changing
             # the database


### PR DESCRIPTION
Reviewer: @koljonen 

This addresses #575. 

We were inaccurately reporting timing data by aggregating the time stamp. 