### PR TITLE
Make it easier to find config option documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,6 @@ The `pgcli` is written using prompt_toolkit_.
     - ``SELECT * FROM <tab>`` will only show table names. 
     - ``SELECT * FROM users WHERE <tab>`` will only show column names. 
 
-* Config file is automatically created at ``~/.config/pgcli/config`` at first launch.
 * Primitive support for ``psql`` back-slash commands. 
 * Pretty prints tabular data.
   Note: `pgcli` uses [tabulate](https://github.com/dbcli/pgcli/blob/master/pgcli/packages/tabulate.py)
@@ -72,6 +71,11 @@ The `pgcli` is written using prompt_toolkit_.
   [this issue](https://github.com/dbcli/pgcli/issues/617) for more details.
 
 .. _prompt_toolkit: https://github.com/jonathanslenders/python-prompt-toolkit
+
+Config
+------
+A config file is automatically created at ``~/.config/pgcli/config`` at first launch.
+See the file itself for a description of all available options.
 
 Contributions:
 --------------


### PR DESCRIPTION
## Description
It took me a little long to find the config options.
Reasons to make it more visible I think are:
* The location is not in the help text
* Not everyone is familiar with the convention of .rc files going in `XDG_CONFIG_HOME`.
* Often options are explained in the readme; I thought it nice to at least mention where one could find a description of them.

On the flipside, the readme becomes a little longer.
This contribution isn't noteworthy of course, so I took the liberty to skip the checklist 😁.
