### PR TITLE
Allow configurable multiline continuation char

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,6 +56,7 @@ Contributors:
     * Manuel Barkhau
     * Sergii V
     * Emanuele Gaifas
+    * Owen Stephens
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,7 @@ Upcoming
 Features:
 ---------
 * Suggest objects from all schemas (not just those in search_path) (Thanks: `Joakim Koljonen`_)
+* Allow configurable character to be used for multi-line query continuations. (Thanks: `Owen Stephens`_)
 
 Bug fixes:
 ----------
@@ -663,3 +664,4 @@ Improvements:
 .. _`Sergii`: https://github.com/foxyterkel 
 .. _`Emanuele Gaifas`: https://github.com/lelit
 .. _`tk`: https://github.com/kanet77
+.. _`Owen Stephens`: https://github.com/owst

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -133,6 +133,7 @@ class PGCli(object):
             self.row_limit = c['main'].as_int('row_limit')
 
         self.min_num_menu_lines = c['main'].as_int('min_num_menu_lines')
+        self.multiline_continuation_char = c['main']['multiline_continuation_char']
         self.table_format = c['main']['table_format']
         self.syntax_style = c['main']['syntax_style']
         self.cli_style = c['colors']
@@ -508,7 +509,8 @@ class PGCli(object):
             return [(Token.Prompt, prompt)]
 
         def get_continuation_tokens(cli, width):
-            return [(Token.Continuation, '.' * (width - 1) + ' ')]
+            continuation=self.multiline_continuation_char * (width - 1) + ' '
+            return [(Token.Continuation, continuation)]
 
         get_toolbar_tokens = create_toolbar_tokens_func(
             lambda: self.vi_mode, self.completion_refresher.is_refreshing,

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -116,6 +116,9 @@ prompt = '\u@\h:\d> '
 # Number of lines to reserve for the suggestion menu
 min_num_menu_lines = 4
 
+# Character used to left pad multi-line queries to match the prompt size.
+multiline_continuation_char = '.'
+
 # Custom colors for the completion menu, toolbar, etc.
 [colors]
 Token.Menu.Completions.Completion.Current = 'bg:#ffffff #000000'


### PR DESCRIPTION
## Description
Makes the character used for continuing multi-line queries configurable. To me, having a space rather than '.' is cleaner, (particularly when pasting the query/output for others to read). 

Now, setting `multiline_continuation_char = ' '` changes:
```
postgres@localhost:testdb1> SELECT *
........................... FROM foo
........................... WHERE bar = 1;
```
to
```
postgres@localhost:testdb1> SELECT *
                            FROM foo
                            WHERE bar = 1;
```

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).