### PR TITLE
Fix for issue #595

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -129,7 +129,7 @@ Running the integration tests
 Integration tests use `behave package http://pythonhosted.org/behave/`_ and
 pytest.
 Configuration settings for this package are provided via ``behave.ini`` file
-in root directory.
+in the ``tests`` directory.
 
 The database user (``pg_test_user = postgres`` in .ini file) has to have
 permissions to create and drop test database. Default user is ``postgres``

--- a/pgcli/packages/prioritization.py
+++ b/pgcli/packages/prioritization.py
@@ -11,7 +11,7 @@ white_space_regex = re.compile('\\s+', re.MULTILINE)
 def _compile_regex(keyword):
     # Surround the keyword with word boundaries and replace interior whitespace
     # with whitespace wildcards
-    pattern = '\\b' + re.sub(white_space_regex, '\\s+', keyword) + '\\b'
+    pattern = '\\b' + white_space_regex.sub(r'\\s+', keyword) + '\\b'
     return re.compile(pattern, re.MULTILINE | re.IGNORECASE)
 
 keywords = get_literals('keywords')


### PR DESCRIPTION
All behaviors and tests pass, with Python 3.6b2. I did not exercise them on previous versions, but I can surely do it, if needed.