### PR TITLE
Remove python 2.6 from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"


### PR DESCRIPTION
@dbcli/pgcli-core 

I'd like to propose that we remove support for Python 2.6. This PR removes Python 2.6 from travis test runs. 

Please let me know if there are any objections. 

Reasons:

* When Python 2.6 first came out George W. Bush was the president of United States. (Let that sink in).
* The official Python 2.6 support ended in Oct 2013. (Three years ago).
* The real reason is I don't have the time to maintain support for it anymore. 