### PR TITLE
Standardize command line option names

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ Contributors:
     * Sergii V
     * Emanuele Gaifas
     * Owen Stephens
+    * Russell Davies
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -9,6 +9,7 @@ Features:
 Bug fixes:
 ----------
 * Fixed external editor bug (issue #668). (Thanks: `Irina Truong`_).
+* Standardize command line option names. (Thanks: `Russell Davies`_)
 
 1.5.1
 =====
@@ -665,3 +666,4 @@ Improvements:
 .. _`Emanuele Gaifas`: https://github.com/lelit
 .. _`tk`: https://github.com/kanet77
 .. _`Owen Stephens`: https://github.com/owst
+.. _`Russell Davies`: https://github.com/russelldavies

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -721,8 +721,8 @@ class PGCli(object):
         help='Host address of the postgres database.')
 @click.option('-p', '--port', default=5432, help='Port number at which the '
         'postgres instance is listening.', envvar='PGPORT')
-@click.option('-U', '--user', envvar='PGUSER', help='User name to '
-        'connect to the postgres database.')
+@click.option('-U', '--username', 'username_opt', envvar='PGUSER',
+        help='Username to connect to the postgres database.')
 @click.option('-W', '--password', 'prompt_passwd', is_flag=True, default=False,
         help='Force password prompt.')
 @click.option('-w', '--no-password', 'never_prompt', is_flag=True,
@@ -737,7 +737,7 @@ class PGCli(object):
         envvar='PGCLIRC', help='Location of pgclirc file.')
 @click.option('-D', '--dsn', default='', envvar='DSN',
         help='Use DSN configured into the [alias_dsn] section of pgclirc file.')
-@click.option('-R', '--row-limit', default=None, envvar='PGROWLIMIT', type=click.INT,
+@click.option('--row-limit', default=None, envvar='PGROWLIMIT', type=click.INT,
         help='Set threshold for row limit prompt. Use 0 to disable prompt.')
 @click.option('--less-chatty', 'less_chatty', is_flag=True,
         default=False,
@@ -745,7 +745,7 @@ class PGCli(object):
 @click.option('--prompt', help='Prompt format (Default: "\\u@\\h:\\d> ").')
 @click.argument('database', default=lambda: None, envvar='PGDATABASE', nargs=1)
 @click.argument('username', default=lambda: None, envvar='PGUSER', nargs=1)
-def cli(database, user, host, port, prompt_passwd, never_prompt,
+def cli(database, username_opt, host, port, prompt_passwd, never_prompt,
     single_connection, dbname, username, version, pgclirc, dsn, row_limit,
     less_chatty, prompt):
 
@@ -775,7 +775,7 @@ def cli(database, user, host, port, prompt_passwd, never_prompt,
 
     # Choose which ever one has a valid value.
     database = database or dbname
-    user = username or user
+    user = username or username_opt
 
     if dsn is not '':
         try:


### PR DESCRIPTION
This standardizes on the same names as psql and removes some
conflicts.

## Description
I was using a database tool that was launching pgcli (thinking it was psql) with the `--username` option. This failed as pgcli expected the username option as `--user`. Since pgcli has extra and different functionality than psql it makes sense to have additional command line options but I think it's important for compatibility purposes to mimic psql's command line interface.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
