### PR TITLE
Parse function bodies

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,10 @@
+Upcoming
+=====
+
+Features:
+---------
+* Better suggestions when editing functions (Thanks: `Joakim Koljonen`_)
+
 1.5.0
 =====
 

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -387,6 +387,17 @@ def test_wildcard_column_expansion_with_alias_qualifier(completer, complete_even
     assert expected == completions
 
 @pytest.mark.parametrize('text', [
+    '''
+    SELECT count(1) FROM users;
+    CREATE FUNCTION foo(custom.products _products) returns custom.shipments
+    LANGUAGE SQL
+    AS $foo$
+    SELECT 1 FROM custom.shipments;
+    INSERT INTO public.orders(*) values(-1, now(), 'preliminary');
+    SELECT 2 FROM custom.users;
+    $foo$;
+    SELECT count(1) FROM custom.shipments;
+    ''',
     'INSERT INTO public.orders(*',
     'INSERT INTO public.Orders(*',
     'INSERT INTO public.orders (*',


### PR DESCRIPTION
Consider this script
```
CREATE FUNCTION foo() returns text LANGUAGE SQL AS $func$
SELECT 1 FROM Bar;
SELECT <cursor> FROM Baz;
$func$;
```
The change here is that `SELECT <cursor> FROM Baz;` will be seen as the
current statement, instead of the whole function definition.
This means we'll no longer get column suggestions from `Bar`.