### PR TITLE
Suggest keywords after ALTER

### DIFF
--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -460,6 +460,8 @@ def suggest_based_on_last_token(token, stmt):
         if not schema:
             suggestions.append(Schema())
         return tuple(suggestions)
+    elif token_v == 'alter':
+        return (Keyword(),)
     elif token.is_keyword:
         # token is a keyword we haven't implemented any special handling for
         # go backwards in the query until we find one we do recognize

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -999,3 +999,10 @@ def test_keyword_casing_upper(keyword_casing, expected, texts):
             Document(text=text, cursor_position=len(text)), complete_event)
         assert expected in [cpl.text for cpl in completions]
 
+
+def test_keyword_after_alter(completer):
+    sql = 'ALTER TABLE users ALTER '
+    expected = Completion('COLUMN', start_position=0, display_meta='keyword')
+    completions = completer.get_completions(
+        Document(text=sql, cursor_position=len(sql)), complete_event)
+    assert expected in set(completions)

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -762,3 +762,9 @@ def test_handle_unrecognized_kw_generously():
     assert expected in set(suggestions)
 
 
+@pytest.mark.parametrize('sql', [
+    'ALTER ',
+    'ALTER TABLE foo ALTER ',
+])
+def test_keyword_after_alter(sql):
+    assert Keyword() in set(suggest_type(sql, sql))


### PR DESCRIPTION
This is super simple I just wanted `ALTER TABLE foo ALTER ` to suggest `COLUMN`