### PR TITLE
Fix issue #603

### DIFF
--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -637,7 +637,7 @@ class PGCompleter(Completer):
         document = Document(text=word_before_cursor,
                             cursor_position=len(word_before_cursor))
         for c in completer.get_completions(document, None):
-            yield Match(completion=c, priority = None)
+            yield Match(completion=c, priority=(0,))
 
     def get_special_matches(self, _, word_before_cursor):
         if not self.pgspecial:

--- a/tests/test_naive_completion.py
+++ b/tests/test_naive_completion.py
@@ -46,3 +46,12 @@ def test_column_name_completion(completer, complete_event):
         Document(text=text, cursor_position=position),
         complete_event))
     assert result == set(map(Completion, completer.all_completions))
+
+def test_paths_completion(completer, complete_event):
+    text = '\i '
+    position = len(text)
+    result = set(completer.get_completions(
+        Document(text=text, cursor_position=position),
+        complete_event,
+        smart_completion=True))
+    assert result > set([Completion(text="setup.py", start_position=0)])


### PR DESCRIPTION
Python 3 forbids comparisons between different types: use a tuple
containing a single 0 (zero) as the priority for path matches so that it
can be compared with those generated by the workhorse method find_matches().