### PR TITLE
master: numbers division for int and float

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -137,7 +137,8 @@ class PGCli(object):
         self.null_string = c['main'].get('null_string', '<null>')
         self.prompt_format = c['main'].get('prompt', self.default_prompt)
         self.on_error = c['main']['on_error'].upper()
-
+        self.decimal_format = c['data_formats']['decimal']
+        self.float_format = c['data_formats']['float']
         self.completion_refresher = CompletionRefresher()
 
         self.query_history = []
@@ -586,8 +587,8 @@ class PGCli(object):
                 max_width = None
 
             formatted = format_output(
-                title, cur, headers, status, self.table_format, self.null_string,
-                self.pgspecial.expanded_output, max_width)
+                title, cur, headers, status, self.table_format, self.decimal_format,
+                self.float_format, self.null_string,  self.pgspecial.expanded_output, max_width)
 
             output.extend(formatted)
             total = time() - start
@@ -791,7 +792,9 @@ def obfuscate_process_password():
 
     setproctitle.setproctitle(process_title)
 
-def format_output(title, cur, headers, status, table_format, missingval='<null>', expanded=False, max_width=None):
+
+def format_output(title, cur, headers, status, table_format, dcmlfmt, floatfmt,
+                  missingval='<null>', expanded=False, max_width=None):
     output = []
     if title:  # Only print the title if it's not None.
         output.append(title)
@@ -801,7 +804,7 @@ def format_output(title, cur, headers, status, table_format, missingval='<null>'
             output.append(expanded_table(cur, headers, missingval))
         else:
             tabulated, rows = tabulate(cur, headers, tablefmt=table_format,
-                missingval=missingval)
+                missingval=missingval, dcmlfmt=dcmlfmt, floatfmt=floatfmt)
             if (max_width and rows and
                     content_exceeds_width(rows[0], max_width) and
                     headers):

--- a/pgcli/packages/tabulate.py
+++ b/pgcli/packages/tabulate.py
@@ -496,7 +496,7 @@ def _column_type(strings, has_invisible=True):
     return reduce(_more_generic, types, int)
 
 
-def _format(val, valtype, floatfmt, missingval=""):
+def _format(val, valtype, dcmlfmt ,floatfmt, missingval=""):
     """Format a value accoding to its type.
 
     Unicode is supported:
@@ -512,7 +512,7 @@ def _format(val, valtype, floatfmt, missingval=""):
         return missingval
 
     if valtype is int:
-        return "{0:,d}".format(val)
+        return format(val, dcmlfmt)
     elif valtype is _text_type:
         return "{0}".format(val)
     elif valtype is _binary_type:
@@ -649,7 +649,7 @@ def _normalize_tabular_data(tabular_data, headers):
 
 
 def tabulate(tabular_data, headers=[], tablefmt="simple",
-             floatfmt=",g", numalign="decimal", stralign="left",
+             dcmlfmt="d", floatfmt="g", numalign="decimal", stralign="left",
              missingval=""):
     """Format a fixed width table for pretty printing.
 
@@ -900,7 +900,7 @@ def tabulate(tabular_data, headers=[], tablefmt="simple",
     # format rows and columns, convert numeric values to strings
     cols = list(zip(*list_of_lists))
     coltypes = list(map(_column_type, cols))
-    cols = [[_format(v, ct, floatfmt, missingval) for v in c]
+    cols = [[_format(v, ct, dcmlfmt, floatfmt, missingval) for v in c]
              for c,ct in zip(cols, coltypes)]
 
     # align columns

--- a/pgcli/packages/tabulate.py
+++ b/pgcli/packages/tabulate.py
@@ -5,7 +5,6 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 from collections import namedtuple
-from decimal import Decimal
 from platform import python_version_tuple
 from wcwidth import wcswidth
 from ..encodingutils import utf8tounicode
@@ -334,7 +333,7 @@ def _type(string, has_invisible=True):
 
     if string is None:
         return _none_type
-    if isinstance(string, (bool, Decimal,)):
+    if isinstance(string, bool):
         return _text_type
     elif hasattr(string, "isoformat"):  # datetime.datetime, date, and time
         return _text_type
@@ -512,7 +511,9 @@ def _format(val, valtype, floatfmt, missingval=""):
     if val is None:
         return missingval
 
-    if valtype in [int, _text_type]:
+    if valtype is int:
+        return "{0:,d}".format(val)
+    elif valtype is _text_type:
         return "{0}".format(val)
     elif valtype is _binary_type:
         try:
@@ -648,7 +649,7 @@ def _normalize_tabular_data(tabular_data, headers):
 
 
 def tabulate(tabular_data, headers=[], tablefmt="simple",
-             floatfmt="g", numalign="decimal", stralign="left",
+             floatfmt=",g", numalign="decimal", stralign="left",
              missingval=""):
     """Format a fixed width table for pretty printing.
 

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -127,3 +127,10 @@ Token.Toolbar.Arg.Text = 'nobold'
 # DNS to call by -D option
 [alias_dsn]
 # example_dsn = postgresql://[user[:password]@][netloc][:port][/dbname]
+
+# Format for number representation
+# for decimal "d" - 12345678, ",d" - 123,456,78
+# for float "g" - 123456.78, ",g" - 123,456.78
+[data_formats]
+decimal = ",d"
+float = ",g"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -45,21 +45,22 @@ def test_obfuscate_process_password():
 
     setproctitle.setproctitle(original_title)
 
+
 def test_format_output():
     results = format_output('Title', [('abc', 'def')], ['head1', 'head2'],
-                            'test status', 'psql')
+                            'test status', 'psql',  dcmlfmt='d', floatfmt='g',)
     expected = ['Title', '+---------+---------+\n| head1   | head2   |\n|---------+---------|\n| abc     | def     |\n+---------+---------+', 'test status']
     assert results == expected
 
 def test_format_output_auto_expand():
     table_results = format_output('Title', [('abc', 'def')],
-                                  ['head1', 'head2'], 'test status', 'psql',
+                                  ['head1', 'head2'], 'test status', 'psql', dcmlfmt='d', floatfmt='g',
                                   max_width=100)
     table = ['Title', '+---------+---------+\n| head1   | head2   |\n|---------+---------|\n| abc     | def     |\n+---------+---------+', 'test status']
     assert table_results == table
 
     expanded_results = format_output('Title', [('abc', 'def')],
-                                     ['head1', 'head2'], 'test status', 'psql',
+                                     ['head1', 'head2'], 'test status', 'psql', dcmlfmt='d', floatfmt='g',
                                      max_width=1)
     expanded = ['Title', u'-[ RECORD 0 ]-------------------------\nhead1 | abc\nhead2 | def\n', 'test status']
     assert expanded_results == expanded

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -237,7 +237,7 @@ def test_large_numbers_render_directly(executor, value):
     run(executor, "create table numbertest(a numeric)")
     run(executor,
         "insert into numbertest (a) values ({0})".format(value))
-
+    value = format(float(value), ',g')
     assert value in run(executor, "select * from numbertest", join=True)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,7 +66,7 @@ def run(executor, sql, join=False, expanded=False, pgspecial=None,
     formatted = []
 
     for title, rows, headers, status, sql, success in results:
-        formatted.extend(format_output(title, rows, headers, status, 'psql',
+        formatted.extend(format_output(title, rows, headers, status, 'psql', dcmlfmt='d', floatfmt='g',
                                        expanded=expanded))
     if join:
         formatted = '\n'.join(formatted)


### PR DESCRIPTION
I apologize in advance for possible mistakes, first time trying to take part in open source project.  All decimal columns defined as text field, I change this behavior. Now decimal defined as float. Changed default formatting for float and int. And separate int and text cases.