### PR TITLE
Adjust the connection order to work around psycopg2 restriction.

### DIFF
--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -185,10 +185,6 @@ class PGExecute(object):
 
             cursor = conn.cursor()
 
-        cursor.execute("SHOW ALL")
-        db_parameters = dict(name_val_desc[:2] for name_val_desc in cursor.fetchall())
-
-        pid = self._select_one(cursor, 'select pg_backend_pid()')[0]
         conn.set_client_encoding('utf8')
         if hasattr(self, 'conn'):
             self.conn.close()
@@ -199,6 +195,11 @@ class PGExecute(object):
         self.password = password
         self.host = host
         self.port = port
+
+        cursor.execute("SHOW ALL")
+        db_parameters = dict(name_val_desc[:2] for name_val_desc in cursor.fetchall())
+
+        pid = self._select_one(cursor, 'select pg_backend_pid()')[0]
         self.pid = pid
         self.superuser = db_parameters.get('is_superuser') == '1'
 


### PR DESCRIPTION
Reviewer: @darikg 

This fixes #646 

Looks like psycopg2 released a new version yesterday that broke us. 😞 

The change was you can't change the `autocommit` status while a cursor is still active. So I moved the sql execution after we set the `autocommit` to `True`. 