### PR TITLE
Attempt to fix #668 (not pretty).

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -351,6 +351,7 @@ class PGCli(object):
         :param document: Document
         :return: Document
         """
+        saved_callables = cli.application.pre_run_callables
         while special.editor_command(document.text):
             filename = special.get_filename(document.text)
             sql, message = special.open_external_editor(filename,
@@ -359,8 +360,10 @@ class PGCli(object):
                 # Something went wrong. Raise an exception and bail.
                 raise RuntimeError(message)
             cli.current_buffer.document = Document(sql, cursor_position=len(sql))
-            document = cli.run(False)
+            cli.application.pre_run_callables = []
+            document = cli.run()
             continue
+        cli.application.pre_run_callables = saved_callables
         return document
 
     def execute_command(self, text, query):
@@ -443,7 +446,7 @@ class PGCli(object):
 
         try:
             while True:
-                document = self.cli.run(True)
+                document = self.cli.run()
 
                 # The reason we check here instead of inside the pgexecute is
                 # because we want to raise the Exit exception which will be

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -351,6 +351,9 @@ class PGCli(object):
         :param document: Document
         :return: Document
         """
+        # FIXME: using application.pre_run_callables like this here is not the best solution.
+        # It's internal api of prompt_toolkit that may change. This was added to fix #668.
+        # We may find a better way to do it in the future.
         saved_callables = cli.application.pre_run_callables
         while special.editor_command(document.text):
             filename = special.get_filename(document.text)


### PR DESCRIPTION
This is an attempt to fix #668 .

There's another PR to do the same: https://github.com/dbcli/pgcli/pull/669, but it does not fix the problem completely, because we need to reset the cli buffer in most cases. Editor command seems to be the special case where we don't want the reset.

This PR is work in progress, because I dislike using internal `prompt_toolkit` API like this. I would like very much for @jonathanslenders to weigh in on this.

cc @amjith @jdpopkin