### PR TITLE
Suggest objects from schemas not in search_path

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -157,6 +157,7 @@ class PGCli(object):
             'generate_aliases': c['main'].as_bool('generate_aliases'),
             'asterisk_column_order': c['main']['asterisk_column_order'],
             'qualify_columns': c['main']['qualify_columns'],
+            'search_path_filter': c['main'].as_bool('search_path_filter'),
             'single_connection': single_connection,
             'keyword_casing': keyword_casing,
         }

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -68,6 +68,9 @@ asterisk_column_order = table_order
 # Possible values: "always", never" and "if_more_than_one_table"
 qualify_columns = if_more_than_one_table
 
+# When no schema is entered, only suggest objects in search_path
+search_path_filter = False
+
 # Default pager.
 # By default 'PAGER' environment variable is used
 # pager = less -SRXF

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -605,6 +605,7 @@ class PGCompleter(Completer):
             + self.get_view_matches(v_sug, word_before_cursor, alias)
             + self.get_function_matches(f_sug, word_before_cursor, alias))
 
+    # Note: tbl is a SchemaObject
     def _make_cand(self, tbl, do_alias, suggestion):
         cased_tbl = self.case(tbl.name)
         if do_alias:
@@ -760,6 +761,9 @@ class PGCompleter(Completer):
         return columns
 
     def _get_schemas(self, obj_typ, schema):
+        """ Returns a list of schemas from which to suggest objects
+        schema is the schema qualification input by the user (if any)
+        """
         metadata = self.dbmetadata[obj_typ]
         if schema:
             schema = self.escape_name(schema)
@@ -770,7 +774,9 @@ class PGCompleter(Completer):
         return None if parent or schema in self.search_path else schema
 
     def populate_schema_objects(self, schema, obj_type):
-        """Returns list of tables or functions for a (optional) schema"""
+        """Returns a list of SchemaObjects representing tables, views, funcs
+        schema is the schema qualification input by the user (if any)
+        """
 
         return [
             SchemaObject(

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -619,6 +619,17 @@ def test_column_alias_search_qualified(completer_aliases_casing,
     cols = ('EntryID', 'EntryTitle')
     assert result[:3] == [column(c, -2) for c in cols]
 
+def test_schema_object_order(completer_all_schemas, complete_event):
+    text = 'SELECT * FROM u'
+    position = len('SELECT * FROM u')
+    result = completer_all_schemas.get_completions(
+        Document(text=text, cursor_position=position),
+        complete_event
+    )
+    assert result[:3] == [
+        table(t, pos=-1) for t in ('users', 'custom."Users"', 'custom.users')
+    ]
+
 def test_all_schema_objects(completer_all_schemas, complete_event):
     text = 'SELECT * FROM '
     position = len('SELECT * FROM ')

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -66,7 +66,7 @@ cased_schemas = [schema(x) for x in ('public', 'blog', 'CUSTOM', '"Custom"')]
 
 @pytest.fixture
 def completer():
-    return testdata.completer
+    return testdata.get_completer(settings={'search_path_filter': True})
 
 casing = ('SELECT', 'Orders', 'User_Emails', 'CUSTOM', 'Func1', 'Entries',
           'Tags', 'EntryTags', 'EntAccLog',
@@ -74,15 +74,35 @@ casing = ('SELECT', 'Orders', 'User_Emails', 'CUSTOM', 'Func1', 'Entries',
 
 @pytest.fixture
 def completer_with_casing():
-    return testdata.get_completer(casing=casing)
+    return testdata.get_completer(
+        settings={'search_path_filter': True},
+        casing=casing
+    )
 
 @pytest.fixture
 def completer_with_aliases():
-    return testdata.get_completer({'generate_aliases': True})
+    return testdata.get_completer(
+        settings={'generate_aliases': True, 'search_path_filter': True}
+    )
 
 @pytest.fixture
-def completer_aliases_casing(request):
-    return testdata.get_completer({'generate_aliases': True}, casing)
+def completer_aliases_casing():
+    return testdata.get_completer(
+        settings={'generate_aliases': True, 'search_path_filter': True},
+        casing=casing
+    )
+
+@pytest.fixture
+def completer_all_schemas():
+    return testdata.get_completer()
+
+@pytest.fixture
+def completer_all_schemas_casing():
+    return testdata.get_completer(casing=casing)
+
+@pytest.fixture
+def completer_all_schemas_aliases():
+    return testdata.get_completer(settings={'generate_aliases': True})
 
 @pytest.fixture
 def complete_event():
@@ -598,3 +618,49 @@ def test_column_alias_search_qualified(completer_aliases_casing,
         Document(text, cursor_position=len('SELECT E.ei')), complete_event)
     cols = ('EntryID', 'EntryTitle')
     assert result[:3] == [column(c, -2) for c in cols]
+
+def test_all_schema_objects(completer_all_schemas, complete_event):
+    text = 'SELECT * FROM '
+    position = len('SELECT * FROM ')
+    result = set(
+        completer_all_schemas.get_completions(
+            Document(text=text, cursor_position=position),
+            complete_event
+        )
+    )
+    assert result >= set(
+        [table(x) for x in ('orders', '"select"', 'custom.shipments')]
+        + [function(x+'()') for x in ('func2', 'custom.func3')]
+    )
+
+def test_all_schema_objects_with_casing(
+    completer_all_schemas_casing, complete_event
+):
+    text = 'SELECT * FROM '
+    position = len('SELECT * FROM ')
+    result = set(
+        completer_all_schemas_casing.get_completions(
+            Document(text=text, cursor_position=position),
+            complete_event
+        )
+    )
+    assert result >= set(
+        [table(x) for x in ('Orders', '"select"', 'CUSTOM.shipments')]
+        + [function(x+'()') for x in ('func2', 'CUSTOM.func3')]
+    )
+
+def test_all_schema_objects_with_aliases(
+    completer_all_schemas_aliases, complete_event
+):
+    text = 'SELECT * FROM '
+    position = len('SELECT * FROM ')
+    result = set(
+        completer_all_schemas_aliases.get_completions(
+            Document(text=text, cursor_position=position),
+            complete_event
+        )
+    )
+    assert result >= set(
+        [table(x) for x in ('orders o', '"select" s', 'custom.shipments s')]
+        + [function(x) for x in ('func2() f', 'custom.func3() f')]
+    )


### PR DESCRIPTION
I keep typing e.g. `SELECT mff` and getting annoyed when `someschema.my_fancy_function()` isn't suggested because I forgot to type the schema first. So this fixes that, for tables, views functions and datatypes.
There's a config option for getting the old behaviour.

I added some rudimentary tests. I'm working on another branch where I'll make it more convenient to run the same test for different completer configs, which will add some more test cases for this feature as well.

Sending this to you @darikg, as it's related to a bunch of my other stuff you've reviewed.