### PR TITLE
Per #298, make expand modes configurable.

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -123,6 +123,8 @@ class PGCli(object):
         self.multi_line = c['main'].as_bool('multi_line')
         self.multiline_mode = c['main'].get('multi_line_mode', 'psql')
         self.vi_mode = c['main'].as_bool('vi')
+        self.auto_expand = c['main'].as_bool('auto_expand')
+        self.expanded_output = c['main'].as_bool('expand')
         self.pgspecial.timing_enabled = c['main'].as_bool('timing')
         if row_limit is not None:
             self.row_limit = row_limit
@@ -584,14 +586,15 @@ class PGCli(object):
                     click.secho("Aborted!", err=True, fg='red')
                     break
 
-            if self.pgspecial.auto_expand:
+            if self.pgspecial.auto_expand or self.auto_expand:
                 max_width = self.cli.output.get_size().columns
             else:
                 max_width = None
 
+            expanded = self.pgspecial.expanded_output or self.expanded_output
             formatted = format_output(
                 title, cur, headers, status, self.table_format, self.decimal_format,
-                self.float_format, self.null_string,  self.pgspecial.expanded_output, max_width)
+                self.float_format, self.null_string, expanded, max_width)
 
             output.extend(formatted)
             total = time() - start

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -22,6 +22,12 @@ multi_line = False
 # a command.
 multi_line_mode = psql
 
+# Enables expand mode, which is similar to `\x` in psql.
+expand = False
+
+# Enables auto expand mode, which is similar to `\x auto` in psql.
+auto_expand = False
+
 # If set to True, table suggestions will include a table alias
 generate_aliases = False
 


### PR DESCRIPTION
This makes it possible to enable through the configuration the always
expand and automatic expansion modes in pgcli.