### PR TITLE
Table-qualifying column suggestions

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -151,6 +151,7 @@ class PGCli(object):
             'generate_casing_file': c['main'].as_bool('generate_casing_file'),
             'generate_aliases': c['main'].as_bool('generate_aliases'),
             'asterisk_column_order': c['main']['asterisk_column_order'],
+            'qualify_columns': c['main']['qualify_columns'],
             'single_connection': single_connection,
             'keyword_casing': keyword_casing,
         }

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -58,6 +58,10 @@ log_level = INFO
 # Possible values: "table_order" and "alphabetic"
 asterisk_column_order = table_order
 
+# Whether to qualify with table alias/name when suggesting columns
+# Possible values: "always", never" and "if_more_than_one_table"
+qualify_columns = if_more_than_one_table
+
 # Default pager.
 # By default 'PAGER' environment variable is used
 # pager = less -SRXF

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -311,10 +311,11 @@ class PGCompleter(Completer):
         for cand in collection:
             if isinstance(cand, _Candidate):
                 item, prio, display_meta, synonyms = cand
+                sort_key = max(_match(x) for x in synonyms)
             else:
-                item, display_meta, prio, synonyms = cand, meta, 0, [cand]
+                item, display_meta, prio = cand, meta, 0
+                sort_key = _match(cand)
 
-            sort_key = max(_match(x) for x in synonyms)
             if sort_key:
                 if display_meta and len(display_meta) > 50:
                     # Truncate meta-text to 50 characters, if necessary

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -30,6 +30,7 @@ NamedQueries.instance = NamedQueries.from_config(
 
 
 Match = namedtuple('Match', ['completion', 'priority'])
+Candidate = namedtuple('Candidate', ['completion', 'priority', 'meta'])
 
 normalize_ref = lambda ref: ref if ref[0] == '"' else '"' + ref.lower() +  '"'
 
@@ -237,15 +238,15 @@ class PGCompleter(Completer):
                            'datatypes': {}}
         self.all_completions = set(self.keywords + self.functions)
 
-    def find_matches(self, text, collection, mode='fuzzy',
-                     meta=None, meta_collection=None,
-                     priority_collection = None):
+    def find_matches(self, text, collection, mode='fuzzy', meta=None):
         """Find completion matches for the given text.
 
         Given the user's input text and a collection of available
         completions, find completions matching the last word of the
         text.
 
+        `collection` can be either a list of strings or a list of Candidate
+        namedtuples.
         `mode` can be either 'fuzzy', or 'strict'
             'fuzzy': fuzzy matching, ties broken by name prevalance
             `keyword`: start only matching, ties broken by keyword prevalance
@@ -254,7 +255,8 @@ class PGCompleter(Completer):
         in the collection of available completions.
 
         """
-
+        if not collection:
+            return []
         prio_order = [
             'keyword', 'function', 'view', 'table', 'datatype', 'database',
             'schema', 'column', 'table alias', 'join', 'name join', 'fk join'
@@ -300,21 +302,17 @@ class PGCompleter(Completer):
                     # fuzzy matches
                     return -float('Infinity'), -match_point
 
-        # Fallback to meta param if meta_collection param is None
-        meta_collection = meta_collection or repeat(meta)
-        # Fallback to 0 if priority_collection param is None
-        priority_collection = priority_collection or repeat(0)
-
-        collection = zip(collection, meta_collection, priority_collection)
-
         matches = []
-
-        for item, meta, prio in collection:
+        for cand in collection:
+            if isinstance(cand, Candidate):
+                item, prio, met = cand
+            else:
+                item, met, prio = cand, meta, 0
             sort_key = _match(item)
             if sort_key:
                 if meta and len(meta) > 50:
                     # Truncate meta-text to 50 characters, if necessary
-                    meta = meta[:47] + u'...'
+                    met = met[:47] + u'...'
 
                 # Lexical order of items in the collection, used for
                 # tiebreaking items with the same match group length and start
@@ -333,7 +331,7 @@ class PGCompleter(Completer):
                 priority = sort_key, type_priority, prio, priority_func(item), lexical_priority
 
                 matches.append(Match(
-                    completion=Completion(item, -text_len, display_meta=meta),
+                    completion=Completion(item, -text_len, display_meta=met),
                     priority=priority))
         return matches
 
@@ -440,7 +438,7 @@ class PGCompleter(Completer):
         refs = set(normalize_ref(t.ref) for t in tbls)
         other_tbls = set((t.schema, t.name)
             for t in list(cols)[:-1])
-        joins, prios = [], []
+        joins = []
         # Iterate over FKs in existing tables to find potential joins
         fks = ((fk, rtbl, rcol) for rtbl, rcols in cols.items()
             for rcol in rcols for fk in rcol.foreignkeys)
@@ -466,12 +464,11 @@ class PGCompleter(Completer):
                 and left.schema == right.schema
                 or left.schema not in(right.schema, 'public')):
                 join = left.schema + '.' + join
-            joins.append(join)
-            prios.append(ref_prio[normalize_ref(rtbl.ref)] * 2 + (
-                0 if (left.schema, left.tbl) in other_tbls else 1))
+            prio = ref_prio[normalize_ref(rtbl.ref)] * 2 + (
+                0 if (left.schema, left.tbl) in other_tbls else 1)
+            joins.append(Candidate(join, prio, 'join'))
 
-        return self.find_matches(word_before_cursor, joins, meta='join',
-            priority_collection=prios)
+        return self.find_matches(word_before_cursor, joins, meta='join')
 
     def get_join_condition_matches(self, suggestion, word_before_cursor):
         col = namedtuple('col', 'schema tbl col')
@@ -482,16 +479,15 @@ class PGCompleter(Completer):
             ltbl, lcols = [(t, cs) for (t, cs) in tbls() if t.ref == lref][-1]
         except IndexError: # The user typed an incorrect table qualifier
             return []
-        conds, prios, found_conds = [], [], set()
+        conds, found_conds = [], set()
 
-        def add_cond(lcol, rcol, rref, prio):
+        def add_cond(lcol, rcol, rref, prio, meta):
             prefix = '' if suggestion.parent else ltbl.ref + '.'
             case = self.case
             cond = prefix + case(lcol) + ' = ' + rref + '.' + case(rcol)
             if cond not in found_conds:
                 found_conds.add(cond)
-                conds.append(cond)
-                prios.append(prio + ref_prio[rref])
+                conds.append(Candidate(cond, prio + ref_prio[rref], meta))
 
         def list_dict(pairs): # Turns [(a, b), (a, c)] into {a: [b, c]}
             d = defaultdict(list)
@@ -514,21 +510,18 @@ class PGCompleter(Completer):
             par = col(fk.parentschema, fk.parenttable, fk.parentcolumn)
             left, right = (child, par) if left == child else (par, child)
             for rtbl in coldict[right]:
-                add_cond(left.col, right.col, rtbl.ref, 2000)
-        matches = self.find_matches(word_before_cursor, conds,
-          meta='fk join', priority_collection=prios)
+                add_cond(left.col, right.col, rtbl.ref, 2000, 'fk join')
         # For name matching, use a {(colname, coltype): TableReference} dict
         coltyp = namedtuple('coltyp', 'name datatype')
         col_table = list_dict((coltyp(c.name, c.datatype), t) for t, c in cols)
-        conds, prios = [], []
         # Find all name-match join conditions
         for c in (coltyp(c.name, c.datatype) for c in lcols):
             for rtbl in (t for t in col_table[c] if t.ref != ltbl.ref):
-                add_cond(c.name, c.name, rtbl.ref, 1000
-                    if c.datatype in ('integer', 'bigint', 'smallint') else 0)
+                prio = 1000 if c.datatype in (
+                    'integer', 'bigint', 'smallint') else 0
+                add_cond(c.name, c.name, rtbl.ref, prio, 'name join')
 
-        return matches + self.find_matches(word_before_cursor, conds,
-          meta='name join', priority_collection=prios)
+        return self.find_matches(word_before_cursor, conds, meta='join')
 
     def get_function_matches(self, suggestion, word_before_cursor, alias=False):
         if suggestion.filter == 'for_from_clause':
@@ -644,10 +637,9 @@ class PGCompleter(Completer):
             return []
 
         commands = self.pgspecial.commands
-        cmd_names = commands.keys()
-        desc = [commands[cmd].description for cmd in cmd_names]
-        return self.find_matches(word_before_cursor, cmd_names, mode='strict',
-                                 meta_collection=desc)
+        cmds = commands.keys()
+        cmds = [Candidate(cmd, 0, commands[cmd].description) for cmd in cmds]
+        return self.find_matches(word_before_cursor, cmds, mode='strict')
 
     def get_datatype_matches(self, suggestion, word_before_cursor):
         # suggest custom datatypes


### PR DESCRIPTION
@darikg Do you have time to look at yet another of my tweaks to the completion engine?

> Support for table-qualifying column suggestions
> 
> ... i.e. suggesting foo.fooid instead of just fooid
> Controlled using a config-file setting:
> **qualify_columns**: always/never/**if_more_than_one_table**.
> 
> To enable the proper sorting of qualified column suggestions, we
> introduce the concept of synonyms for suggestions
> (in `pgcompleter.find_matches`). They way synonyms work is that a
> number of synonyms may be provided for a suggestion sent to
> `find_matches`. If synonyms are provided, sorting is based on how
> well the best synonym matches the input, instead of only comparing
> the input to the suggestion text.
> In this case, the unqualified name acts as a synonym.
> I have a couple of other ideas of use cases where we can use synonyms
> to get better completions with less typing for the user, which I intend
> to explore later.