### PR TITLE
Parametrize completer in tests + deduplicate test code

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,2 @@
+[MESSAGES CONTROL]
+disable=missing-docstring,invalid-name

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -2,13 +2,24 @@ from pgcli.packages.parseutils.meta import FunctionMetadata, ForeignKey
 from prompt_toolkit.completion import Completion
 from functools import partial
 from itertools import product
+from prompt_toolkit.document import Document
+from mock import Mock
 
 escape = lambda name: ('"' + name + '"' if not name.islower() or name in (
     'select', 'insert') else name)
 
 def completion(display_meta, text, pos=0):
-    return Completion(text, start_position=pos,
-        display_meta=display_meta)
+    return Completion(text, start_position=pos, display_meta=display_meta)
+
+def get_result(completer, text, position=None):
+    position = len(text) if position is None else position
+    return completer.get_completions(
+        Document(text=text, cursor_position=position), Mock()
+    )
+
+def result_set(completer, text, position=None):
+    return set(get_result(completer, text, position))
+
 
 # The code below is quivalent to
 # def schema(text, pos=0):

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -80,6 +80,31 @@ class MetaData(object):
         schemas = set(sch for schs in self.metadata.values() for sch in schs)
         return [schema(escape(s), pos=pos) for s in schemas]
 
+    def functions_and_keywords(self, schema='public', pos=0):
+        return (
+            self.functions(schema, pos) + self.builtin_functions(pos) +
+            self.keywords(pos)
+        )
+
+    # Note that the filtering parameters here only apply to the columns
+    def columns_functions_and_keywords(self, parent, schema='public', typ='tables', pos=0):
+        return (
+            self.functions_and_keywords(pos=pos) +
+            self.columns(parent, schema, typ, pos)
+        )
+
+    def from_clause_items(self, schema='public', pos=0):
+        return (
+            self.functions(schema, pos) + self.views(schema, pos) +
+            self.tables(schema, pos)
+        )
+
+    def schemas_and_from_clause_items(self, schema='public', pos=0):
+        return self.from_clause_items(schema, pos) + self.schemas(pos)
+
+    def types(self, schema='public', pos=0):
+        return self.datatypes(schema, pos) + self.tables(schema, pos)
+
     @property
     def completer(self):
         return self.get_completer()

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -1,26 +1,33 @@
-from pgcli.packages.parseutils.meta import FunctionMetadata, ForeignKey
-from prompt_toolkit.completion import Completion
 from functools import partial
 from itertools import product
+from pgcli.packages.parseutils.meta import FunctionMetadata, ForeignKey
+from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
 from mock import Mock
 import pytest
 
-escape = lambda name: ('"' + name + '"' if not name.islower() or name in (
-    'select', 'insert') else name)
-
 parametrize = pytest.mark.parametrize
+
 qual = ['if_more_than_one_table', 'always']
 no_qual = ['if_more_than_one_table', 'never']
 
+
+def escape(name):
+    if not name.islower() or name in ('select', 'insert'):
+        return '"' + name + '"'
+    return name
+
+
 def completion(display_meta, text, pos=0):
     return Completion(text, start_position=pos, display_meta=display_meta)
+
 
 def get_result(completer, text, position=None):
     position = len(text) if position is None else position
     return completer.get_completions(
         Document(text=text, cursor_position=position), Mock()
     )
+
 
 def result_set(completer, text, position=None):
     return set(get_result(completer, text, position))
@@ -30,14 +37,23 @@ def result_set(completer, text, position=None):
 # def schema(text, pos=0):
 #   return completion('schema', text, pos)
 # and so on
-schema, table, view, function, column, keyword, datatype, alias, name_join,\
-    fk_join, join = [partial(completion, display_meta)
-    for display_meta in('schema', 'table', 'view', 'function', 'column',
-    'keyword', 'datatype', 'table alias', 'name join', 'fk join', 'join')]
+schema = partial(completion, 'schema')
+table = partial(completion, 'table')
+view = partial(completion, 'view')
+function = partial(completion, 'function')
+column = partial(completion, 'column')
+keyword = partial(completion, 'keyword')
+datatype = partial(completion, 'datatype')
+alias = partial(completion, 'table alias')
+name_join = partial(completion, 'name join')
+fk_join = partial(completion, 'fk join')
+join = partial(completion, 'join')
+
 
 def wildcard_expansion(cols, pos=-1):
-        return Completion(cols, start_position=pos, display_meta='columns',
-            display = '*')
+    return Completion(
+        cols, start_position=pos, display_meta='columns', display='*')
+
 
 class MetaData(object):
     def __init__(self, metadata):
@@ -52,97 +68,103 @@ class MetaData(object):
     def keywords(self, pos=0):
         return [keyword(kw, pos) for kw in self.completer.keywords]
 
-    def columns(self, parent, schema='public', typ='tables', pos=0):
+    def columns(self, tbl, parent='public', typ='tables', pos=0):
         if typ == 'functions':
-            fun = [x for x in self.metadata[typ][schema] if x[0] == parent][0]
+            fun = [x for x in self.metadata[typ][parent] if x[0] == tbl][0]
             cols = fun[1]
         else:
-            cols = self.metadata[typ][schema][parent]
+            cols = self.metadata[typ][parent][tbl]
         return [column(escape(col), pos) for col in cols]
 
-    def datatypes(self, schema='public', pos=0):
-        return [datatype(escape(x), pos)
-            for x in self.metadata.get('datatypes', {}).get(schema, [])]
+    def datatypes(self, parent='public', pos=0):
+        return [
+            datatype(escape(x), pos)
+            for x in self.metadata.get('datatypes', {}).get(parent, [])]
 
-    def tables(self, schema='public', pos=0):
-        return [table(escape(x), pos)
-            for x in self.metadata.get('tables', {}).get(schema, [])]
+    def tables(self, parent='public', pos=0):
+        return [
+            table(escape(x), pos)
+            for x in self.metadata.get('tables', {}).get(parent, [])]
 
-    def views(self, schema='public', pos=0):
-        return [view(escape(x), pos)
-            for x in self.metadata.get('views', {}).get(schema, [])]
+    def views(self, parent='public', pos=0):
+        return [
+            view(escape(x), pos)
+            for x in self.metadata.get('views', {}).get(parent, [])]
 
-    def functions(self, schema='public', pos=0):
-        return [function(escape(x[0] + '()'), pos)
-            for x in self.metadata.get('functions', {}).get(schema, [])]
+    def functions(self, parent='public', pos=0):
+        return [
+            function(escape(x[0] + '()'), pos)
+            for x in self.metadata.get('functions', {}).get(parent, [])]
 
     def schemas(self, pos=0):
         schemas = set(sch for schs in self.metadata.values() for sch in schs)
         return [schema(escape(s), pos=pos) for s in schemas]
 
-    def functions_and_keywords(self, schema='public', pos=0):
+    def functions_and_keywords(self, parent='public', pos=0):
         return (
-            self.functions(schema, pos) + self.builtin_functions(pos) +
+            self.functions(parent, pos) + self.builtin_functions(pos) +
             self.keywords(pos)
         )
 
     # Note that the filtering parameters here only apply to the columns
-    def columns_functions_and_keywords(self, parent, schema='public', typ='tables', pos=0):
+    def columns_functions_and_keywords(
+            self, tbl, parent='public', typ='tables', pos=0
+    ):
         return (
             self.functions_and_keywords(pos=pos) +
-            self.columns(parent, schema, typ, pos)
+            self.columns(tbl, parent, typ, pos)
         )
 
-    def from_clause_items(self, schema='public', pos=0):
+    def from_clause_items(self, parent='public', pos=0):
         return (
-            self.functions(schema, pos) + self.views(schema, pos) +
-            self.tables(schema, pos)
+            self.functions(parent, pos) + self.views(parent, pos) +
+            self.tables(parent, pos)
         )
 
-    def schemas_and_from_clause_items(self, schema='public', pos=0):
-        return self.from_clause_items(schema, pos) + self.schemas(pos)
+    def schemas_and_from_clause_items(self, parent='public', pos=0):
+        return self.from_clause_items(parent, pos) + self.schemas(pos)
 
-    def types(self, schema='public', pos=0):
-        return self.datatypes(schema, pos) + self.tables(schema, pos)
+    def types(self, parent='public', pos=0):
+        return self.datatypes(parent, pos) + self.tables(parent, pos)
 
     @property
     def completer(self):
         return self.get_completer()
 
     def get_completers(self, casing):
-        '''
-        Returns a function taking three bools `casing`, `filtr`, `alias` and
+        """
+        Returns a function taking three bools `casing`, `filtr`, `aliasing` and
         the list `qualify`, all defaulting to None.
         Returns a list of completers.
         These parameters specify the allowed values for the corresponding
         completer parameters, `None` meaning any, i.e. (None, None, None, None)
         results in all 24 possible completers, whereas e.g.
-        (True, False, True, ['never']) results in the one completer with casing,
-        without `search_path` filtering of objects, with table aliasing, and
-        without column qualification.
-        '''
-        def _cfg(_casing, filtr, alias, qualify):
-            cfg = {'settings':{}}
+        (True, False, True, ['never']) results in the one completer with
+        casing, without `search_path` filtering of objects, with table
+        aliasing, and without column qualification.
+        """
+        def _cfg(_casing, filtr, aliasing, qualify):
+            cfg = {'settings': {}}
             if _casing:
                 cfg['casing'] = casing
             cfg['settings']['search_path_filter'] = filtr
-            cfg['settings']['generate_aliases'] = alias
+            cfg['settings']['generate_aliases'] = aliasing
             cfg['settings']['qualify_columns'] = qualify
             return cfg
 
-        def _cfgs(casing, filtr, alias, qualify):
+        def _cfgs(casing, filtr, aliasing, qualify):
             casings = [True, False] if casing is None else [casing]
             filtrs = [True, False] if filtr is None else [filtr]
-            aliases = [True, False] if alias is None else [alias]
+            aliases = [True, False] if aliasing is None else [aliasing]
             qualifys = qualify or ['always', 'if_more_than_one_table', 'never']
             return [
                 _cfg(*p) for p in product(casings, filtrs, aliases, qualifys)
             ]
 
-        def completers(casing=None, filtr=None, alias=None, qualify=None):
+        def completers(casing=None, filtr=None, aliasing=None, qualify=None):
             get_comp = self.get_completer
             return [
-                get_comp(**c) for c in _cfgs(casing, filtr, alias, qualify)
+                get_comp(**c) for c in _cfgs(casing, filtr, aliasing, qualify)
             ]
 
         return completers
@@ -154,29 +176,32 @@ class MetaData(object):
 
         schemata, tables, tbl_cols, views, view_cols = [], [], [], [], []
 
-        for schema, tbls in metadata['tables'].items():
-            schemata.append(schema)
+        for sch, tbls in metadata['tables'].items():
+            schemata.append(sch)
 
-            for table, cols in tbls.items():
-                tables.append((schema, table))
+            for tbl, cols in tbls.items():
+                tables.append((sch, tbl))
                 # Let all columns be text columns
-                tbl_cols.extend([(schema, table, col, 'text') for col in cols])
+                tbl_cols.extend([(sch, tbl, col, 'text') for col in cols])
 
-        for schema, tbls in metadata.get('views', {}).items():
-            for view, cols in tbls.items():
-                views.append((schema, view))
+        for sch, tbls in metadata.get('views', {}).items():
+            for tbl, cols in tbls.items():
+                views.append((sch, tbl))
                 # Let all columns be text columns
-                view_cols.extend([(schema, view, col, 'text') for col in cols])
+                view_cols.extend([(sch, tbl, col, 'text') for col in cols])
 
-        functions = [FunctionMetadata(schema, *func_meta)
-                        for schema, funcs in metadata['functions'].items()
-                        for func_meta in funcs]
+        functions = [
+            FunctionMetadata(sch, *func_meta)
+            for sch, funcs in metadata['functions'].items()
+            for func_meta in funcs]
 
-        datatypes = [(schema, datatype)
-                        for schema, datatypes in metadata['datatypes'].items()
-                        for datatype in datatypes]
+        datatypes = [
+            (sch, typ)
+            for sch, datatypes in metadata['datatypes'].items()
+            for typ in datatypes]
 
-        foreignkeys = [ForeignKey(*fk) for fks in metadata['foreignkeys'].values()
+        foreignkeys = [
+            ForeignKey(*fk) for fks in metadata['foreignkeys'].values()
             for fk in fks]
 
         comp.extend_schemata(schemata)

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -4,9 +4,14 @@ from functools import partial
 from itertools import product
 from prompt_toolkit.document import Document
 from mock import Mock
+import pytest
 
 escape = lambda name: ('"' + name + '"' if not name.islower() or name in (
     'select', 'insert') else name)
+
+parametrize = pytest.mark.parametrize
+qual = ['if_more_than_one_table', 'always']
+no_qual = ['if_more_than_one_table', 'never']
 
 def completion(display_meta, text, pos=0):
     return Completion(text, start_position=pos, display_meta=display_meta)

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -110,7 +110,7 @@ def test_suggested_join_conditions(completer, text):
         fk_join('shipments.user_id = users.id')])
 
 
-@parametrize('completer', completers(filtr=True, casing=False, alias=False))
+@parametrize('completer', completers(filtr=True, casing=False, aliasing=False))
 @parametrize(('query', 'tbl'), itertools.product((
     'SELECT * FROM public.{0} RIGHT OUTER JOIN ',
     '''SELECT *
@@ -143,7 +143,7 @@ def test_suggested_column_names_in_function(completer):
     assert result == set(testdata.columns('products', 'custom'))
 
 
-@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('completer', completers(casing=False, aliasing=False))
 @parametrize('text', [
     'SELECT * FROM Custom.',
     'SELECT * FROM custom.',
@@ -163,7 +163,7 @@ def test_suggested_table_names_with_schema_dot(
     assert result == set(testdata.from_clause_items('custom', start_position))
 
 
-@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('completer', completers(casing=False, aliasing=False))
 @parametrize('text', [
     'SELECT * FROM "Custom".',
 ])
@@ -232,7 +232,7 @@ def test_suggested_aliases_after_on_right_side(completer):
     assert result == set([alias('x'), alias('y')])
 
 
-@parametrize('completer', completers(filtr=True, casing=False, alias=False))
+@parametrize('completer', completers(filtr=True, casing=False, aliasing=False))
 def test_table_names_after_from(completer):
     text = 'SELECT * FROM '
     result = result_set(completer, text)
@@ -406,14 +406,14 @@ def test_suggest_columns_from_quoted_table(completer, text):
 texts = ['SELECT * FROM ', 'SELECT * FROM public.Orders O CROSS JOIN ']
 
 
-@parametrize('completer', completers(filtr=True, casing=False, alias=False))
+@parametrize('completer', completers(filtr=True, casing=False, aliasing=False))
 @parametrize('text', texts)
 def test_schema_or_visible_table_completion(completer, text):
     result = result_set(completer, text)
     assert result == set(testdata.schemas_and_from_clause_items())
 
 
-@parametrize('completer', completers(alias=True, casing=False, filtr=True))
+@parametrize('completer', completers(aliasing=True, casing=False, filtr=True))
 @parametrize('text', texts)
 def test_table_aliases(completer, text):
     result = result_set(completer, text)
@@ -425,7 +425,7 @@ def test_table_aliases(completer, text):
         function('func2() f')])
 
 
-@parametrize('completer', completers(alias=True, casing=True, filtr=True))
+@parametrize('completer', completers(aliasing=True, casing=True, filtr=True))
 @parametrize('text', texts)
 def test_aliases_with_casing(completer, text):
     result = result_set(completer, text)
@@ -437,7 +437,7 @@ def test_aliases_with_casing(completer, text):
         function('func2() f')])
 
 
-@parametrize('completer', completers(alias=False, casing=True, filtr=True))
+@parametrize('completer', completers(aliasing=False, casing=True, filtr=True))
 @parametrize('text', texts)
 def test_table_casing(completer, text):
     result = result_set(completer, text)
@@ -449,35 +449,35 @@ def test_table_casing(completer, text):
         function('func2()')])
 
 
-@parametrize('completer', completers(alias=False, casing=True))
+@parametrize('completer', completers(aliasing=False, casing=True))
 def test_alias_search_without_aliases2(completer):
     text = 'SELECT * FROM blog.et'
     result = get_result(completer, text)
     assert result[0] == table('EntryTags', -2)
 
 
-@parametrize('completer', completers(alias=False, casing=True))
+@parametrize('completer', completers(aliasing=False, casing=True))
 def test_alias_search_without_aliases1(completer):
     text = 'SELECT * FROM blog.e'
     result = get_result(completer, text)
     assert result[0] == table('Entries', -1)
 
 
-@parametrize('completer', completers(alias=True, casing=True))
+@parametrize('completer', completers(aliasing=True, casing=True))
 def test_alias_search_with_aliases2(completer):
     text = 'SELECT * FROM blog.et'
     result = get_result(completer, text)
     assert result[0] == table('EntryTags ET', -2)
 
 
-@parametrize('completer', completers(alias=True, casing=True))
+@parametrize('completer', completers(aliasing=True, casing=True))
 def test_alias_search_with_aliases1(completer):
     text = 'SELECT * FROM blog.e'
     result = get_result(completer, text)
     assert result[0] == table('Entries E', -1)
 
 
-@parametrize('completer', completers(alias=True, casing=True))
+@parametrize('completer', completers(aliasing=True, casing=True))
 def test_join_alias_search_with_aliases1(completer):
     text = 'SELECT * FROM blog.Entries E JOIN blog.e'
     result = get_result(completer, text)
@@ -485,7 +485,7 @@ def test_join_alias_search_with_aliases1(completer):
         'EntAccLog EAL ON EAL.EntryID = E.EntryID', -1)]
 
 
-@parametrize('completer', completers(alias=False, casing=True))
+@parametrize('completer', completers(aliasing=False, casing=True))
 def test_join_alias_search_without_aliases1(completer):
     text = 'SELECT * FROM blog.Entries JOIN blog.e'
     result = get_result(completer, text)
@@ -493,14 +493,14 @@ def test_join_alias_search_without_aliases1(completer):
         'EntAccLog ON EntAccLog.EntryID = Entries.EntryID', -1)]
 
 
-@parametrize('completer', completers(alias=True, casing=True))
+@parametrize('completer', completers(aliasing=True, casing=True))
 def test_join_alias_search_with_aliases2(completer):
     text = 'SELECT * FROM blog.Entries E JOIN blog.et'
     result = get_result(completer, text)
     assert result[0] == join('EntryTags ET ON ET.EntryID = E.EntryID', -2)
 
 
-@parametrize('completer', completers(alias=False, casing=True))
+@parametrize('completer', completers(aliasing=False, casing=True))
 def test_join_alias_search_without_aliases2(completer):
     text = 'SELECT * FROM blog.Entries JOIN blog.et'
     result = get_result(completer, text)
@@ -540,14 +540,14 @@ def test_column_alias_search_qualified(completer):
     assert result[:3] == [column(c, -2) for c in cols]
 
 
-@parametrize('completer', completers(casing=False, filtr=False, alias=False))
+@parametrize('completer', completers(casing=False, filtr=False, aliasing=False))
 def test_schema_object_order(completer):
     result = get_result(completer, 'SELECT * FROM u')
     assert result[:3] == [
         table(t, pos=-1) for t in ('users', 'custom."Users"', 'custom.users')
     ]
 
-@parametrize('completer', completers(casing=False, filtr=False, alias=False))
+@parametrize('completer', completers(casing=False, filtr=False, aliasing=False))
 def test_all_schema_objects(completer):
     text = ('SELECT * FROM ')
     result = result_set(completer, text)
@@ -557,7 +557,7 @@ def test_all_schema_objects(completer):
     )
 
 
-@parametrize('completer', completers(filtr=False, alias=False, casing=True))
+@parametrize('completer', completers(filtr=False, aliasing=False, casing=True))
 def test_all_schema_objects_with_casing(completer):
     text = 'SELECT * FROM '
     result = result_set(completer, text)
@@ -567,7 +567,7 @@ def test_all_schema_objects_with_casing(completer):
     )
 
 
-@parametrize('completer', completers(casing=False, filtr=False, alias=True))
+@parametrize('completer', completers(casing=False, filtr=False, aliasing=True))
 def test_all_schema_objects_with_aliases(completer):
     text = ('SELECT * FROM ')
     result = result_set(completer, text)

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -1,9 +1,8 @@
 from __future__ import unicode_literals
-import pytest
 import itertools
 from metadata import (MetaData, alias, name_join, fk_join, join,
     schema, table, function, wildcard_expansion, column,
-    get_result, result_set)
+    get_result, result_set, qual, no_qual, parametrize)
 
 metadata = {
     'tables': {
@@ -63,20 +62,13 @@ metadata = {
 
 testdata = MetaData(metadata)
 cased_schemas = [schema(x) for x in ('public', 'blog', 'CUSTOM', '"Custom"')]
-
 casing = ('SELECT', 'Orders', 'User_Emails', 'CUSTOM', 'Func1', 'Entries',
           'Tags', 'EntryTags', 'EntAccLog',
           'EntryID', 'EntryTitle', 'EntryText')
-
 completers = testdata.get_completers(casing)
-parametrize = pytest.mark.parametrize
 
 
-@parametrize(
-    'completer', completers(
-        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(filtr=True, casing=False, qualify=no_qual))
 @parametrize('table', [
     'users',
     '"users"',
@@ -95,11 +87,7 @@ def test_suggested_column_names_from_shadowed_visible_table(
         )
 
 
-@parametrize(
-    'completer', completers(
-        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(filtr=True, casing=False, qualify=no_qual))
 @parametrize('text', [
     'SELECT  from custom.users',
     'WITH users as (SELECT 1 AS foo) SELECT  from custom.users',
@@ -114,11 +102,7 @@ def test_suggested_column_names_from_qualified_shadowed_table(completer, text):
         )
 
 
-@parametrize(
-    'completer', completers(
-        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(filtr=True, casing=False, qualify=no_qual))
 @parametrize('text', [
     'WITH users as (SELECT 1 AS foo) SELECT  from users',
     ])
@@ -161,11 +145,7 @@ def test_suggested_joins(completer, query, tbl):
         ] + testdata.functions())
 
 
-@parametrize(
-    'completer', completers(
-        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(filtr=True, casing=False, qualify=no_qual))
 def test_suggested_column_names_from_schema_qualifed_table(completer):
     text = 'SELECT  from custom.products'
     position = len('SELECT ')
@@ -176,11 +156,7 @@ def test_suggested_column_names_from_schema_qualifed_table(completer):
     )
 
 
-@parametrize(
-    'completer', completers(
-        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(filtr=True, casing=False, qualify=no_qual))
 def test_suggested_column_names_in_function(completer):
     text = 'SELECT MAX( from custom.products'
     position = len('SELECT MAX(')
@@ -236,11 +212,7 @@ def test_suggested_column_names_with_qualified_alias(completer):
     assert set(result) == set(testdata.columns('products', 'custom'))
 
 
-@parametrize(
-    'completer', completers(
-        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(filtr=True, casing=False, qualify=no_qual))
 def test_suggested_multiple_column_names(completer):
     text = 'SELECT id,  from custom.products'
     position = len('SELECT id, ')
@@ -324,12 +296,7 @@ def test_suggest_columns_from_aliased_set_returning_function(completer):
         testdata.columns('set_returning_func', 'custom', 'functions'))
 
 
-@parametrize(
-    'completer',
-    completers(
-        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer',completers(filtr=True, casing=False, qualify=no_qual))
 @parametrize('text', [
     'SELECT * FROM custom.set_returning_func()',
     'SELECT * FROM Custom.set_returning_func()',
@@ -410,12 +377,7 @@ def test_wildcard_column_expansion_with_table_qualifier(completer):
     assert expected == completions
 
 
-@parametrize(
-    'completer',
-    completers(
-        filtr=True, casing=False, qualify=['if_more_than_one_table', 'always']
-    )
-)
+@parametrize('completer',completers(filtr=True, casing=False, qualify=qual))
 def test_wildcard_column_expansion_with_two_tables(completer):
     text = 'SELECT * FROM public."select" JOIN custom.users ON true'
     position = len('SELECT *')
@@ -586,12 +548,7 @@ def test_function_alias_search_with_aliases(completer):
     assert result[0] == function('enter_entry()', -2)
 
 
-@parametrize(
-    'completer',
-    completers(
-        filtr=True, casing=True, qualify=['if_more_than_one_table', 'never']
-    )
-)
+@parametrize('completer',completers(filtr=True, casing=True, qualify=no_qual))
 def test_column_alias_search(completer):
     text = 'SELECT et FROM blog.Entries E'
     position = len('SELECT et')

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -64,66 +64,33 @@ metadata = {
 testdata = MetaData(metadata)
 cased_schemas = [schema(x) for x in ('public', 'blog', 'CUSTOM', '"Custom"')]
 
-@pytest.fixture
-def completer():
-    return testdata.get_completer(settings={'search_path_filter': True})
-
 casing = ('SELECT', 'Orders', 'User_Emails', 'CUSTOM', 'Func1', 'Entries',
           'Tags', 'EntryTags', 'EntAccLog',
           'EntryID', 'EntryTitle', 'EntryText')
 
-@pytest.fixture
-def completer_with_casing():
-    return testdata.get_completer(
-        settings={'search_path_filter': True},
-        casing=casing
-    )
-
-@pytest.fixture
-def completer_with_aliases():
-    return testdata.get_completer(
-        settings={'generate_aliases': True, 'search_path_filter': True}
-    )
-
-@pytest.fixture
-def completer_aliases_casing():
-    return testdata.get_completer(
-        settings={'generate_aliases': True, 'search_path_filter': True},
-        casing=casing
-    )
-
-@pytest.fixture
-def completer_all_schemas():
-    return testdata.get_completer()
-
-@pytest.fixture
-def completer_all_schemas_casing():
-    return testdata.get_completer(casing=casing)
-
-@pytest.fixture
-def completer_all_schemas_aliases():
-    return testdata.get_completer(settings={'generate_aliases': True})
+completers = testdata.get_completers(casing)
+parametrize = pytest.mark.parametrize
 
 @pytest.fixture
 def complete_event():
     from mock import Mock
     return Mock()
 
-@pytest.mark.parametrize('table', [
+@parametrize(
+    'completer', completers(
+        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
+@parametrize('table', [
     'users',
     '"users"',
     ])
-def test_suggested_column_names_from_shadowed_visible_table(completer, complete_event, table):
-    """
-    Suggest column and function names when selecting from table
-    :param completer:
-    :param complete_event:
-    :return:
-    """
+def test_suggested_column_names_from_shadowed_visible_table(
+    completer, complete_event, table
+):
     text = 'SELECT  FROM ' + table
     position = len('SELECT ')
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=position),
+    result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
 
     assert set(result) == set(testdata.columns('users') +
@@ -132,14 +99,20 @@ def test_suggested_column_names_from_shadowed_visible_table(completer, complete_
         testdata.keywords())
         )
 
-@pytest.mark.parametrize('text', [
+@parametrize(
+    'completer', completers(
+        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
+@parametrize('text', [
     'SELECT  from custom.users',
     'WITH users as (SELECT 1 AS foo) SELECT  from custom.users',
     ])
-def test_suggested_column_names_from_qualified_shadowed_table(completer, complete_event, text):
+def test_suggested_column_names_from_qualified_shadowed_table(
+    completer, complete_event, text
+):
     position = text.find('  ') + 1
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=position),
+    result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set(testdata.columns('users', 'custom') +
         testdata.functions() +
@@ -147,19 +120,26 @@ def test_suggested_column_names_from_qualified_shadowed_table(completer, complet
         testdata.keywords())
         )
 
-@pytest.mark.parametrize('text', [
+@parametrize(
+    'completer', completers(
+        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
+@parametrize('text', [
     'WITH users as (SELECT 1 AS foo) SELECT  from users',
     ])
-def test_suggested_column_names_from_cte(completer, complete_event, text):
+def test_suggested_column_names_from_cte(
+    completer, complete_event, text
+):
     position = text.find('  ') + 1
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=position),
+    result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([column('foo')] + testdata.functions() +
         list(testdata.builtin_functions() + testdata.keywords())
     )
 
-@pytest.mark.parametrize('text', [
+@parametrize('completer', completers(casing=False))
+@parametrize('text', [
     'SELECT * FROM users JOIN custom.shipments ON ',
     '''SELECT *
     FROM public.users
@@ -167,8 +147,7 @@ def test_suggested_column_names_from_cte(completer, complete_event, text):
 ])
 def test_suggested_join_conditions(completer, complete_event, text):
     position = len(text)
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=position),
+    result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
         alias('users'),
@@ -176,7 +155,8 @@ def test_suggested_join_conditions(completer, complete_event, text):
         name_join('shipments.id = users.id'),
         fk_join('shipments.user_id = users.id')])
 
-@pytest.mark.parametrize(('query', 'tbl'), itertools.product((
+@parametrize('completer', completers(filtr=True, casing=False, alias=False))
+@parametrize(('query', 'tbl'), itertools.product((
     'SELECT * FROM public.{0} RIGHT OUTER JOIN ',
     '''SELECT *
     FROM {0}
@@ -185,53 +165,57 @@ def test_suggested_join_conditions(completer, complete_event, text):
 def test_suggested_joins(completer, complete_event, query, tbl):
     text = query.format(tbl)
     position = len(text)
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=position),
+    result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set(testdata.schemas() + testdata.tables() + [
         join('custom.shipments ON shipments.user_id = {0}.id'.format(tbl)),
         ] + testdata.functions())
 
-def test_suggested_column_names_from_schema_qualifed_table(completer, complete_event):
-    """
-    Suggest column and function names when selecting from a qualified-table
-    :param completer:
-    :param complete_event:
-    :return:
-    """
+@parametrize(
+    'completer', completers(
+        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
+def test_suggested_column_names_from_schema_qualifed_table(
+    completer, complete_event
+):
     text = 'SELECT  from custom.products'
     position = len('SELECT ')
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=position), complete_event))
-    assert set(result) == set(testdata.columns('products', 'custom') + testdata.functions() +
-        list(testdata.builtin_functions() +
-        testdata.keywords())
+    result = set(
+        completer.get_completions(
+            Document(text=text, cursor_position=position), complete_event
         )
+    )
+    assert set(result) == set(
+        testdata.columns('products', 'custom') + testdata.functions() +
+        list(testdata.builtin_functions() + testdata.keywords())
+    )
 
-def test_suggested_column_names_in_function(completer, complete_event):
-    """
-    Suggest column and function names when selecting multiple
-    columns from table
-    :param completer:
-    :param complete_event:
-    :return:
-    """
+@parametrize(
+    'completer', completers(
+        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
+def test_suggested_column_names_in_function(
+    completer, complete_event
+):
     text = 'SELECT MAX( from custom.products'
     position = len('SELECT MAX(')
     result = completer.get_completions(
-        Document(text=text, cursor_position=position),
-        complete_event)
+        Document(text=text, cursor_position=position), complete_event
+    )
     assert set(result) == set(testdata.columns('products', 'custom'))
 
-
-@pytest.mark.parametrize('text', [
+@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('text', [
     'SELECT * FROM Custom.',
     'SELECT * FROM custom.',
     'SELECT * FROM "custom".',
 ])
-@pytest.mark.parametrize('use_leading_double_quote', [False, True])
-def test_suggested_table_names_with_schema_dot(completer, complete_event,
-                                               text, use_leading_double_quote):
+@parametrize('use_leading_double_quote', [False, True])
+def test_suggested_table_names_with_schema_dot(
+    completer, complete_event, text, use_leading_double_quote
+):
     if use_leading_double_quote:
         text += '"'
         start_pos = -1
@@ -239,17 +223,18 @@ def test_suggested_table_names_with_schema_dot(completer, complete_event,
         start_pos = 0
 
     position = len(text)
-    result = completer.get_completions(
-        Document(text=text, cursor_position=position), complete_event)
+    result = completer.get_completions(Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set(testdata.tables('custom', start_pos)
         + testdata.functions('custom', start_pos))
 
-@pytest.mark.parametrize('text', [
+@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('text', [
     'SELECT * FROM "Custom".',
 ])
-@pytest.mark.parametrize('use_leading_double_quote', [False, True])
-def test_suggested_table_names_with_schema_dot2(completer, complete_event,
-                                               text, use_leading_double_quote):
+@parametrize('use_leading_double_quote', [False, True])
+def test_suggested_table_names_with_schema_dot2(
+    completer, complete_event, text, use_leading_double_quote
+):
     if use_leading_double_quote:
         text += '"'
         start_pos = -1
@@ -257,37 +242,27 @@ def test_suggested_table_names_with_schema_dot2(completer, complete_event,
         start_pos = 0
 
     position = len(text)
-    result = completer.get_completions(
-        Document(text=text, cursor_position=position), complete_event)
+    result = completer.get_completions(Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set(testdata.functions('Custom', start_pos) +
         testdata.tables('Custom', start_pos))
 
+@parametrize('completer', completers(filtr=True, casing=False))
 def test_suggested_column_names_with_qualified_alias(completer, complete_event):
-    """
-    Suggest column names on table alias and dot
-    :param completer:
-    :param complete_event:
-    :return:
-    """
     text = 'SELECT p. from custom.products p'
     position = len('SELECT p.')
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=position),
+    result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set(testdata.columns('products', 'custom'))
 
+@parametrize(
+    'completer', completers(
+        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
 def test_suggested_multiple_column_names(completer, complete_event):
-    """
-    Suggest column and function names when selecting multiple
-    columns from table
-    :param completer:
-    :param complete_event:
-    :return:
-    """
     text = 'SELECT id,  from custom.products'
     position = len('SELECT id, ')
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=position),
+    result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set(testdata.columns('products', 'custom') +
         testdata.functions() +
@@ -295,29 +270,22 @@ def test_suggested_multiple_column_names(completer, complete_event):
         testdata.keywords())
         )
 
+@parametrize('completer', completers(filtr=True, casing=False))
 def test_suggested_multiple_column_names_with_alias(completer, complete_event):
-    """
-    Suggest column names on table alias and dot
-    when selecting multiple columns from table
-    :param completer:
-    :param complete_event:
-    :return:
-    """
     text = 'SELECT p.id, p. from custom.products p'
     position = len('SELECT u.id, u.')
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=position),
+    result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set(testdata.columns('products', 'custom'))
 
-@pytest.mark.parametrize('text', [
+@parametrize('completer', completers(filtr=True, casing=False))
+@parametrize('text', [
     'SELECT x.id, y.product_name FROM custom.products x JOIN custom.products y ON ',
     'SELECT x.id, y.product_name FROM custom.products x JOIN custom.products y ON JOIN public.orders z ON z.id > y.id'
 ])
 def test_suggestions_after_on(completer, complete_event, text):
     position = len('SELECT x.id, y.product_name FROM custom.products x JOIN custom.products y ON ')
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=position),
+    result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
         alias('x'),
@@ -326,87 +294,97 @@ def test_suggestions_after_on(completer, complete_event, text):
         name_join('y.product_name = x.product_name'),
         name_join('y.id = x.id')])
 
+@parametrize('completer', completers())
 def test_suggested_aliases_after_on_right_side(completer, complete_event):
     text = 'SELECT x.id, y.product_name FROM custom.products x JOIN custom.products y ON x.id = '
     position = len(text)
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=position),
+    result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set([
         alias('x'),
         alias('y')])
 
+@parametrize('completer', completers(filtr=True, casing=False, alias=False))
 def test_table_names_after_from(completer, complete_event):
     text = 'SELECT * FROM '
     position = len('SELECT * FROM ')
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=position),
+    result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set(testdata.schemas() + testdata.tables()
         + testdata.functions())
 
+@parametrize('completer', completers(filtr=True, casing=False))
 def test_schema_qualified_function_name(completer, complete_event):
     text = 'SELECT custom.func'
     postion = len(text)
-    result = set(completer.get_completions(
-        Document(text=text, cursor_position=postion), complete_event))
+    result = set(completer.get_completions(Document(text=text, cursor_position=postion), complete_event))
     assert result == set([
         function('func3()', -len('func')),
         function('set_returning_func()', -len('func'))])
 
-
-@pytest.mark.parametrize('text', [
+@parametrize('completer', completers(filtr=True, casing=False))
+@parametrize('text', [
     'SELECT 1::custom.',
     'CREATE TABLE foo (bar custom.',
     'CREATE FUNCTION foo (bar INT, baz custom.',
     'ALTER TABLE foo ALTER COLUMN bar TYPE custom.',
 ])
-def test_schema_qualified_type_name(text, completer, complete_event):
+def test_schema_qualified_type_name(completer, text, complete_event):
     pos = len(text)
-    result = completer.get_completions(
-        Document(text=text, cursor_position=pos), complete_event)
+    result = completer.get_completions(Document(text=text, cursor_position=pos), complete_event)
     assert set(result) == set(testdata.datatypes('custom')
         + testdata.tables('custom'))
 
-
-def test_suggest_columns_from_aliased_set_returning_function(completer, complete_event):
+@parametrize('completer', completers(filtr=True, casing=False))
+def test_suggest_columns_from_aliased_set_returning_function(
+    completer, complete_event
+):
     sql = 'select f. from custom.set_returning_func() f'
     pos = len('select f.')
-    result = completer.get_completions(Document(text=sql, cursor_position=pos),
-                                       complete_event)
+    result = completer.get_completions(Document(text=sql, cursor_position=pos), complete_event
+    )
     assert set(result) == set(
         testdata.columns('set_returning_func', 'custom', 'functions'))
 
-@pytest.mark.parametrize('text', [
+@parametrize(
+    'completer',
+    completers(
+        filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
+@parametrize('text', [
     'SELECT * FROM custom.set_returning_func()',
     'SELECT * FROM Custom.set_returning_func()',
     'SELECT * FROM Custom.Set_Returning_Func()'
 ])
-def test_wildcard_column_expansion_with_function(completer, complete_event, text):
+def test_wildcard_column_expansion_with_function(
+    completer, complete_event, text
+):
     pos = len('SELECT *')
 
-    completions = completer.get_completions(
-        Document(text=text, cursor_position=pos), complete_event)
+    completions = completer.get_completions(Document(text=text, cursor_position=pos), complete_event)
 
     col_list = 'x'
     expected = [wildcard_expansion(col_list)]
 
     assert expected == completions
 
-
-def test_wildcard_column_expansion_with_alias_qualifier(completer, complete_event):
+@parametrize('completer', completers(filtr=True, casing=False))
+def test_wildcard_column_expansion_with_alias_qualifier(
+    completer, complete_event
+):
     sql = 'SELECT p.* FROM custom.products p'
     pos = len('SELECT p.*')
 
-    completions = completer.get_completions(
-        Document(text=sql, cursor_position=pos), complete_event)
+    completions = completer.get_completions(Document(text=sql, cursor_position=pos), complete_event)
 
     col_list = 'id, p.product_name, p.price'
     expected = [wildcard_expansion(col_list)]
 
     assert expected == completions
 
-@pytest.mark.parametrize('text', [
+@parametrize('completer', completers(filtr=True, casing=False))
+@parametrize('text', [
     '''
     SELECT count(1) FROM users;
     CREATE FUNCTION foo(custom.products _products) returns custom.shipments
@@ -435,52 +413,64 @@ def test_wildcard_column_expansion_with_alias_qualifier(completer, complete_even
     'INSERT INTO orders (*)',
     'INSERT INTO Orders (*)'
 ])
-def test_wildcard_column_expansion_with_insert(completer, complete_event, text):
+def test_wildcard_column_expansion_with_insert(
+    completer, complete_event, text
+):
     pos = text.index('*') + 1
-    completions = completer.get_completions(
-        Document(text=text, cursor_position=pos), complete_event)
+    completions = completer.get_completions(Document(text=text, cursor_position=pos), complete_event)
 
     expected = [wildcard_expansion('id, ordered_date, status')]
     assert expected == completions
 
-def test_wildcard_column_expansion_with_table_qualifier(completer, complete_event):
+@parametrize('completer', completers(filtr=True, casing=False))
+def test_wildcard_column_expansion_with_table_qualifier(
+    completer, complete_event
+):
     sql = 'SELECT "select".* FROM public."select"'
     pos = len('SELECT "select".*')
 
-    completions = completer.get_completions(
-        Document(text=sql, cursor_position=pos), complete_event)
+    completions = completer.get_completions(Document(text=sql, cursor_position=pos), complete_event)
 
     col_list = 'id, "select"."insert", "select"."ABC"'
     expected = [wildcard_expansion(col_list)]
 
     assert expected == completions
 
-def test_wildcard_column_expansion_with_two_tables(completer, complete_event):
+@parametrize(
+    'completer',
+    completers(
+        filtr=True, casing=False, qualify=['if_more_than_one_table', 'always']
+    )
+)
+def test_wildcard_column_expansion_with_two_tables(
+    completer, complete_event
+):
     sql = 'SELECT * FROM public."select" JOIN custom.users ON true'
     pos = len('SELECT *')
 
-    completions = completer.get_completions(
-        Document(text=sql, cursor_position=pos), complete_event)
+    completions = completer.get_completions(Document(text=sql, cursor_position=pos), complete_event)
 
     cols = ('"select".id, "select"."insert", "select"."ABC", '
         'users.id, users.phone_number')
     expected = [wildcard_expansion(cols)]
     assert completions == expected
 
-
-def test_wildcard_column_expansion_with_two_tables_and_parent(completer, complete_event):
+@parametrize('completer', completers(filtr=True, casing=False))
+def test_wildcard_column_expansion_with_two_tables_and_parent(
+    completer, complete_event
+):
     sql = 'SELECT "select".* FROM public."select" JOIN custom.users u ON true'
     pos = len('SELECT "select".*')
 
-    completions = completer.get_completions(
-        Document(text=sql, cursor_position=pos), complete_event)
+    completions = completer.get_completions(Document(text=sql, cursor_position=pos), complete_event)
 
     col_list = 'id, "select"."insert", "select"."ABC"'
     expected = [wildcard_expansion(col_list)]
 
     assert expected == completions
 
-@pytest.mark.parametrize('text', [
+@parametrize('completer', completers(filtr=True, casing=False))
+@parametrize('text', [
     'SELECT U. FROM custom.Users U',
     'SELECT U. FROM custom.USERS U',
     'SELECT U. FROM custom.users U',
@@ -494,29 +484,30 @@ def test_suggest_columns_from_unquoted_table(completer, complete_event, text):
                                        complete_event)
     assert set(result) == set(testdata.columns('users', 'custom'))
 
-@pytest.mark.parametrize('text', [
+@parametrize('completer', completers(filtr=True, casing=False))
+@parametrize('text', [
     'SELECT U. FROM custom."Users" U',
     'SELECT U. FROM "custom"."Users" U'
 ])
 def test_suggest_columns_from_quoted_table(completer, complete_event, text):
     pos = len('SELECT U.')
-    result = completer.get_completions(Document(text=text, cursor_position=pos),
-                                       complete_event)
+    result = completer.get_completions(Document(text=text, cursor_position=pos), complete_event
+    )
     assert set(result) == set(testdata.columns('Users', 'custom'))
 
 texts = ['SELECT * FROM ', 'SELECT * FROM public.Orders O CROSS JOIN ']
 
-@pytest.mark.parametrize('text', texts)
+@parametrize('completer', completers(filtr=True, casing=False, alias=False))
+@parametrize('text', texts)
 def test_schema_or_visible_table_completion(completer, complete_event, text):
     result = completer.get_completions(Document(text=text), complete_event)
     assert set(result) == set(testdata.schemas()
         + testdata.views() + testdata.tables() + testdata.functions())
-    result = completer.get_completions(Document(text=text), complete_event)
 
-@pytest.mark.parametrize('text', texts)
-def test_table_aliases(completer_with_aliases, complete_event, text):
-    result = completer_with_aliases.get_completions(
-        Document(text=text), complete_event)
+@parametrize('completer', completers(alias=True, casing=False, filtr=True))
+@parametrize('text', texts)
+def test_table_aliases(completer, complete_event, text):
+    result = completer.get_completions(Document(text=text), complete_event)
     assert set(result) == set(testdata.schemas() + [
         table('users u'),
         table('orders o' if text == 'SELECT * FROM ' else 'orders o2'),
@@ -524,10 +515,10 @@ def test_table_aliases(completer_with_aliases, complete_event, text):
         function('func1() f'),
         function('func2() f')])
 
-@pytest.mark.parametrize('text', texts)
-def test_aliases_with_casing(completer_aliases_casing, complete_event, text):
-    result = completer_aliases_casing.get_completions(
-        Document(text=text), complete_event)
+@parametrize('completer', completers(alias=True, casing=True, filtr=True))
+@parametrize('text', texts)
+def test_aliases_with_casing(completer, complete_event, text):
+    result = completer.get_completions(Document(text=text), complete_event)
     assert set(result) == set(cased_schemas + [
         table('users u'),
         table('Orders O' if text == 'SELECT * FROM ' else 'Orders O2'),
@@ -535,10 +526,10 @@ def test_aliases_with_casing(completer_aliases_casing, complete_event, text):
         function('Func1() F'),
         function('func2() f')])
 
-@pytest.mark.parametrize('text', texts)
-def test_table_casing(completer_with_casing, complete_event, text):
-    result = completer_with_casing.get_completions(
-        Document(text=text), complete_event)
+@parametrize('completer', completers(alias=False, casing=True, filtr=True))
+@parametrize('text', texts)
+def test_table_casing(completer, complete_event, text):
+    result = completer.get_completions(Document(text=text), complete_event)
     assert set(result) == set(cased_schemas + [
         table('users'),
         table('Orders'),
@@ -546,94 +537,98 @@ def test_table_casing(completer_with_casing, complete_event, text):
         function('Func1()'),
         function('func2()')])
 
-def test_alias_search_without_aliases2(completer_with_casing, complete_event):
+@parametrize('completer', completers(alias=False, casing=True))
+def test_alias_search_without_aliases2(completer, complete_event
+):
     text = 'SELECT * FROM blog.et'
-    result = completer_with_casing.get_completions(
-        Document(text=text), complete_event)
+    result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == table('EntryTags', -2)
 
-def test_alias_search_without_aliases1(completer_with_casing, complete_event):
+@parametrize('completer', completers(alias=False, casing=True))
+def test_alias_search_without_aliases1(completer, complete_event
+):
     text = 'SELECT * FROM blog.e'
-    result = completer_with_casing.get_completions(
-        Document(text=text), complete_event)
+    result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == table('Entries', -1)
 
-def test_alias_search_with_aliases2(completer_aliases_casing, complete_event):
+@parametrize('completer', completers(alias=True, casing=True))
+def test_alias_search_with_aliases2(completer, complete_event):
     text = 'SELECT * FROM blog.et'
-    result = completer_aliases_casing.get_completions(
-        Document(text=text), complete_event)
+    result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == table('EntryTags ET', -2)
 
-def test_alias_search_with_aliases1(completer_aliases_casing, complete_event):
+@parametrize('completer', completers(alias=True, casing=True))
+def test_alias_search_with_aliases1(completer, complete_event):
     text = 'SELECT * FROM blog.e'
-    result = completer_aliases_casing.get_completions(
-        Document(text=text), complete_event)
+    result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == table('Entries E', -1)
 
-def test_join_alias_search_with_aliases1(completer_aliases_casing,
+@parametrize('completer', completers(alias=True, casing=True))
+def test_join_alias_search_with_aliases1(completer,
                                          complete_event):
     text = 'SELECT * FROM blog.Entries E JOIN blog.e'
-    result = completer_aliases_casing.get_completions(
-        Document(text=text), complete_event)
+    result = completer.get_completions(Document(text=text), complete_event)
     assert result[:2] == [table('Entries E2', -1), join(
         'EntAccLog EAL ON EAL.EntryID = E.EntryID', -1)]
 
-def test_join_alias_search_without_aliases1(completer_with_casing,
-                                            complete_event):
+@parametrize('completer', completers(alias=False, casing=True))
+def test_join_alias_search_without_aliases1(completer, complete_event):
     text = 'SELECT * FROM blog.Entries JOIN blog.e'
-    result = completer_with_casing.get_completions(
-        Document(text=text), complete_event)
+    result = completer.get_completions(Document(text=text), complete_event)
     assert result[:2] == [table('Entries', -1), join(
         'EntAccLog ON EntAccLog.EntryID = Entries.EntryID', -1)]
 
-def test_join_alias_search_with_aliases2(completer_aliases_casing,
-                                         complete_event):
+@parametrize('completer', completers(alias=True, casing=True))
+def test_join_alias_search_with_aliases2(completer, complete_event):
     text = 'SELECT * FROM blog.Entries E JOIN blog.et'
-    result = completer_aliases_casing.get_completions(
-        Document(text=text), complete_event)
+    result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == join('EntryTags ET ON ET.EntryID = E.EntryID', -2)
 
-def test_join_alias_search_without_aliases2(completer_with_casing,
-                                            complete_event):
+@parametrize('completer', completers(alias=False, casing=True))
+def test_join_alias_search_without_aliases2(completer, complete_event):
     text = 'SELECT * FROM blog.Entries JOIN blog.et'
-    result = completer_with_casing.get_completions(
-        Document(text=text), complete_event)
+    result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == join(
         'EntryTags ON EntryTags.EntryID = Entries.EntryID', -2)
 
-def test_function_alias_search_without_aliases(completer_with_casing,
-                                               complete_event):
+@parametrize('completer', completers())
+def test_function_alias_search_without_aliases(completer, complete_event):
     text = 'SELECT blog.ees'
-    result = completer_with_casing.get_completions(
-        Document(text=text), complete_event)
+    result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == function('extract_entry_symbols()', -3)
 
-def test_function_alias_search_with_aliases(completer_aliases_casing,
-                                            complete_event):
+@parametrize('completer', completers())
+def test_function_alias_search_with_aliases(completer, complete_event):
     text = 'SELECT blog.ee'
-    result = completer_aliases_casing.get_completions(
-        Document(text=text), complete_event)
+    result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == function('enter_entry()', -2)
 
-def test_column_alias_search(completer_aliases_casing, complete_event):
+@parametrize(
+    'completer',
+    completers(
+        filtr=True, casing=True, qualify=['if_more_than_one_table', 'never']
+    )
+)
+def test_column_alias_search(completer, complete_event):
     text = 'SELECT et FROM blog.Entries E'
-    result = completer_aliases_casing.get_completions(
-        Document(text, cursor_position=len('SELECT et')), complete_event)
+    result = completer.get_completions(
+        Document(text, cursor_position=len('SELECT et')), complete_event
+    )
     cols = ('EntryText', 'EntryTitle', 'EntryID')
     assert result[:3] == [column(c, -2) for c in cols]
 
-def test_column_alias_search_qualified(completer_aliases_casing,
-                                       complete_event):
+@parametrize('completer', completers(casing=True))
+def test_column_alias_search_qualified(completer, complete_event):
     text = 'SELECT E.ei FROM blog.Entries E'
-    result = completer_aliases_casing.get_completions(
-        Document(text, cursor_position=len('SELECT E.ei')), complete_event)
+    result = completer.get_completions(Document(text, cursor_position=len('SELECT E.ei')), complete_event)
     cols = ('EntryID', 'EntryTitle')
     assert result[:3] == [column(c, -2) for c in cols]
 
-def test_schema_object_order(completer_all_schemas, complete_event):
+@parametrize('completer', completers(casing=False, filtr=False, alias=False))
+def test_schema_object_order(completer, complete_event):
     text = 'SELECT * FROM u'
     position = len('SELECT * FROM u')
-    result = completer_all_schemas.get_completions(
+    result = completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event
     )
@@ -641,11 +636,12 @@ def test_schema_object_order(completer_all_schemas, complete_event):
         table(t, pos=-1) for t in ('users', 'custom."Users"', 'custom.users')
     ]
 
-def test_all_schema_objects(completer_all_schemas, complete_event):
+@parametrize('completer', completers(casing=False, filtr=False, alias=False))
+def test_all_schema_objects(completer, complete_event):
     text = 'SELECT * FROM '
     position = len('SELECT * FROM ')
     result = set(
-        completer_all_schemas.get_completions(
+        completer.get_completions(
             Document(text=text, cursor_position=position),
             complete_event
         )
@@ -655,13 +651,12 @@ def test_all_schema_objects(completer_all_schemas, complete_event):
         + [function(x+'()') for x in ('func2', 'custom.func3')]
     )
 
-def test_all_schema_objects_with_casing(
-    completer_all_schemas_casing, complete_event
-):
+@parametrize('completer', completers(filtr=False, alias=False, casing=True))
+def test_all_schema_objects_with_casing(completer, complete_event):
     text = 'SELECT * FROM '
     position = len('SELECT * FROM ')
     result = set(
-        completer_all_schemas_casing.get_completions(
+        completer.get_completions(
             Document(text=text, cursor_position=position),
             complete_event
         )
@@ -671,13 +666,12 @@ def test_all_schema_objects_with_casing(
         + [function(x+'()') for x in ('func2', 'CUSTOM.func3')]
     )
 
-def test_all_schema_objects_with_aliases(
-    completer_all_schemas_aliases, complete_event
-):
+@parametrize('completer', completers(casing=False, filtr=False, alias=True))
+def test_all_schema_objects_with_aliases(completer, complete_event):
     text = 'SELECT * FROM '
     position = len('SELECT * FROM ')
     result = set(
-        completer_all_schemas_aliases.get_completions(
+        completer.get_completions(
             Document(text=text, cursor_position=position),
             complete_event
         )

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -71,10 +71,12 @@ casing = ('SELECT', 'Orders', 'User_Emails', 'CUSTOM', 'Func1', 'Entries',
 completers = testdata.get_completers(casing)
 parametrize = pytest.mark.parametrize
 
+
 @pytest.fixture
 def complete_event():
     from mock import Mock
     return Mock()
+
 
 @parametrize(
     'completer', completers(
@@ -99,6 +101,7 @@ def test_suggested_column_names_from_shadowed_visible_table(
         testdata.keywords())
         )
 
+
 @parametrize(
     'completer', completers(
         filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
@@ -120,6 +123,7 @@ def test_suggested_column_names_from_qualified_shadowed_table(
         testdata.keywords())
         )
 
+
 @parametrize(
     'completer', completers(
         filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
@@ -138,6 +142,7 @@ def test_suggested_column_names_from_cte(
         list(testdata.builtin_functions() + testdata.keywords())
     )
 
+
 @parametrize('completer', completers(casing=False))
 @parametrize('text', [
     'SELECT * FROM users JOIN custom.shipments ON ',
@@ -155,6 +160,7 @@ def test_suggested_join_conditions(completer, complete_event, text):
         name_join('shipments.id = users.id'),
         fk_join('shipments.user_id = users.id')])
 
+
 @parametrize('completer', completers(filtr=True, casing=False, alias=False))
 @parametrize(('query', 'tbl'), itertools.product((
     'SELECT * FROM public.{0} RIGHT OUTER JOIN ',
@@ -170,6 +176,7 @@ def test_suggested_joins(completer, complete_event, query, tbl):
     assert set(result) == set(testdata.schemas() + testdata.tables() + [
         join('custom.shipments ON shipments.user_id = {0}.id'.format(tbl)),
         ] + testdata.functions())
+
 
 @parametrize(
     'completer', completers(
@@ -191,6 +198,7 @@ def test_suggested_column_names_from_schema_qualifed_table(
         list(testdata.builtin_functions() + testdata.keywords())
     )
 
+
 @parametrize(
     'completer', completers(
         filtr=True, casing=False, qualify=['never', 'if_more_than_one_table']
@@ -205,6 +213,7 @@ def test_suggested_column_names_in_function(
         Document(text=text, cursor_position=position), complete_event
     )
     assert set(result) == set(testdata.columns('products', 'custom'))
+
 
 @parametrize('completer', completers(casing=False, alias=False))
 @parametrize('text', [
@@ -227,6 +236,7 @@ def test_suggested_table_names_with_schema_dot(
     assert set(result) == set(testdata.tables('custom', start_pos)
         + testdata.functions('custom', start_pos))
 
+
 @parametrize('completer', completers(casing=False, alias=False))
 @parametrize('text', [
     'SELECT * FROM "Custom".',
@@ -246,6 +256,7 @@ def test_suggested_table_names_with_schema_dot2(
     assert set(result) == set(testdata.functions('Custom', start_pos) +
         testdata.tables('Custom', start_pos))
 
+
 @parametrize('completer', completers(filtr=True, casing=False))
 def test_suggested_column_names_with_qualified_alias(completer, complete_event):
     text = 'SELECT p. from custom.products p'
@@ -253,6 +264,7 @@ def test_suggested_column_names_with_qualified_alias(completer, complete_event):
     result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set(testdata.columns('products', 'custom'))
+
 
 @parametrize(
     'completer', completers(
@@ -270,6 +282,7 @@ def test_suggested_multiple_column_names(completer, complete_event):
         testdata.keywords())
         )
 
+
 @parametrize('completer', completers(filtr=True, casing=False))
 def test_suggested_multiple_column_names_with_alias(completer, complete_event):
     text = 'SELECT p.id, p. from custom.products p'
@@ -277,6 +290,7 @@ def test_suggested_multiple_column_names_with_alias(completer, complete_event):
     result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set(testdata.columns('products', 'custom'))
+
 
 @parametrize('completer', completers(filtr=True, casing=False))
 @parametrize('text', [
@@ -294,6 +308,7 @@ def test_suggestions_after_on(completer, complete_event, text):
         name_join('y.product_name = x.product_name'),
         name_join('y.id = x.id')])
 
+
 @parametrize('completer', completers())
 def test_suggested_aliases_after_on_right_side(completer, complete_event):
     text = 'SELECT x.id, y.product_name FROM custom.products x JOIN custom.products y ON x.id = '
@@ -304,6 +319,7 @@ def test_suggested_aliases_after_on_right_side(completer, complete_event):
         alias('x'),
         alias('y')])
 
+
 @parametrize('completer', completers(filtr=True, casing=False, alias=False))
 def test_table_names_after_from(completer, complete_event):
     text = 'SELECT * FROM '
@@ -313,6 +329,7 @@ def test_table_names_after_from(completer, complete_event):
     assert set(result) == set(testdata.schemas() + testdata.tables()
         + testdata.functions())
 
+
 @parametrize('completer', completers(filtr=True, casing=False))
 def test_schema_qualified_function_name(completer, complete_event):
     text = 'SELECT custom.func'
@@ -321,6 +338,7 @@ def test_schema_qualified_function_name(completer, complete_event):
     assert result == set([
         function('func3()', -len('func')),
         function('set_returning_func()', -len('func'))])
+
 
 @parametrize('completer', completers(filtr=True, casing=False))
 @parametrize('text', [
@@ -335,6 +353,7 @@ def test_schema_qualified_type_name(completer, text, complete_event):
     assert set(result) == set(testdata.datatypes('custom')
         + testdata.tables('custom'))
 
+
 @parametrize('completer', completers(filtr=True, casing=False))
 def test_suggest_columns_from_aliased_set_returning_function(
     completer, complete_event
@@ -345,6 +364,7 @@ def test_suggest_columns_from_aliased_set_returning_function(
     )
     assert set(result) == set(
         testdata.columns('set_returning_func', 'custom', 'functions'))
+
 
 @parametrize(
     'completer',
@@ -369,6 +389,7 @@ def test_wildcard_column_expansion_with_function(
 
     assert expected == completions
 
+
 @parametrize('completer', completers(filtr=True, casing=False))
 def test_wildcard_column_expansion_with_alias_qualifier(
     completer, complete_event
@@ -382,6 +403,7 @@ def test_wildcard_column_expansion_with_alias_qualifier(
     expected = [wildcard_expansion(col_list)]
 
     assert expected == completions
+
 
 @parametrize('completer', completers(filtr=True, casing=False))
 @parametrize('text', [
@@ -422,6 +444,7 @@ def test_wildcard_column_expansion_with_insert(
     expected = [wildcard_expansion('id, ordered_date, status')]
     assert expected == completions
 
+
 @parametrize('completer', completers(filtr=True, casing=False))
 def test_wildcard_column_expansion_with_table_qualifier(
     completer, complete_event
@@ -435,6 +458,7 @@ def test_wildcard_column_expansion_with_table_qualifier(
     expected = [wildcard_expansion(col_list)]
 
     assert expected == completions
+
 
 @parametrize(
     'completer',
@@ -455,6 +479,7 @@ def test_wildcard_column_expansion_with_two_tables(
     expected = [wildcard_expansion(cols)]
     assert completions == expected
 
+
 @parametrize('completer', completers(filtr=True, casing=False))
 def test_wildcard_column_expansion_with_two_tables_and_parent(
     completer, complete_event
@@ -468,6 +493,7 @@ def test_wildcard_column_expansion_with_two_tables_and_parent(
     expected = [wildcard_expansion(col_list)]
 
     assert expected == completions
+
 
 @parametrize('completer', completers(filtr=True, casing=False))
 @parametrize('text', [
@@ -484,6 +510,7 @@ def test_suggest_columns_from_unquoted_table(completer, complete_event, text):
                                        complete_event)
     assert set(result) == set(testdata.columns('users', 'custom'))
 
+
 @parametrize('completer', completers(filtr=True, casing=False))
 @parametrize('text', [
     'SELECT U. FROM custom."Users" U',
@@ -497,12 +524,14 @@ def test_suggest_columns_from_quoted_table(completer, complete_event, text):
 
 texts = ['SELECT * FROM ', 'SELECT * FROM public.Orders O CROSS JOIN ']
 
+
 @parametrize('completer', completers(filtr=True, casing=False, alias=False))
 @parametrize('text', texts)
 def test_schema_or_visible_table_completion(completer, complete_event, text):
     result = completer.get_completions(Document(text=text), complete_event)
     assert set(result) == set(testdata.schemas()
         + testdata.views() + testdata.tables() + testdata.functions())
+
 
 @parametrize('completer', completers(alias=True, casing=False, filtr=True))
 @parametrize('text', texts)
@@ -515,6 +544,7 @@ def test_table_aliases(completer, complete_event, text):
         function('func1() f'),
         function('func2() f')])
 
+
 @parametrize('completer', completers(alias=True, casing=True, filtr=True))
 @parametrize('text', texts)
 def test_aliases_with_casing(completer, complete_event, text):
@@ -525,6 +555,7 @@ def test_aliases_with_casing(completer, complete_event, text):
         table('"select" s'),
         function('Func1() F'),
         function('func2() f')])
+
 
 @parametrize('completer', completers(alias=False, casing=True, filtr=True))
 @parametrize('text', texts)
@@ -537,12 +568,14 @@ def test_table_casing(completer, complete_event, text):
         function('Func1()'),
         function('func2()')])
 
+
 @parametrize('completer', completers(alias=False, casing=True))
 def test_alias_search_without_aliases2(completer, complete_event
 ):
     text = 'SELECT * FROM blog.et'
     result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == table('EntryTags', -2)
+
 
 @parametrize('completer', completers(alias=False, casing=True))
 def test_alias_search_without_aliases1(completer, complete_event
@@ -551,17 +584,20 @@ def test_alias_search_without_aliases1(completer, complete_event
     result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == table('Entries', -1)
 
+
 @parametrize('completer', completers(alias=True, casing=True))
 def test_alias_search_with_aliases2(completer, complete_event):
     text = 'SELECT * FROM blog.et'
     result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == table('EntryTags ET', -2)
 
+
 @parametrize('completer', completers(alias=True, casing=True))
 def test_alias_search_with_aliases1(completer, complete_event):
     text = 'SELECT * FROM blog.e'
     result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == table('Entries E', -1)
+
 
 @parametrize('completer', completers(alias=True, casing=True))
 def test_join_alias_search_with_aliases1(completer,
@@ -571,6 +607,7 @@ def test_join_alias_search_with_aliases1(completer,
     assert result[:2] == [table('Entries E2', -1), join(
         'EntAccLog EAL ON EAL.EntryID = E.EntryID', -1)]
 
+
 @parametrize('completer', completers(alias=False, casing=True))
 def test_join_alias_search_without_aliases1(completer, complete_event):
     text = 'SELECT * FROM blog.Entries JOIN blog.e'
@@ -578,11 +615,13 @@ def test_join_alias_search_without_aliases1(completer, complete_event):
     assert result[:2] == [table('Entries', -1), join(
         'EntAccLog ON EntAccLog.EntryID = Entries.EntryID', -1)]
 
+
 @parametrize('completer', completers(alias=True, casing=True))
 def test_join_alias_search_with_aliases2(completer, complete_event):
     text = 'SELECT * FROM blog.Entries E JOIN blog.et'
     result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == join('EntryTags ET ON ET.EntryID = E.EntryID', -2)
+
 
 @parametrize('completer', completers(alias=False, casing=True))
 def test_join_alias_search_without_aliases2(completer, complete_event):
@@ -591,17 +630,20 @@ def test_join_alias_search_without_aliases2(completer, complete_event):
     assert result[0] == join(
         'EntryTags ON EntryTags.EntryID = Entries.EntryID', -2)
 
+
 @parametrize('completer', completers())
 def test_function_alias_search_without_aliases(completer, complete_event):
     text = 'SELECT blog.ees'
     result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == function('extract_entry_symbols()', -3)
 
+
 @parametrize('completer', completers())
 def test_function_alias_search_with_aliases(completer, complete_event):
     text = 'SELECT blog.ee'
     result = completer.get_completions(Document(text=text), complete_event)
     assert result[0] == function('enter_entry()', -2)
+
 
 @parametrize(
     'completer',
@@ -617,12 +659,14 @@ def test_column_alias_search(completer, complete_event):
     cols = ('EntryText', 'EntryTitle', 'EntryID')
     assert result[:3] == [column(c, -2) for c in cols]
 
+
 @parametrize('completer', completers(casing=True))
 def test_column_alias_search_qualified(completer, complete_event):
     text = 'SELECT E.ei FROM blog.Entries E'
     result = completer.get_completions(Document(text, cursor_position=len('SELECT E.ei')), complete_event)
     cols = ('EntryID', 'EntryTitle')
     assert result[:3] == [column(c, -2) for c in cols]
+
 
 @parametrize('completer', completers(casing=False, filtr=False, alias=False))
 def test_schema_object_order(completer, complete_event):
@@ -651,6 +695,7 @@ def test_all_schema_objects(completer, complete_event):
         + [function(x+'()') for x in ('func2', 'custom.func3')]
     )
 
+
 @parametrize('completer', completers(filtr=False, alias=False, casing=True))
 def test_all_schema_objects_with_casing(completer, complete_event):
     text = 'SELECT * FROM '
@@ -665,6 +710,7 @@ def test_all_schema_objects_with_casing(completer, complete_event):
         [table(x) for x in ('Orders', '"select"', 'CUSTOM.shipments')]
         + [function(x+'()') for x in ('func2', 'CUSTOM.func3')]
     )
+
 
 @parametrize('completer', completers(casing=False, filtr=False, alias=True))
 def test_all_schema_objects_with_aliases(completer, complete_event):

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -322,8 +322,8 @@ def test_suggested_aliases_after_on_right_side(completer, complete_event):
 
 @parametrize('completer', completers(filtr=True, casing=False, alias=False))
 def test_table_names_after_from(completer, complete_event):
-    text = 'SELECT * FROM '
-    position = len('SELECT * FROM ')
+    text = ('SELECT * FROM ')
+    position = len(text)
     result = set(completer.get_completions(Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set(testdata.schemas() + testdata.tables()
@@ -682,8 +682,8 @@ def test_schema_object_order(completer, complete_event):
 
 @parametrize('completer', completers(casing=False, filtr=False, alias=False))
 def test_all_schema_objects(completer, complete_event):
-    text = 'SELECT * FROM '
-    position = len('SELECT * FROM ')
+    text = ('SELECT * FROM ')
+    position = len(text)
     result = set(
         completer.get_completions(
             Document(text=text, cursor_position=position),
@@ -698,8 +698,8 @@ def test_all_schema_objects(completer, complete_event):
 
 @parametrize('completer', completers(filtr=False, alias=False, casing=True))
 def test_all_schema_objects_with_casing(completer, complete_event):
-    text = 'SELECT * FROM '
-    position = len('SELECT * FROM ')
+    text = ('SELECT * FROM ')
+    position = len(text)
     result = set(
         completer.get_completions(
             Document(text=text, cursor_position=position),
@@ -714,8 +714,8 @@ def test_all_schema_objects_with_casing(completer, complete_event):
 
 @parametrize('completer', completers(casing=False, filtr=False, alias=True))
 def test_all_schema_objects_with_aliases(completer, complete_event):
-    text = 'SELECT * FROM '
-    position = len('SELECT * FROM ')
+    text = ('SELECT * FROM ')
+    position = len(text)
     result = set(
         completer.get_completions(
             Document(text=text, cursor_position=position),

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -73,18 +73,13 @@ completers = testdata.get_completers(casing)
     'users',
     '"users"',
     ])
-def test_suggested_column_names_from_shadowed_visible_table(
-    completer, table
-):
-    text = 'SELECT  FROM ' + table
-    position = len('SELECT ')
-    result = result_set(completer, text, position)
-
-    assert set(result) == set(testdata.columns('users') +
+def test_suggested_column_names_from_shadowed_visible_table(completer, table):
+    result = result_set(completer, 'SELECT  FROM ' + table, len('SELECT '))
+    assert result == set(testdata.columns('users') +
         testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
-        )
+    )
 
 
 @parametrize('completer', completers(filtr=True, casing=False, qualify=no_qual))
@@ -93,9 +88,8 @@ def test_suggested_column_names_from_shadowed_visible_table(
     'WITH users as (SELECT 1 AS foo) SELECT  from custom.users',
     ])
 def test_suggested_column_names_from_qualified_shadowed_table(completer, text):
-    position = text.find('  ') + 1
-    result = result_set(completer, text, position)
-    assert set(result) == set(testdata.columns('users', 'custom') +
+    result = result_set(completer, text, position = text.find('  ') + 1)
+    assert result == set(testdata.columns('users', 'custom') +
         testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
@@ -107,9 +101,8 @@ def test_suggested_column_names_from_qualified_shadowed_table(completer, text):
     'WITH users as (SELECT 1 AS foo) SELECT  from users',
     ])
 def test_suggested_column_names_from_cte(completer, text):
-    position = text.find('  ') + 1
-    result = result_set(completer, text, position)
-    assert set(result) == set([column('foo')] + testdata.functions() +
+    result = result_set(completer, text, text.find('  ') + 1)
+    assert result == set([column('foo')] + testdata.functions() +
         list(testdata.builtin_functions() + testdata.keywords())
     )
 
@@ -123,7 +116,7 @@ def test_suggested_column_names_from_cte(completer, text):
 ])
 def test_suggested_join_conditions(completer, text):
     result = result_set(completer, text)
-    assert set(result) == set([
+    assert result == set([
         alias('users'),
         alias('shipments'),
         name_join('shipments.id = users.id'),
@@ -138,19 +131,18 @@ def test_suggested_join_conditions(completer, text):
     JOIN '''
 ), ('users', '"users"', 'Users')))
 def test_suggested_joins(completer, query, tbl):
-    text = query.format(tbl)
-    result = result_set(completer, text)
-    assert set(result) == set(testdata.schemas() + testdata.tables() + [
+    result = result_set(completer, query.format(tbl))
+    assert result == set(testdata.schemas() + testdata.tables() + [
         join('custom.shipments ON shipments.user_id = {0}.id'.format(tbl)),
         ] + testdata.functions())
 
 
 @parametrize('completer', completers(filtr=True, casing=False, qualify=no_qual))
 def test_suggested_column_names_from_schema_qualifed_table(completer):
-    text = 'SELECT  from custom.products'
-    position = len('SELECT ')
-    result = result_set(completer, text, position)
-    assert set(result) == set(
+    result = result_set(
+        completer, 'SELECT  from custom.products', len('SELECT ')
+    )
+    assert result == set(
         testdata.columns('products', 'custom') + testdata.functions() +
         list(testdata.builtin_functions() + testdata.keywords())
     )
@@ -158,10 +150,10 @@ def test_suggested_column_names_from_schema_qualifed_table(completer):
 
 @parametrize('completer', completers(filtr=True, casing=False, qualify=no_qual))
 def test_suggested_column_names_in_function(completer):
-    text = 'SELECT MAX( from custom.products'
-    position = len('SELECT MAX(')
-    result = result_set(completer, text, position)
-    assert set(result) == set(testdata.columns('products', 'custom'))
+    result = result_set(
+        completer, 'SELECT MAX( from custom.products', len('SELECT MAX(')
+    )
+    assert result == set(testdata.columns('products', 'custom'))
 
 
 @parametrize('completer', completers(casing=False, alias=False))
@@ -181,7 +173,7 @@ def test_suggested_table_names_with_schema_dot(
         start_position = 0
 
     result = result_set(completer, text)
-    assert set(result) == set(testdata.tables('custom', start_position)
+    assert result == set(testdata.tables('custom', start_position)
         + testdata.functions('custom', start_position))
 
 
@@ -200,24 +192,24 @@ def test_suggested_table_names_with_schema_dot2(
         start_position = 0
 
     result = result_set(completer, text)
-    assert set(result) == set(testdata.functions('Custom', start_position) +
+    assert result == set(testdata.functions('Custom', start_position) +
         testdata.tables('Custom', start_position))
 
 
 @parametrize('completer', completers(filtr=True, casing=False))
 def test_suggested_column_names_with_qualified_alias(completer):
-    text = 'SELECT p. from custom.products p'
-    position = len('SELECT p.')
-    result = result_set(completer, text, position)
-    assert set(result) == set(testdata.columns('products', 'custom'))
+    result = result_set(
+        completer, 'SELECT p. from custom.products p', len('SELECT p.')
+    )
+    assert result == set(testdata.columns('products', 'custom'))
 
 
 @parametrize('completer', completers(filtr=True, casing=False, qualify=no_qual))
 def test_suggested_multiple_column_names(completer):
-    text = 'SELECT id,  from custom.products'
-    position = len('SELECT id, ')
-    result = result_set(completer, text, position)
-    assert set(result) == set(testdata.columns('products', 'custom') +
+    result = result_set(
+        completer, 'SELECT id,  from custom.products', len('SELECT id, ')
+    )
+    assert result == set(testdata.columns('products', 'custom') +
         testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
@@ -226,10 +218,12 @@ def test_suggested_multiple_column_names(completer):
 
 @parametrize('completer', completers(filtr=True, casing=False))
 def test_suggested_multiple_column_names_with_alias(completer):
-    text = 'SELECT p.id, p. from custom.products p'
-    position = len('SELECT u.id, u.')
-    result = result_set(completer, text, position)
-    assert set(result) == set(testdata.columns('products', 'custom'))
+    result = result_set(
+        completer,
+        'SELECT p.id, p. from custom.products p',
+        len('SELECT u.id, u.')
+    )
+    assert result == set(testdata.columns('products', 'custom'))
 
 
 @parametrize('completer', completers(filtr=True, casing=False))
@@ -240,7 +234,7 @@ def test_suggested_multiple_column_names_with_alias(completer):
 def test_suggestions_after_on(completer, text):
     position = len('SELECT x.id, y.product_name FROM custom.products x JOIN custom.products y ON ')
     result = result_set(completer, text, position)
-    assert set(result) == set([
+    assert result == set([
         alias('x'),
         alias('y'),
         name_join('y.price = x.price'),
@@ -252,16 +246,16 @@ def test_suggestions_after_on(completer, text):
 def test_suggested_aliases_after_on_right_side(completer):
     text = 'SELECT x.id, y.product_name FROM custom.products x JOIN custom.products y ON x.id = '
     result = result_set(completer, text)
-    assert set(result) == set([
+    assert result == set([
         alias('x'),
         alias('y')])
 
 
 @parametrize('completer', completers(filtr=True, casing=False, alias=False))
 def test_table_names_after_from(completer):
-    text = ('SELECT * FROM ')
+    text = 'SELECT * FROM '
     result = result_set(completer, text)
-    assert set(result) == set(testdata.schemas() + testdata.tables()
+    assert result == set(testdata.schemas() + testdata.tables()
         + testdata.functions())
 
 
@@ -283,16 +277,18 @@ def test_schema_qualified_function_name(completer):
 ])
 def test_schema_qualified_type_name(completer, text):
     result = result_set(completer, text)
-    assert set(result) == set(testdata.datatypes('custom')
+    assert result == set(testdata.datatypes('custom')
         + testdata.tables('custom'))
 
 
 @parametrize('completer', completers(filtr=True, casing=False))
 def test_suggest_columns_from_aliased_set_returning_function(completer):
-    text = 'select f. from custom.set_returning_func() f'
-    position = len('select f.')
-    result = result_set(completer, text, position)
-    assert set(result) == set(
+    result = result_set(
+        completer,
+        'select f. from custom.set_returning_func() f',
+        len('select f.')
+    )
+    assert result == set(
         testdata.columns('set_returning_func', 'custom', 'functions'))
 
 
@@ -415,7 +411,7 @@ def test_wildcard_column_expansion_with_two_tables_and_parent(completer):
 def test_suggest_columns_from_unquoted_table(completer, text):
     position = len('SELECT U.')
     result = result_set(completer, text, position)
-    assert set(result) == set(testdata.columns('users', 'custom'))
+    assert result == set(testdata.columns('users', 'custom'))
 
 
 @parametrize('completer', completers(filtr=True, casing=False))
@@ -426,7 +422,7 @@ def test_suggest_columns_from_unquoted_table(completer, text):
 def test_suggest_columns_from_quoted_table(completer, text):
     position = len('SELECT U.')
     result = result_set(completer, text, position)
-    assert set(result) == set(testdata.columns('Users', 'custom'))
+    assert result == set(testdata.columns('Users', 'custom'))
 
 texts = ['SELECT * FROM ', 'SELECT * FROM public.Orders O CROSS JOIN ']
 
@@ -434,16 +430,16 @@ texts = ['SELECT * FROM ', 'SELECT * FROM public.Orders O CROSS JOIN ']
 @parametrize('completer', completers(filtr=True, casing=False, alias=False))
 @parametrize('text', texts)
 def test_schema_or_visible_table_completion(completer, text):
-    result = get_result(completer, text)
-    assert set(result) == set(testdata.schemas()
+    result = result_set(completer, text)
+    assert result == set(testdata.schemas()
         + testdata.views() + testdata.tables() + testdata.functions())
 
 
 @parametrize('completer', completers(alias=True, casing=False, filtr=True))
 @parametrize('text', texts)
 def test_table_aliases(completer, text):
-    result = get_result(completer, text)
-    assert set(result) == set(testdata.schemas() + [
+    result = result_set(completer, text)
+    assert result == set(testdata.schemas() + [
         table('users u'),
         table('orders o' if text == 'SELECT * FROM ' else 'orders o2'),
         table('"select" s'),
@@ -454,8 +450,8 @@ def test_table_aliases(completer, text):
 @parametrize('completer', completers(alias=True, casing=True, filtr=True))
 @parametrize('text', texts)
 def test_aliases_with_casing(completer, text):
-    result = get_result(completer, text)
-    assert set(result) == set(cased_schemas + [
+    result = result_set(completer, text)
+    assert result == set(cased_schemas + [
         table('users u'),
         table('Orders O' if text == 'SELECT * FROM ' else 'Orders O2'),
         table('"select" s'),
@@ -466,8 +462,8 @@ def test_aliases_with_casing(completer, text):
 @parametrize('completer', completers(alias=False, casing=True, filtr=True))
 @parametrize('text', texts)
 def test_table_casing(completer, text):
-    result = get_result(completer, text)
-    assert set(result) == set(cased_schemas + [
+    result = result_set(completer, text)
+    assert result == set(cased_schemas + [
         table('users'),
         table('Orders'),
         table('"select"'),
@@ -550,27 +546,25 @@ def test_function_alias_search_with_aliases(completer):
 
 @parametrize('completer',completers(filtr=True, casing=True, qualify=no_qual))
 def test_column_alias_search(completer):
-    text = 'SELECT et FROM blog.Entries E'
-    position = len('SELECT et')
-    result = get_result(completer, text, position)
+    result = get_result(
+        completer, 'SELECT et FROM blog.Entries E', len('SELECT et')
+    )
     cols = ('EntryText', 'EntryTitle', 'EntryID')
     assert result[:3] == [column(c, -2) for c in cols]
 
 
 @parametrize('completer', completers(casing=True))
 def test_column_alias_search_qualified(completer):
-    text = 'SELECT E.ei FROM blog.Entries E'
-    position = len('SELECT E.ei')
-    result = get_result(completer, text, position)
+    result = get_result(
+        completer, 'SELECT E.ei FROM blog.Entries E', len('SELECT E.ei')
+    )
     cols = ('EntryID', 'EntryTitle')
     assert result[:3] == [column(c, -2) for c in cols]
 
 
 @parametrize('completer', completers(casing=False, filtr=False, alias=False))
 def test_schema_object_order(completer):
-    text = 'SELECT * FROM u'
-    position = len('SELECT * FROM u')
-    result = get_result(completer, text, position)
+    result = get_result(completer, 'SELECT * FROM u')
     assert result[:3] == [
         table(t, pos=-1) for t in ('users', 'custom."Users"', 'custom.users')
     ]
@@ -587,7 +581,7 @@ def test_all_schema_objects(completer):
 
 @parametrize('completer', completers(filtr=False, alias=False, casing=True))
 def test_all_schema_objects_with_casing(completer):
-    text = ('SELECT * FROM ')
+    text = 'SELECT * FROM '
     result = result_set(completer, text)
     assert result >= set(
         [table(x) for x in ('Orders', '"select"', 'CUSTOM.shipments')]

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -53,30 +53,8 @@ cased_aliased_rels = [table(t) for t in ('Users U', '"Users" U', 'Orders O',
     '_custom_fun() cf', 'Custom_Fun() CF', 'Custom_Func1() CF',
     'custom_func2() cf', 'set_returning_func() srf')]
 
-
-@pytest.fixture
-def completer():
-    return testdata.completer
-
-@pytest.fixture
-def cased_completer():
-    return testdata.get_completer(casing=casing)
-
-@pytest.fixture
-def aliased_completer():
-    return testdata.get_completer({'generate_aliases': True})
-
-@pytest.fixture
-def cased_aliased_completer():
-    return testdata.get_completer({'generate_aliases': True}, casing)
-
-@pytest.fixture
-def cased_always_qualifying_completer():
-    return testdata.get_completer({'qualify_columns': 'always'}, casing)
-
-@pytest.fixture
-def auto_qualifying_completer():
-    return testdata.get_completer({'qualify_columns': 'if_more_than_one_table'})
+completers = testdata.get_completers(casing)
+parametrize = pytest.mark.parametrize
 
 
 @pytest.fixture
@@ -84,6 +62,8 @@ def complete_event():
     from mock import Mock
     return Mock()
 
+
+@parametrize('completer', completers())
 def test_empty_string_completion(completer, complete_event):
     text = ''
     position = 0
@@ -93,6 +73,8 @@ def test_empty_string_completion(completer, complete_event):
             complete_event))
     assert set(testdata.keywords()) == result
 
+
+@parametrize('completer', completers())
 def test_select_keyword_completion(completer, complete_event):
     text = 'SEL'
     position = len('SEL')
@@ -102,6 +84,7 @@ def test_select_keyword_completion(completer, complete_event):
     assert set(result) == set([keyword('SELECT', -3)])
 
 
+@parametrize('completer', completers())
 def test_builtin_function_name_completion(completer, complete_event):
     text = 'SELECT MA'
     position = len('SELECT MA')
@@ -113,6 +96,7 @@ def test_builtin_function_name_completion(completer, complete_event):
     ])
 
 
+@parametrize('completer', completers())
 def test_builtin_function_matches_only_at_start(completer, complete_event):
     text = 'SELECT IN'
     position = len('SELECT IN')
@@ -124,6 +108,7 @@ def test_builtin_function_matches_only_at_start(completer, complete_event):
     assert 'MIN' not in result
 
 
+@parametrize('completer', completers(casing=False, alias=False))
 def test_user_function_name_completion(completer, complete_event):
     text = 'SELECT cu'
     position = len('SELECT cu')
@@ -138,6 +123,7 @@ def test_user_function_name_completion(completer, complete_event):
         ])
 
 
+@parametrize('completer', completers(casing=False, alias=False))
 def test_user_function_name_completion_matches_anywhere(completer,
                                                         complete_event):
     text = 'SELECT om'
@@ -151,13 +137,12 @@ def test_user_function_name_completion_matches_anywhere(completer,
         function('custom_func2()', -2)])
 
 
+@parametrize(
+    'completer', completers(
+        casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
 def test_suggested_column_names_from_visible_table(completer, complete_event):
-    """
-    Suggest column and function names when selecting from table
-    :param completer:
-    :param complete_event:
-    :return:
-    """
     text = 'SELECT  from users'
     position = len('SELECT ')
     result = set(completer.get_completions(
@@ -166,94 +151,101 @@ def test_suggested_column_names_from_visible_table(completer, complete_event):
     assert set(result) == set(testdata.columns('users') + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
-        )
+    )
 
 
-def test_suggested_cased_column_names(cased_completer, complete_event):
-    """
-    Suggest column and function names when selecting from table
-    :param completer:
-    :param complete_event:
-    :return:
-    """
+@parametrize(
+    'completer', completers(
+        casing=True, qualify=['if_more_than_one_table', 'never']
+    )
+)
+def test_suggested_cased_column_names(completer, complete_event):
     text = 'SELECT  from users'
     position = len('SELECT ')
-    result = set(cased_completer.get_completions(
+    result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set(cased_funcs + cased_users_cols
         + testdata.builtin_functions() + testdata.keywords())
 
 
-@pytest.mark.parametrize('text', [
+@parametrize(
+    'completer', completers(casing=False, qualify=['if_more_than_one_table'])
+)
+@parametrize('text', [
     'SELECT  from users',
     'INSERT INTO Orders SELECT  from users',
 ])
 def test_suggested_auto_qualified_column_names(
-    text, auto_qualifying_completer, complete_event
+    text, completer, complete_event
 ):
     pos = text.index('  ') + 1
     cols = [column(c.lower()) for c in cased_users_col_names]
-    result = set(auto_qualifying_completer.get_completions(
+    result = set(completer.get_completions(
         Document(text=text, cursor_position=pos),
         complete_event))
     assert set(result) == set(testdata.functions() + cols
         + testdata.builtin_functions() + testdata.keywords())
 
 
-@pytest.mark.parametrize('text', [
+@parametrize(
+    'completer', completers(
+        casing=False, qualify=['always', 'if_more_than_one_table']
+    )
+)
+@parametrize('text', [
     'SELECT  from users U NATURAL JOIN "Users"',
     'INSERT INTO Orders SELECT  from users U NATURAL JOIN "Users"',
 ])
 def test_suggested_auto_qualified_column_names_two_tables(
-    text, auto_qualifying_completer, complete_event
+    text, completer, complete_event
 ):
     pos = text.index('  ') + 1
     cols = [column('U.' + c.lower()) for c in cased_users_col_names]
     cols += [column('"Users".' + c.lower()) for c in cased_users2_col_names]
-    result = set(auto_qualifying_completer.get_completions(
+    result = set(completer.get_completions(
         Document(text=text, cursor_position=pos),
         complete_event))
     assert set(result) == set(testdata.functions() + cols
         + testdata.builtin_functions() + testdata.keywords())
 
 
-@pytest.mark.parametrize('text', [
+@parametrize('completer', completers(casing=True, qualify=['always']))
+@parametrize('text', [
     'UPDATE users SET ',
     'INSERT INTO users(',
 ])
 def test_no_column_qualification(
-    text, cased_always_qualifying_completer, complete_event
+    text, completer, complete_event
 ):
     pos = len(text)
     cols = [column(c) for c in cased_users_col_names]
-    result = set(cased_always_qualifying_completer.get_completions(
+    result = set(completer.get_completions(
         Document(text=text, cursor_position=pos),
         complete_event))
     assert set(result) == set(cols)
 
 
+@parametrize('completer', completers(casing=True, qualify=['always']))
 def test_suggested_cased_always_qualified_column_names(
-    cased_always_qualifying_completer, complete_event
+    completer, complete_event
 ):
     text = 'SELECT  from users'
     position = len('SELECT ')
     cols = [column('users.' + c) for c in cased_users_col_names]
-    result = set(cased_always_qualifying_completer.get_completions(
+    result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set(cased_funcs + cols
         + testdata.builtin_functions() + testdata.keywords())
 
 
+@parametrize(
+    'completer', completers(
+        casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
 def test_suggested_column_names_in_function(completer, complete_event):
-    """
-    Suggest column and function names when selecting multiple
-    columns from table
-    :param completer:
-    :param complete_event:
-    :return:
-    """
     text = 'SELECT MAX( from users'
     position = len('SELECT MAX(')
     result = completer.get_completions(
@@ -261,13 +253,9 @@ def test_suggested_column_names_in_function(completer, complete_event):
         complete_event)
     assert set(result) == set(testdata.columns('users'))
 
+
+@parametrize('completer', completers(casing=False))
 def test_suggested_column_names_with_table_dot(completer, complete_event):
-    """
-    Suggest column names on table name and dot
-    :param completer:
-    :param complete_event:
-    :return:
-    """
     text = 'SELECT users. from users'
     position = len('SELECT users.')
     result = set(completer.get_completions(
@@ -275,13 +263,9 @@ def test_suggested_column_names_with_table_dot(completer, complete_event):
         complete_event))
     assert set(result) == set(testdata.columns('users'))
 
+
+@parametrize('completer', completers(casing=False))
 def test_suggested_column_names_with_alias(completer, complete_event):
-    """
-    Suggest column names on table alias and dot
-    :param completer:
-    :param complete_event:
-    :return:
-    """
     text = 'SELECT u. from users u'
     position = len('SELECT u.')
     result = set(completer.get_completions(
@@ -289,14 +273,13 @@ def test_suggested_column_names_with_alias(completer, complete_event):
         complete_event))
     assert set(result) == set(testdata.columns('users'))
 
+
+@parametrize(
+    'completer', completers(
+        casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
 def test_suggested_multiple_column_names(completer, complete_event):
-    """
-    Suggest column and function names when selecting multiple
-    columns from table
-    :param completer:
-    :param complete_event:
-    :return:
-    """
     text = 'SELECT id,  from users u'
     position = len('SELECT id, ')
     result = set(completer.get_completions(
@@ -307,14 +290,9 @@ def test_suggested_multiple_column_names(completer, complete_event):
         testdata.keywords())
         )
 
+
+@parametrize('completer', completers(casing=False))
 def test_suggested_multiple_column_names_with_alias(completer, complete_event):
-    """
-    Suggest column names on table alias and dot
-    when selecting multiple columns from table
-    :param completer:
-    :param complete_event:
-    :return:
-    """
     text = 'SELECT u.id, u. from users u'
     position = len('SELECT u.id, u.')
     result = set(completer.get_completions(
@@ -323,29 +301,19 @@ def test_suggested_multiple_column_names_with_alias(completer, complete_event):
     assert set(result) == set(testdata.columns('users'))
 
 
-def test_suggested_cased_column_names_with_alias(cased_completer, complete_event):
-    """
-    Suggest column names on table alias and dot
-    when selecting multiple columns from table
-    :param completer:
-    :param complete_event:
-    :return:
-    """
+
+@parametrize('completer', completers(casing=True))
+def test_suggested_cased_column_names_with_alias(completer, complete_event):
     text = 'SELECT u.id, u. from users u'
     position = len('SELECT u.id, u.')
-    result = set(cased_completer.get_completions(
+    result = set(completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event))
     assert set(result) == set(cased_users_cols)
 
+
+@parametrize('completer', completers(casing=False))
 def test_suggested_multiple_column_names_with_dot(completer, complete_event):
-    """
-    Suggest column names on table names and dot
-    when selecting multiple columns from table
-    :param completer:
-    :param complete_event:
-    :return:
-    """
     text = 'SELECT users.id, users. from users u'
     position = len('SELECT users.id, users.')
     result = set(completer.get_completions(
@@ -354,6 +322,7 @@ def test_suggested_multiple_column_names_with_dot(completer, complete_event):
     assert set(result) == set(testdata.columns('users'))
 
 
+@parametrize('completer', completers(casing=False))
 def test_suggest_columns_after_three_way_join(completer, complete_event):
     text = '''SELECT * FROM users u1
               INNER JOIN users u2 ON u1.id = u2.id
@@ -382,7 +351,9 @@ join_condition_texts = [
     '''
 ]
 
-@pytest.mark.parametrize('text', join_condition_texts)
+
+@parametrize('completer', completers(casing=False))
+@parametrize('text', join_condition_texts)
 def test_suggested_join_conditions(completer, complete_event, text):
     result = set(completer.get_completions(
         Document(text=text,), complete_event))
@@ -391,16 +362,20 @@ def test_suggested_join_conditions(completer, complete_event, text):
         alias('U2'),
         fk_join('U2.userid = U.id')])
 
-@pytest.mark.parametrize('text', join_condition_texts)
-def test_cased_join_conditions(cased_completer, complete_event, text):
-    result = set(cased_completer.get_completions(
+
+@parametrize('completer', completers(casing=True))
+@parametrize('text', join_condition_texts)
+def test_cased_join_conditions(completer, complete_event, text):
+    result = set(completer.get_completions(
         Document(text=text), complete_event))
     assert set(result) == set([
         alias('U'),
         alias('U2'),
         fk_join('U2.UserID = U.ID')])
 
-@pytest.mark.parametrize('text', [
+
+@parametrize('completer', completers(casing=False))
+@parametrize('text', [
     '''SELECT *
     FROM users
     CROSS JOIN "Users"
@@ -424,7 +399,9 @@ def test_suggested_join_conditions_with_same_table_twice(completer, complete_eve
         alias('"Users"')
     ]
 
-@pytest.mark.parametrize('text', [
+
+@parametrize('completer', completers())
+@parametrize('text', [
     'SELECT * FROM users JOIN users u2 on foo.'
 ])
 def test_suggested_join_conditions_with_invalid_qualifier(completer, complete_event, text):
@@ -434,7 +411,9 @@ def test_suggested_join_conditions_with_invalid_qualifier(completer, complete_ev
         complete_event))
     assert set(result) == set()
 
-@pytest.mark.parametrize(('text', 'ref'), [
+
+@parametrize('completer', completers(casing=False))
+@parametrize(('text', 'ref'), [
     ('SELECT * FROM users JOIN NonTable on ', 'NonTable'),
     ('SELECT * FROM users JOIN nontable nt on ', 'nt')
 ])
@@ -445,7 +424,9 @@ def test_suggested_join_conditions_with_invalid_table(completer, complete_event,
         complete_event))
     assert set(result) == set([alias('users'), alias(ref)])
 
-@pytest.mark.parametrize('text', [
+
+@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('text', [
     'SELECT * FROM "Users" u JOIN u',
     'SELECT * FROM "Users" u JOIN uid',
     'SELECT * FROM "Users" u JOIN userid',
@@ -475,7 +456,9 @@ join_texts = [
     INNER JOIN '''
 ]
 
-@pytest.mark.parametrize('text', join_texts)
+
+@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('text', join_texts)
 def test_suggested_joins(completer, complete_event, text):
     result = set(completer.get_completions(
         Document(text=text), complete_event))
@@ -486,27 +469,35 @@ def test_suggested_joins(completer, complete_event, text):
         join('users users2 ON users2.parentid = Users.id'),
         ] + testdata.functions())
 
-@pytest.mark.parametrize('text', join_texts)
-def test_cased_joins(cased_completer, complete_event, text):
-    result = set(cased_completer.get_completions(
-        Document(text=text), complete_event))
+
+@parametrize('completer', completers(casing=True, alias=False))
+@parametrize('text', join_texts)
+def test_cased_joins(completer, complete_event, text):
+    result = set(
+        completer.get_completions(Document(text=text), complete_event)
+    )
     assert set(result) == set([schema('PUBLIC')] + cased_rels + [
         join('"Users" ON "Users".UserID = Users.ID'),
         join('Users Users2 ON Users2.ID = Users.PARENTID'),
         join('Users Users2 ON Users2.PARENTID = Users.ID'),
-        ])
+    ])
 
-@pytest.mark.parametrize('text', join_texts)
-def test_aliased_joins(aliased_completer, complete_event, text):
-    result = set(aliased_completer.get_completions(
-        Document(text=text), complete_event))
+
+@parametrize('completer', completers(casing=False, alias=True))
+@parametrize('text', join_texts)
+def test_aliased_joins(completer, complete_event, text):
+    result = set(
+        completer.get_completions(Document(text=text), complete_event)
+    )
     assert set(result) == set(testdata.schemas() + aliased_rels + [
         join('"Users" U ON U.userid = Users.id'),
         join('users u ON u.id = Users.parentid'),
         join('users u ON u.parentid = Users.id'),
-        ])
+    ])
 
-@pytest.mark.parametrize('text', [
+
+@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('text', [
     'SELECT * FROM public."Users" JOIN ',
     'SELECT * FROM public."Users" RIGHT OUTER JOIN ',
     '''SELECT *
@@ -523,7 +514,9 @@ def test_suggested_joins_quoted_schema_qualified_table(completer, complete_event
         join('public.users ON users.id = "Users".userid'),
         ] + testdata.functions())
 
-@pytest.mark.parametrize('text', [
+
+@parametrize('completer', completers(casing=False))
+@parametrize('text', [
     'SELECT u.name, o.id FROM users u JOIN orders o ON ',
     'SELECT u.name, o.id FROM users u JOIN orders o ON JOIN orders o2 ON'
 ])
@@ -538,7 +531,9 @@ def test_suggested_aliases_after_on(completer, complete_event, text):
         name_join('o.email = u.email'),
         alias('o')])
 
-@pytest.mark.parametrize('text', [
+
+@parametrize('completer', completers())
+@parametrize('text', [
     'SELECT u.name, o.id FROM users u JOIN orders o ON o.user_id = ',
     'SELECT u.name, o.id FROM users u JOIN orders o ON o.user_id =  JOIN orders o2 ON'
 ])
@@ -551,7 +546,9 @@ def test_suggested_aliases_after_on_right_side(completer, complete_event, text):
         alias('u'),
         alias('o')])
 
-@pytest.mark.parametrize('text', [
+
+@parametrize('completer', completers(casing=False))
+@parametrize('text', [
     'SELECT users.name, orders.id FROM users JOIN orders ON ',
     'SELECT users.name, orders.id FROM users JOIN orders ON JOIN orders orders2 ON'
 ])
@@ -566,7 +563,9 @@ def test_suggested_tables_after_on(completer, complete_event, text):
         alias('users'),
         alias('orders')])
 
-@pytest.mark.parametrize('text', [
+
+@parametrize('completer', completers(casing=False))
+@parametrize('text', [
     'SELECT users.name, orders.id FROM users JOIN orders ON orders.user_id = JOIN orders orders2 ON',
     'SELECT users.name, orders.id FROM users JOIN orders ON orders.user_id = '
 ])
@@ -579,7 +578,9 @@ def test_suggested_tables_after_on_right_side(completer, complete_event, text):
         alias('users'),
         alias('orders')])
 
-@pytest.mark.parametrize('text', [
+
+@parametrize('completer', completers(casing=False))
+@parametrize('text', [
     'SELECT * FROM users INNER JOIN orders USING (',
     'SELECT * FROM users INNER JOIN orders USING(',
 ])
@@ -590,9 +591,11 @@ def test_join_using_suggests_common_columns(completer, complete_event, text):
     assert set(result) == set([
         column('id'),
         column('email'),
-        ])
+    ])
 
-@pytest.mark.parametrize('text', [
+
+@parametrize('completer', completers(casing=False))
+@parametrize('text', [
     'SELECT * FROM users u1 JOIN users u2 USING (email) JOIN user_emails ue USING()',
     'SELECT * FROM users u1 JOIN users u2 USING(email) JOIN user_emails ue USING ()',
     'SELECT * FROM users u1 JOIN user_emails ue USING () JOIN users u2 ue USING(first_name, last_name)',
@@ -605,9 +608,11 @@ def test_join_using_suggests_from_last_table(completer, complete_event, text):
     assert set(result) == set([
         column('id'),
         column('email'),
-        ])
+    ])
 
-@pytest.mark.parametrize('text', [
+
+@parametrize('completer', completers(casing=False))
+@parametrize('text', [
     'SELECT * FROM users INNER JOIN orders USING (id,',
     'SELECT * FROM users INNER JOIN orders USING(id,',
 ])
@@ -618,9 +623,11 @@ def test_join_using_suggests_columns_after_first_column(completer, complete_even
     assert set(result) == set([
         column('id'),
         column('email'),
-        ])
+    ])
 
-@pytest.mark.parametrize('text', [
+
+@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('text', [
     'SELECT * FROM ',
     'SELECT * FROM users CROSS JOIN ',
     'SELECT * FROM users natural join '
@@ -644,8 +651,14 @@ def test_table_names_after_from(completer, complete_event, text):
         'custom_func1()',
         'custom_func2()',
         'set_returning_func()',
-        ]
+    ]
 
+
+@parametrize(
+    'completer', completers(
+        casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
 def test_auto_escaped_col_names(completer, complete_event):
     text = 'SELECT  from "select"'
     position = len('SELECT ')
@@ -656,9 +669,10 @@ def test_auto_escaped_col_names(completer, complete_event):
         ] + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
-        )
+    )
 
 
+@parametrize('completer', completers(alias=False))
 def test_allow_leading_double_quote_in_last_word(completer, complete_event):
     text = 'SELECT * from "sele'
     position = len(text)
@@ -670,7 +684,8 @@ def test_allow_leading_double_quote_in_last_word(completer, complete_event):
     assert expected in set(result)
 
 
-@pytest.mark.parametrize('text', [
+@parametrize('completer', completers(casing=False))
+@parametrize('text', [
     'SELECT 1::',
     'CREATE TABLE foo (bar ',
     'CREATE FUNCTION foo (bar INT, baz ',
@@ -684,6 +699,7 @@ def test_suggest_datatype(text, completer, complete_event):
         testdata.tables() + list(testdata.builtin_datatypes()))
 
 
+@parametrize('completer', completers(casing=False))
 def test_suggest_columns_from_escaped_table_alias(completer, complete_event):
     sql = 'select * from "select" s where s.'
     pos = len(sql)
@@ -692,6 +708,11 @@ def test_suggest_columns_from_escaped_table_alias(completer, complete_event):
     assert set(result) == set(testdata.columns('select'))
 
 
+@parametrize(
+    'completer', completers(
+        casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
 def test_suggest_columns_from_set_returning_function(completer, complete_event):
     sql = 'select  from set_returning_func()'
     pos = len('select ')
@@ -704,6 +725,7 @@ def test_suggest_columns_from_set_returning_function(completer, complete_event):
         + testdata.keywords()))
 
 
+@parametrize('completer', completers(casing=False))
 def test_suggest_columns_from_aliased_set_returning_function(completer, complete_event):
     sql = 'select f. from set_returning_func() f'
     pos = len('select f.')
@@ -712,6 +734,7 @@ def test_suggest_columns_from_aliased_set_returning_function(completer, complete
     assert set(result) == set(testdata.columns('set_returning_func', typ='functions'))
 
 
+@parametrize('completer', completers(casing=False))
 def test_join_functions_using_suggests_common_columns(completer, complete_event):
     text = '''SELECT * FROM set_returning_func() f1
               INNER JOIN set_returning_func() f2 USING ('''
@@ -722,6 +745,7 @@ def test_join_functions_using_suggests_common_columns(completer, complete_event)
         testdata.columns('set_returning_func', typ='functions'))
 
 
+@parametrize('completer', completers(casing=False))
 def test_join_functions_on_suggests_columns_and_join_conditions(completer, complete_event):
     text = '''SELECT * FROM set_returning_func() f1
               INNER JOIN set_returning_func() f2 ON f1.'''
@@ -734,6 +758,7 @@ def test_join_functions_on_suggests_columns_and_join_conditions(completer, compl
          ] + testdata.columns('set_returning_func', typ='functions'))
 
 
+@parametrize('completer', completers())
 def test_learn_keywords(completer, complete_event):
     sql = 'CREATE VIEW v AS SELECT 1'
     completer.extend_query_history(sql)
@@ -746,6 +771,7 @@ def test_learn_keywords(completer, complete_event):
     assert completions[0].text == 'VIEW'
 
 
+@parametrize('completer', completers(casing=False, alias=False))
 def test_learn_table_names(completer, complete_event):
     history = 'SELECT * FROM users; SELECT * FROM orders; SELECT * FROM users'
     completer.extend_query_history(history)
@@ -761,6 +787,11 @@ def test_learn_table_names(completer, complete_event):
     assert completions.index(users) < completions.index(orders)
 
 
+@parametrize(
+    'completer', completers(
+        casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
 def test_columns_before_keywords(completer, complete_event):
     sql = 'SELECT * FROM orders WHERE s'
     completions = completer.get_completions(
@@ -771,7 +802,13 @@ def test_columns_before_keywords(completer, complete_event):
 
     assert completions.index(col) < completions.index(kw)
 
-@pytest.mark.parametrize('sql', [
+
+@parametrize(
+    'completer', completers(
+        casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
+@parametrize('sql', [
     'SELECT * FROM users',
     'INSERT INTO users SELECT * FROM users u',
     '''INSERT INTO users(id, parentid, email, first_name, last_name)
@@ -789,7 +826,9 @@ def test_wildcard_column_expansion(completer, complete_event, sql):
 
     assert expected == completions
 
-@pytest.mark.parametrize('sql', [
+
+@parametrize('completer', completers(casing=False))
+@parametrize('sql', [
     'SELECT u.* FROM users u',
     'INSERT INTO public.users SELECT u.* FROM users u',
     '''INSERT INTO users(id, parentid, email, first_name, last_name)
@@ -807,7 +846,9 @@ def test_wildcard_column_expansion_with_alias(completer, complete_event, sql):
 
     assert expected == completions
 
-@pytest.mark.parametrize('text,expected', [
+
+@parametrize('completer', completers(casing=False))
+@parametrize('text,expected', [
     ('SELECT users.* FROM users',
         'id, users.parentid, users.email, users.first_name, users.last_name'),
     ('SELECT Users.* FROM Users',
@@ -823,6 +864,12 @@ def test_wildcard_column_expansion_with_table_qualifier(completer, complete_even
 
     assert expected == completions
 
+
+@parametrize(
+    'completer', completers(
+        casing=False, qualify=['always', 'if_more_than_one_table']
+    )
+)
 def test_wildcard_column_expansion_with_two_tables(completer, complete_event):
     sql = 'SELECT * FROM "select" JOIN users u ON true'
     pos = len('SELECT *')
@@ -836,6 +883,7 @@ def test_wildcard_column_expansion_with_two_tables(completer, complete_event):
     assert completions == expected
 
 
+@parametrize('completer', completers(casing=False))
 def test_wildcard_column_expansion_with_two_tables_and_parent(completer, complete_event):
     sql = 'SELECT "select".* FROM "select" JOIN users u ON true'
     pos = len('SELECT "select".*')
@@ -849,7 +897,8 @@ def test_wildcard_column_expansion_with_two_tables_and_parent(completer, complet
     assert expected == completions
 
 
-@pytest.mark.parametrize('text', [
+@parametrize('completer', completers(casing=False))
+@parametrize('text', [
     'SELECT U. FROM Users U',
     'SELECT U. FROM USERS U',
     'SELECT U. FROM users U'
@@ -861,6 +910,7 @@ def test_suggest_columns_from_unquoted_table(completer, complete_event, text):
     assert set(result) == set(testdata.columns('users'))
 
 
+@parametrize('completer', completers(casing=False))
 def test_suggest_columns_from_quoted_table(completer, complete_event):
     text = 'SELECT U. FROM "Users" U'
     pos = len('SELECT U.')
@@ -868,23 +918,27 @@ def test_suggest_columns_from_quoted_table(completer, complete_event):
                                        complete_event)
     assert set(result) == set(testdata.columns('Users'))
 
-@pytest.mark.parametrize('text', ['SELECT * FROM ',
+
+@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('text', ['SELECT * FROM ',
     'SELECT * FROM Orders o CROSS JOIN '])
 def test_schema_or_visible_table_completion(completer, complete_event, text):
     result = completer.get_completions(Document(text=text), complete_event)
     assert set(result) == set(testdata.schemas()
         + testdata.views() + testdata.tables() + testdata.functions())
 
-@pytest.mark.parametrize('text', ['SELECT * FROM '])
-def test_table_aliases(aliased_completer, complete_event, text):
-    result = aliased_completer.get_completions(
-        Document(text=text), complete_event)
+
+@parametrize('completer', completers(casing=False, alias=True))
+@parametrize('text', ['SELECT * FROM '])
+def test_table_aliases(completer, complete_event, text):
+    result = completer.get_completions(Document(text=text), complete_event)
     assert set(result) == set(testdata.schemas() + aliased_rels)
 
-@pytest.mark.parametrize('text', ['SELECT * FROM Orders o CROSS JOIN '])
-def test_duplicate_table_aliases(aliased_completer, complete_event, text):
-    result = aliased_completer.get_completions(
-        Document(text=text), complete_event)
+
+@parametrize('completer', completers(casing=False, alias=True))
+@parametrize('text', ['SELECT * FROM Orders o CROSS JOIN '])
+def test_duplicate_table_aliases(completer, complete_event, text):
+    result = completer.get_completions(Document(text=text), complete_event)
     assert set(result) == set(testdata.schemas() + [
         table('orders o2'),
         table('users u'),
@@ -897,11 +951,11 @@ def test_duplicate_table_aliases(aliased_completer, complete_event, text):
         function('custom_func2() cf'),
         function('set_returning_func() srf')])
 
-@pytest.mark.parametrize('text', ['SELECT * FROM Orders o CROSS JOIN '])
-def test_duplicate_aliases_with_casing(cased_aliased_completer,
-                                        complete_event, text):
-    result = cased_aliased_completer.get_completions(
-        Document(text=text), complete_event)
+
+@parametrize('completer', completers(casing=True, alias=True))
+@parametrize('text', ['SELECT * FROM Orders o CROSS JOIN '])
+def test_duplicate_aliases_with_casing(completer, complete_event, text):
+    result = completer.get_completions(Document(text=text), complete_event)
     assert set(result) == set([
         schema('PUBLIC'),
         table('Orders O2'),
@@ -915,20 +969,24 @@ def test_duplicate_aliases_with_casing(cased_aliased_completer,
         function('custom_func2() cf'),
         function('set_returning_func() srf')])
 
-@pytest.mark.parametrize('text', ['SELECT * FROM '])
-def test_aliases_with_casing(cased_aliased_completer, complete_event, text):
-    result = cased_aliased_completer.get_completions(
-        Document(text=text), complete_event)
+
+@parametrize('completer', completers(casing=True, alias=True))
+@parametrize('text', ['SELECT * FROM '])
+def test_aliases_with_casing(completer, complete_event, text):
+    result = completer.get_completions(Document(text=text), complete_event)
     assert set(result) == set([schema('PUBLIC')] + cased_aliased_rels)
 
-@pytest.mark.parametrize('text', ['SELECT * FROM '])
-def test_table_casing(cased_completer, complete_event, text):
-    result = cased_completer.get_completions(
+
+@parametrize('completer', completers(casing=True, alias=False))
+@parametrize('text', ['SELECT * FROM '])
+def test_table_casing(completer, complete_event, text):
+    result = completer.get_completions(
         Document(text=text), complete_event)
     assert set(result) == set([schema('PUBLIC')] + cased_rels)
 
 
-@pytest.mark.parametrize('text', [
+@parametrize('completer', completers(casing=False))
+@parametrize('text', [
     'INSERT INTO users ()',
     'INSERT INTO users()',
     'INSERT INTO users () SELECT * FROM orders;',
@@ -941,6 +999,7 @@ def test_insert(completer, complete_event, text):
     assert set(result) == set(testdata.columns('users'))
 
 
+@parametrize('completer', completers(casing=False, alias=False))
 def test_suggest_cte_names(completer, complete_event):
     text = '''
         WITH cte1 AS (SELECT a, b, c FROM foo),
@@ -958,6 +1017,11 @@ def test_suggest_cte_names(completer, complete_event):
     assert expected <= set(result)
 
 
+@parametrize(
+    'completer', completers(
+        casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
 def test_suggest_columns_from_cte(completer, complete_event):
     text = 'WITH cte AS (SELECT foo, bar FROM baz) SELECT  FROM cte'
     pos = len('WITH cte AS (SELECT foo, bar FROM baz) SELECT ')
@@ -974,7 +1038,12 @@ def test_suggest_columns_from_cte(completer, complete_event):
     assert set(expected) == set(result)
 
 
-@pytest.mark.parametrize('text', [
+@parametrize(
+    'completer', completers(
+        casing=False, qualify=['never', 'if_more_than_one_table']
+    )
+)
+@parametrize('text', [
     'WITH cte AS (SELECT foo FROM bar) SELECT * FROM cte WHERE cte.',
     'WITH cte AS (SELECT foo FROM bar) SELECT * FROM cte c WHERE c.',
 ])
@@ -987,7 +1056,7 @@ def test_cte_qualified_columns(completer, complete_event, text):
     assert set(expected) == set(result)
 
 
-@pytest.mark.parametrize('keyword_casing,expected,texts', [
+@parametrize('keyword_casing,expected,texts', [
     ('upper', 'SELECT', ('', 's', 'S', 'Sel')),
     ('lower', 'select', ('', 's', 'S', 'Sel')),
     ('auto', 'SELECT', ('', 'S', 'SEL', 'seL')),
@@ -1000,7 +1069,7 @@ def test_keyword_casing_upper(keyword_casing, expected, texts):
             Document(text=text, cursor_position=len(text)), complete_event)
         assert expected in [cpl.text for cpl in completions]
 
-
+@parametrize('completer', completers())
 def test_keyword_after_alter(completer):
     sql = 'ALTER TABLE users ALTER '
     expected = Completion('COLUMN', start_position=0, display_meta='keyword')

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -84,7 +84,7 @@ def test_builtin_function_matches_only_at_start(completer):
     assert 'MIN' not in result
 
 
-@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('completer', completers(casing=False, aliasing=False))
 def test_user_function_name_completion(completer):
     result = result_set(completer, 'SELECT cu')
     assert result == set([
@@ -96,7 +96,7 @@ def test_user_function_name_completion(completer):
     ])
 
 
-@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('completer', completers(casing=False, aliasing=False))
 def test_user_function_name_completion_matches_anywhere(completer):
     result = result_set(completer, 'SELECT om')
     assert result == set([
@@ -312,7 +312,7 @@ def test_suggested_join_conditions_with_invalid_table(completer, text, ref):
     assert result == set([alias('users'), alias(ref)])
 
 
-@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('completer', completers(casing=False, aliasing=False))
 @parametrize('text', [
     'SELECT * FROM "Users" u JOIN u',
     'SELECT * FROM "Users" u JOIN uid',
@@ -341,7 +341,7 @@ join_texts = [
 ]
 
 
-@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('completer', completers(casing=False, aliasing=False))
 @parametrize('text', join_texts)
 def test_suggested_joins(completer, text):
     result = result_set(completer, text)
@@ -354,7 +354,7 @@ def test_suggested_joins(completer, text):
     )
 
 
-@parametrize('completer', completers(casing=True, alias=False))
+@parametrize('completer', completers(casing=True, aliasing=False))
 @parametrize('text', join_texts)
 def test_cased_joins(completer, text):
     result = result_set(completer, text)
@@ -365,7 +365,7 @@ def test_cased_joins(completer, text):
     ])
 
 
-@parametrize('completer', completers(casing=False, alias=True))
+@parametrize('completer', completers(casing=False, aliasing=True))
 @parametrize('text', join_texts)
 def test_aliased_joins(completer, text):
     result = result_set(completer, text)
@@ -376,7 +376,7 @@ def test_aliased_joins(completer, text):
     ])
 
 
-@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('completer', completers(casing=False, aliasing=False))
 @parametrize('text', [
     'SELECT * FROM public."Users" JOIN ',
     'SELECT * FROM public."Users" RIGHT OUTER JOIN ',
@@ -480,7 +480,7 @@ def test_join_using_suggests_columns_after_first_column(completer, text):
     assert result == set([column('id'), column('email')])
 
 
-@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('completer', completers(casing=False, aliasing=False))
 @parametrize('text', [
     'SELECT * FROM ',
     'SELECT * FROM users CROSS JOIN ',
@@ -510,7 +510,7 @@ def test_auto_escaped_col_names(completer):
     assert result == set(testdata.columns_functions_and_keywords('select'))
 
 
-@parametrize('completer', completers(alias=False))
+@parametrize('completer', completers(aliasing=False))
 def test_allow_leading_double_quote_in_last_word(completer):
     result = result_set(completer, 'SELECT * from "sele')
 
@@ -592,7 +592,7 @@ def test_learn_keywords(completer):
     assert completions[0].text == 'VIEW'
 
 
-@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('completer', completers(casing=False, aliasing=False))
 def test_learn_table_names(completer):
     history = 'SELECT * FROM users; SELECT * FROM orders; SELECT * FROM users'
     completer.extend_query_history(history)
@@ -721,7 +721,7 @@ def test_suggest_columns_from_quoted_table(completer):
     assert result == set(testdata.columns('Users'))
 
 
-@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('completer', completers(casing=False, aliasing=False))
 @parametrize('text', ['SELECT * FROM ',
     'SELECT * FROM Orders o CROSS JOIN '])
 def test_schema_or_visible_table_completion(completer, text):
@@ -729,14 +729,14 @@ def test_schema_or_visible_table_completion(completer, text):
     assert result == set(testdata.schemas_and_from_clause_items())
 
 
-@parametrize('completer', completers(casing=False, alias=True))
+@parametrize('completer', completers(casing=False, aliasing=True))
 @parametrize('text', ['SELECT * FROM '])
 def test_table_aliases(completer, text):
     result = result_set(completer, text)
     assert result == set(testdata.schemas() + aliased_rels)
 
 
-@parametrize('completer', completers(casing=False, alias=True))
+@parametrize('completer', completers(casing=False, aliasing=True))
 @parametrize('text', ['SELECT * FROM Orders o CROSS JOIN '])
 def test_duplicate_table_aliases(completer, text):
     result = result_set(completer, text)
@@ -753,7 +753,7 @@ def test_duplicate_table_aliases(completer, text):
         function('set_returning_func() srf')])
 
 
-@parametrize('completer', completers(casing=True, alias=True))
+@parametrize('completer', completers(casing=True, aliasing=True))
 @parametrize('text', ['SELECT * FROM Orders o CROSS JOIN '])
 def test_duplicate_aliases_with_casing(completer, text):
     result = result_set(completer, text)
@@ -771,14 +771,14 @@ def test_duplicate_aliases_with_casing(completer, text):
         function('set_returning_func() srf')])
 
 
-@parametrize('completer', completers(casing=True, alias=True))
+@parametrize('completer', completers(casing=True, aliasing=True))
 @parametrize('text', ['SELECT * FROM '])
 def test_aliases_with_casing(completer, text):
     result = result_set(completer, text)
     assert result == set([schema('PUBLIC')] + cased_aliased_rels)
 
 
-@parametrize('completer', completers(casing=True, alias=False))
+@parametrize('completer', completers(casing=True, aliasing=False))
 @parametrize('text', ['SELECT * FROM '])
 def test_table_casing(completer, text):
     result = result_set(completer, text)
@@ -798,7 +798,7 @@ def test_insert(completer, text):
     assert result == set(testdata.columns('users'))
 
 
-@parametrize('completer', completers(casing=False, alias=False))
+@parametrize('completer', completers(casing=False, aliasing=False))
 def test_suggest_cte_names(completer):
     text = '''
         WITH cte1 AS (SELECT a, b, c FROM foo),

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -76,8 +76,8 @@ def test_empty_string_completion(completer, complete_event):
 
 @parametrize('completer', completers())
 def test_select_keyword_completion(completer, complete_event):
-    text = 'SEL'
-    position = len('SEL')
+    text = ('SEL')
+    position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position),
         complete_event)
@@ -86,8 +86,8 @@ def test_select_keyword_completion(completer, complete_event):
 
 @parametrize('completer', completers())
 def test_builtin_function_name_completion(completer, complete_event):
-    text = 'SELECT MA'
-    position = len('SELECT MA')
+    text = ('SELECT MA')
+    position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([
@@ -98,8 +98,8 @@ def test_builtin_function_name_completion(completer, complete_event):
 
 @parametrize('completer', completers())
 def test_builtin_function_matches_only_at_start(completer, complete_event):
-    text = 'SELECT IN'
-    position = len('SELECT IN')
+    text = ('SELECT IN')
+    position = len(text)
     document = Document(text=text, cursor_position=position)
 
     result = [c.text for c in
@@ -110,8 +110,8 @@ def test_builtin_function_matches_only_at_start(completer, complete_event):
 
 @parametrize('completer', completers(casing=False, alias=False))
 def test_user_function_name_completion(completer, complete_event):
-    text = 'SELECT cu'
-    position = len('SELECT cu')
+    text = ('SELECT cu')
+    position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([
@@ -126,8 +126,8 @@ def test_user_function_name_completion(completer, complete_event):
 @parametrize('completer', completers(casing=False, alias=False))
 def test_user_function_name_completion_matches_anywhere(completer,
                                                         complete_event):
-    text = 'SELECT om'
-    position = len('SELECT om')
+    text = ('SELECT om')
+    position = len(text)
     result = completer.get_completions(
         Document(text=text, cursor_position=position), complete_event)
     assert set(result) == set([

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -57,31 +57,27 @@ completers = testdata.get_completers(casing)
 
 @parametrize('completer', completers())
 def test_empty_string_completion(completer):
-    text = ''
-    result = result_set(completer, text)
+    result = result_set(completer, '')
     assert set(testdata.keywords()) == result
 
 
 @parametrize('completer', completers())
 def test_select_keyword_completion(completer):
-    text = ('SEL')
-    result = result_set(completer, text)
+    result = result_set(completer, 'SEL')
     assert result == set([keyword('SELECT', -3)])
 
 
 @parametrize('completer', completers())
 def test_builtin_function_name_completion(completer):
-    text = ('SELECT MA')
-    result = result_set(completer, text)
+    result = result_set(completer, 'SELECT MA')
     assert result == set([
         function('MAX', -2),
         keyword('MAXEXTENTS', -2), keyword('MATERIALIZED VIEW', -2)
     ])
 
-
 @parametrize('completer', completers())
 def test_builtin_function_matches_only_at_start(completer):
-    text = ('SELECT IN')
+    text = 'SELECT IN'
 
     result = [c.text for c in get_result(completer, text)]
 
@@ -90,8 +86,7 @@ def test_builtin_function_matches_only_at_start(completer):
 
 @parametrize('completer', completers(casing=False, alias=False))
 def test_user_function_name_completion(completer):
-    text = ('SELECT cu')
-    result = result_set(completer, text)
+    result = result_set(completer, 'SELECT cu')
     assert result == set([
         function('custom_fun()', -2),
         function('_custom_fun()', -2),
@@ -103,8 +98,7 @@ def test_user_function_name_completion(completer):
 
 @parametrize('completer', completers(casing=False, alias=False))
 def test_user_function_name_completion_matches_anywhere(completer):
-    text = ('SELECT om')
-    result = result_set(completer, text)
+    result = result_set(completer, 'SELECT om')
     assert result == set([
         function('custom_fun()', -2),
         function('_custom_fun()', -2),
@@ -114,9 +108,7 @@ def test_user_function_name_completion_matches_anywhere(completer):
 
 @parametrize('completer', completers(casing=False, qualify=no_qual))
 def test_suggested_column_names_from_visible_table(completer):
-    text = 'SELECT  from users'
-    position = len('SELECT ')
-    result = result_set(completer, text, position)
+    result = result_set(completer, 'SELECT  from users', len('SELECT '))
     assert result == set(testdata.columns('users') + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
@@ -125,9 +117,7 @@ def test_suggested_column_names_from_visible_table(completer):
 
 @parametrize('completer', completers(casing=True, qualify=no_qual))
 def test_suggested_cased_column_names(completer):
-    text = 'SELECT  from users'
-    position = len('SELECT ')
-    result = result_set(completer, text, position)
+    result = result_set(completer, 'SELECT  from users', len('SELECT '))
     assert result == set(cased_funcs + cased_users_cols
         + testdata.builtin_functions() + testdata.keywords())
 
@@ -184,33 +174,31 @@ def test_suggested_cased_always_qualified_column_names(
 
 @parametrize('completer', completers(casing=False, qualify=no_qual))
 def test_suggested_column_names_in_function(completer):
-    text = 'SELECT MAX( from users'
-    position = len('SELECT MAX(')
-    result = result_set(completer, text, position)
+    result = result_set(
+        completer, 'SELECT MAX( from users', len('SELECT MAX(')
+    )
     assert result == set(testdata.columns('users'))
 
 
 @parametrize('completer', completers(casing=False))
 def test_suggested_column_names_with_table_dot(completer):
-    text = 'SELECT users. from users'
-    position = len('SELECT users.')
-    result = result_set(completer, text, position)
+    result = result_set(
+        completer, 'SELECT users. from users', len('SELECT users.')
+    )
     assert result == set(testdata.columns('users'))
 
 
 @parametrize('completer', completers(casing=False))
 def test_suggested_column_names_with_alias(completer):
-    text = 'SELECT u. from users u'
-    position = len('SELECT u.')
-    result = result_set(completer, text, position)
+    result = result_set(completer, 'SELECT u. from users u', len('SELECT u.'))
     assert result == set(testdata.columns('users'))
 
 
 @parametrize('completer', completers(casing=False, qualify=no_qual))
 def test_suggested_multiple_column_names(completer):
-    text = 'SELECT id,  from users u'
-    position = len('SELECT id, ')
-    result = result_set(completer, text, position)
+    result = result_set(
+        completer, 'SELECT id,  from users u', len('SELECT id, ')
+    )
     assert result == set(testdata.columns('users') + testdata.functions() +
         list(testdata.builtin_functions() +
         testdata.keywords())
@@ -219,26 +207,28 @@ def test_suggested_multiple_column_names(completer):
 
 @parametrize('completer', completers(casing=False))
 def test_suggested_multiple_column_names_with_alias(completer):
-    text = 'SELECT u.id, u. from users u'
-    position = len('SELECT u.id, u.')
-    result = result_set(completer, text, position)
+    result = result_set(
+        completer, 'SELECT u.id, u. from users u', len('SELECT u.id, u.')
+    )
     assert result == set(testdata.columns('users'))
 
 
 
 @parametrize('completer', completers(casing=True))
 def test_suggested_cased_column_names_with_alias(completer):
-    text = 'SELECT u.id, u. from users u'
-    position = len('SELECT u.id, u.')
-    result = result_set(completer, text, position)
+    result = result_set(
+        completer, 'SELECT u.id, u. from users u', len('SELECT u.id, u.')
+    )
     assert result == set(cased_users_cols)
 
 
 @parametrize('completer', completers(casing=False))
 def test_suggested_multiple_column_names_with_dot(completer):
-    text = 'SELECT users.id, users. from users u'
-    position = len('SELECT users.id, users.')
-    result = result_set(completer, text, position)
+    result = result_set(
+        completer,
+        'SELECT users.id, users. from users u',
+        len('SELECT users.id, users.')
+    )
     assert result == set(testdata.columns('users'))
 
 
@@ -249,6 +239,7 @@ def test_suggest_columns_after_three_way_join(completer):
               INNER JOIN users u3 ON u2.id = u3.'''
     result = result_set(completer, text)
     assert (column('id') in result)
+
 
 join_condition_texts = [
     'INSERT INTO orders SELECT * FROM users U JOIN "Users" U2 ON ',
@@ -274,19 +265,17 @@ join_condition_texts = [
 def test_suggested_join_conditions(completer, text):
     result = result_set(completer, text)
     assert result == set([
-        alias('U'),
-        alias('U2'),
-        fk_join('U2.userid = U.id')])
+        alias('U'), alias('U2'), fk_join('U2.userid = U.id')
+    ])
 
 
 @parametrize('completer', completers(casing=True))
 @parametrize('text', join_condition_texts)
 def test_cased_join_conditions(completer, text):
     result = result_set(completer, text)
-    assert result == set([
-        alias('U'),
-        alias('U2'),
-        fk_join('U2.UserID = U.ID')])
+    assert result == set(
+        [alias('U'), alias('U2'), fk_join('U2.UserID = U.ID')]
+    )
 
 
 @parametrize('completer', completers(casing=False))
@@ -375,9 +364,7 @@ def test_suggested_joins(completer, text):
 @parametrize('completer', completers(casing=True, alias=False))
 @parametrize('text', join_texts)
 def test_cased_joins(completer, text):
-    result = set(
-        result_set(completer, text)
-    )
+    result = result_set(completer, text)
     assert result == set([schema('PUBLIC')] + cased_rels + [
         join('"Users" ON "Users".UserID = Users.ID'),
         join('Users Users2 ON Users2.ID = Users.PARENTID'),
@@ -388,9 +375,7 @@ def test_cased_joins(completer, text):
 @parametrize('completer', completers(casing=False, alias=True))
 @parametrize('text', join_texts)
 def test_aliased_joins(completer, text):
-    result = set(
-        result_set(completer, text)
-    )
+    result = result_set(completer, text)
     assert result == set(testdata.schemas() + aliased_rels + [
         join('"Users" U ON U.userid = Users.id'),
         join('users u ON u.id = Users.parentid'),
@@ -411,7 +396,7 @@ def test_suggested_joins_quoted_schema_qualified_table(completer, text):
     assert result == set(testdata.schemas() + testdata.tables()
         + testdata.views() + [
         join('public.users ON users.id = "Users".userid'),
-        ] + testdata.functions())
+    ] + testdata.functions())
 
 
 @parametrize('completer', completers(casing=False))
@@ -435,11 +420,11 @@ def test_suggested_aliases_after_on(completer, text):
     'SELECT u.name, o.id FROM users u JOIN orders o ON o.user_id =  JOIN orders o2 ON'
 ])
 def test_suggested_aliases_after_on_right_side(completer, text):
-    position = len('SELECT u.name, o.id FROM users u JOIN orders o ON o.user_id = ')
+    position = len(
+        'SELECT u.name, o.id FROM users u JOIN orders o ON o.user_id = '
+    )
     result = result_set(completer, text, position)
-    assert result == set([
-        alias('u'),
-        alias('o')])
+    assert result == set([alias('u'), alias('o')])
 
 
 @parametrize('completer', completers(casing=False))
@@ -454,7 +439,8 @@ def test_suggested_tables_after_on(completer, text):
         name_join('orders.id = users.id'),
         name_join('orders.email = users.email'),
         alias('users'),
-        alias('orders')])
+        alias('orders')
+    ])
 
 
 @parametrize('completer', completers(casing=False))
@@ -465,9 +451,7 @@ def test_suggested_tables_after_on(completer, text):
 def test_suggested_tables_after_on_right_side(completer, text):
     position = len('SELECT users.name, orders.id FROM users JOIN orders ON orders.user_id = ')
     result = result_set(completer, text, position)
-    assert result == set([
-        alias('users'),
-        alias('orders')])
+    assert result == set([alias('users'), alias('orders')])
 
 
 @parametrize('completer', completers(casing=False))
@@ -477,10 +461,7 @@ def test_suggested_tables_after_on_right_side(completer, text):
 ])
 def test_join_using_suggests_common_columns(completer, text):
     result = result_set(completer, text)
-    assert result == set([
-        column('id'),
-        column('email'),
-    ])
+    assert result == set([column('id'), column('email')])
 
 
 @parametrize('completer', completers(casing=False))
@@ -493,10 +474,7 @@ def test_join_using_suggests_common_columns(completer, text):
 def test_join_using_suggests_from_last_table(completer, text):
     position = text.index('()') + 1
     result = result_set(completer, text, position)
-    assert result == set([
-        column('id'),
-        column('email'),
-    ])
+    assert result == set([column('id'), column('email')])
 
 
 @parametrize('completer', completers(casing=False))
@@ -506,10 +484,7 @@ def test_join_using_suggests_from_last_table(completer, text):
 ])
 def test_join_using_suggests_columns_after_first_column(completer, text):
     result = result_set(completer, text)
-    assert result == set([
-        column('id'),
-        column('email'),
-    ])
+    assert result == set([column('id'), column('email')])
 
 
 @parametrize('completer', completers(casing=False, alias=False))
@@ -539,9 +514,7 @@ def test_table_names_after_from(completer, text):
 
 @parametrize('completer', completers(casing=False, qualify=no_qual))
 def test_auto_escaped_col_names(completer):
-    text = 'SELECT  from "select"'
-    position = len('SELECT ')
-    result = result_set(completer, text, position)
+    result = result_set(completer, 'SELECT  from "select"', len('SELECT '))
     assert result == set(testdata.columns('select') + [
         ] + testdata.functions() +
         list(testdata.builtin_functions() +
@@ -551,8 +524,7 @@ def test_auto_escaped_col_names(completer):
 
 @parametrize('completer', completers(alias=False))
 def test_allow_leading_double_quote_in_last_word(completer):
-    text = 'SELECT * from "sele'
-    result = result_set(completer, text)
+    result = result_set(completer, 'SELECT * from "sele')
 
     expected = table('"select"', -5)
 
@@ -574,29 +546,31 @@ def test_suggest_datatype(text, completer):
 
 @parametrize('completer', completers(casing=False))
 def test_suggest_columns_from_escaped_table_alias(completer):
-    text = 'select * from "select" s where s.'
-    result = result_set(completer, text)
+    result = result_set(completer, 'select * from "select" s where s.')
     assert result == set(testdata.columns('select'))
 
 
 @parametrize('completer', completers(casing=False, qualify=no_qual))
 def test_suggest_columns_from_set_returning_function(completer):
-    text = 'select  from set_returning_func()'
-    position = len('select ')
-    result = result_set(completer, text, position)
+    result = result_set(
+        completer, 'select  from set_returning_func()', len('select ')
+    )
     assert result == set(
         testdata.columns('set_returning_func', typ='functions')
         + testdata.functions()
         + list(testdata.builtin_functions()
-        + testdata.keywords()))
+        + testdata.keywords())
+    )
 
 
 @parametrize('completer', completers(casing=False))
 def test_suggest_columns_from_aliased_set_returning_function(completer):
-    text = 'select f. from set_returning_func() f'
-    position = len('select f.')
-    result = result_set(completer, text, position)
-    assert result == set(testdata.columns('set_returning_func', typ='functions'))
+    result = result_set(
+        completer, 'select f. from set_returning_func() f', len('select f.')
+    )
+    assert result == set(
+        testdata.columns('set_returning_func', typ='functions')
+    )
 
 
 @parametrize('completer', completers(casing=False))
@@ -605,7 +579,8 @@ def test_join_functions_using_suggests_common_columns(completer):
               INNER JOIN set_returning_func() f2 USING ('''
     result = result_set(completer, text)
     assert result == set(
-        testdata.columns('set_returning_func', typ='functions'))
+        testdata.columns('set_returning_func', typ='functions')
+    )
 
 
 @parametrize('completer', completers(casing=False))
@@ -613,10 +588,10 @@ def test_join_functions_on_suggests_columns_and_join_conditions(completer):
     text = '''SELECT * FROM set_returning_func() f1
               INNER JOIN set_returning_func() f2 ON f1.'''
     result = result_set(completer, text)
-    assert result == set([
-         name_join('y = f2.y'),
-         name_join('x = f2.x'),
-         ] + testdata.columns('set_returning_func', typ='functions'))
+    assert result == set(
+        [name_join('y = f2.y'), name_join('x = f2.x')] +
+        testdata.columns('set_returning_func', typ='functions')
+    )
 
 
 @parametrize('completer', completers())
@@ -702,7 +677,9 @@ def test_wildcard_column_expansion_with_alias(completer, text):
     ('SELECT Users.* FROM Users',
         'id, Users.parentid, Users.email, Users.first_name, Users.last_name'),
 ])
-def test_wildcard_column_expansion_with_table_qualifier(completer, text, expected):
+def test_wildcard_column_expansion_with_table_qualifier(
+    completer, text, expected
+):
     position = len('SELECT users.*')
 
     completions = get_result(completer, text, position)
@@ -752,9 +729,9 @@ def test_suggest_columns_from_unquoted_table(completer, text):
 
 @parametrize('completer', completers(casing=False))
 def test_suggest_columns_from_quoted_table(completer):
-    text = 'SELECT U. FROM "Users" U'
-    position = len('SELECT U.')
-    result = result_set(completer, text, position)
+    result = result_set(
+        completer, 'SELECT U. FROM "Users" U', len('SELECT U.')
+    )
     assert result == set(testdata.columns('Users'))
 
 
@@ -853,16 +830,18 @@ def test_suggest_cte_names(completer):
 
 @parametrize('completer', completers(casing=False, qualify=no_qual))
 def test_suggest_columns_from_cte(completer):
-    text = 'WITH cte AS (SELECT foo, bar FROM baz) SELECT  FROM cte'
-    position = len('WITH cte AS (SELECT foo, bar FROM baz) SELECT ')
-    result = result_set(completer, text, position)
-    expected = ([Completion('foo', 0, display_meta='column'),
-                 Completion('bar', 0, display_meta='column'),
-                 ] +
-                testdata.functions() +
-                testdata.builtin_functions() +
-                testdata.keywords()
-                )
+    result = result_set(
+        completer,
+        'WITH cte AS (SELECT foo, bar FROM baz) SELECT  FROM cte',
+        len('WITH cte AS (SELECT foo, bar FROM baz) SELECT ')
+    )
+    expected = (
+        [
+            Completion('foo', 0, display_meta='column'),
+            Completion('bar', 0, display_meta='column'),
+        ] + testdata.functions() + testdata.builtin_functions() +
+        testdata.keywords()
+    )
 
     assert set(expected) == result
 

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -1,8 +1,7 @@
 from __future__ import unicode_literals
-import pytest
 from metadata import (MetaData, alias, name_join, fk_join, join, keyword,
     schema, table, view, function, column, wildcard_expansion,
-    get_result, result_set)
+    get_result, result_set, qual, no_qual, parametrize)
 from prompt_toolkit.completion import Completion
 
 
@@ -53,9 +52,7 @@ cased_aliased_rels = [table(t) for t in ('Users U', '"Users" U', 'Orders O',
     '"select" s')] + [view('User_Emails UE')] + [function(f) for f in (
     '_custom_fun() cf', 'Custom_Fun() CF', 'Custom_Func1() CF',
     'custom_func2() cf', 'set_returning_func() srf')]
-
 completers = testdata.get_completers(casing)
-parametrize = pytest.mark.parametrize
 
 
 @parametrize('completer', completers())
@@ -115,11 +112,7 @@ def test_user_function_name_completion_matches_anywhere(completer):
         function('custom_func2()', -2)])
 
 
-@parametrize(
-    'completer', completers(
-        casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(casing=False, qualify=no_qual))
 def test_suggested_column_names_from_visible_table(completer):
     text = 'SELECT  from users'
     position = len('SELECT ')
@@ -130,11 +123,7 @@ def test_suggested_column_names_from_visible_table(completer):
     )
 
 
-@parametrize(
-    'completer', completers(
-        casing=True, qualify=['if_more_than_one_table', 'never']
-    )
-)
+@parametrize('completer', completers(casing=True, qualify=no_qual))
 def test_suggested_cased_column_names(completer):
     text = 'SELECT  from users'
     position = len('SELECT ')
@@ -143,9 +132,7 @@ def test_suggested_cased_column_names(completer):
         + testdata.builtin_functions() + testdata.keywords())
 
 
-@parametrize(
-    'completer', completers(casing=False, qualify=['if_more_than_one_table'])
-)
+@parametrize('completer', completers(casing=False, qualify=no_qual))
 @parametrize('text', [
     'SELECT  from users',
     'INSERT INTO Orders SELECT  from users',
@@ -158,11 +145,7 @@ def test_suggested_auto_qualified_column_names(text, completer):
         + testdata.builtin_functions() + testdata.keywords())
 
 
-@parametrize(
-    'completer', completers(
-        casing=False, qualify=['always', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(casing=False, qualify=qual))
 @parametrize('text', [
     'SELECT  from users U NATURAL JOIN "Users"',
     'INSERT INTO Orders SELECT  from users U NATURAL JOIN "Users"',
@@ -199,11 +182,7 @@ def test_suggested_cased_always_qualified_column_names(
         + testdata.builtin_functions() + testdata.keywords())
 
 
-@parametrize(
-    'completer', completers(
-        casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(casing=False, qualify=no_qual))
 def test_suggested_column_names_in_function(completer):
     text = 'SELECT MAX( from users'
     position = len('SELECT MAX(')
@@ -227,11 +206,7 @@ def test_suggested_column_names_with_alias(completer):
     assert result == set(testdata.columns('users'))
 
 
-@parametrize(
-    'completer', completers(
-        casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(casing=False, qualify=no_qual))
 def test_suggested_multiple_column_names(completer):
     text = 'SELECT id,  from users u'
     position = len('SELECT id, ')
@@ -562,11 +537,7 @@ def test_table_names_after_from(completer, text):
     ]
 
 
-@parametrize(
-    'completer', completers(
-        casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(casing=False, qualify=no_qual))
 def test_auto_escaped_col_names(completer):
     text = 'SELECT  from "select"'
     position = len('SELECT ')
@@ -608,11 +579,7 @@ def test_suggest_columns_from_escaped_table_alias(completer):
     assert result == set(testdata.columns('select'))
 
 
-@parametrize(
-    'completer', completers(
-        casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(casing=False, qualify=no_qual))
 def test_suggest_columns_from_set_returning_function(completer):
     text = 'select  from set_returning_func()'
     position = len('select ')
@@ -679,11 +646,7 @@ def test_learn_table_names(completer):
     assert completions.index(users) < completions.index(orders)
 
 
-@parametrize(
-    'completer', completers(
-        casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(casing=False, qualify=no_qual))
 def test_columns_before_keywords(completer):
     text = 'SELECT * FROM orders WHERE s'
     completions = get_result(completer, text)
@@ -694,11 +657,7 @@ def test_columns_before_keywords(completer):
     assert completions.index(col) < completions.index(kw)
 
 
-@parametrize(
-    'completer', completers(
-        casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(casing=False, qualify=no_qual))
 @parametrize('text', [
     'SELECT * FROM users',
     'INSERT INTO users SELECT * FROM users u',
@@ -753,11 +712,7 @@ def test_wildcard_column_expansion_with_table_qualifier(completer, text, expecte
     assert expected == completions
 
 
-@parametrize(
-    'completer', completers(
-        casing=False, qualify=['always', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(casing=False, qualify=qual))
 def test_wildcard_column_expansion_with_two_tables(completer):
     text = 'SELECT * FROM "select" JOIN users u ON true'
     position = len('SELECT *')
@@ -896,11 +851,7 @@ def test_suggest_cte_names(completer):
     assert expected <= result
 
 
-@parametrize(
-    'completer', completers(
-        casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(casing=False, qualify=no_qual))
 def test_suggest_columns_from_cte(completer):
     text = 'WITH cte AS (SELECT foo, bar FROM baz) SELECT  FROM cte'
     position = len('WITH cte AS (SELECT foo, bar FROM baz) SELECT ')
@@ -916,11 +867,7 @@ def test_suggest_columns_from_cte(completer):
     assert set(expected) == result
 
 
-@parametrize(
-    'completer', completers(
-        casing=False, qualify=['never', 'if_more_than_one_table']
-    )
-)
+@parametrize('completer', completers(casing=False, qualify=no_qual))
 @parametrize('text', [
     'WITH cte AS (SELECT foo FROM bar) SELECT * FROM cte WHERE cte.',
     'WITH cte AS (SELECT foo FROM bar) SELECT * FROM cte c WHERE c.',


### PR DESCRIPTION
Instead of having a bunch of hard-coded completer fixtures (with different configs) in tests/test_smart_completion_multiple_schemata.py and tests/test_smart_completion_public_schema_only.py, let's have a completer factory in tests/metadata.py. Also, instead of running a test case for one completer config, let's run it for a bunch of different completer configs. That's the basic idea.

Also, I noticed there was some room for deduplication of the smart_completion code, so I moved a bunch of duplicated code from the test functions into metadata.py. There's no change in function for any commit except the first ("Parametrize ...").