### PR TITLE
Suggest columns for `ORDER BY` and `DISTINCT` (fixes #685)

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,7 @@ Features:
 ---------
 * Suggest objects from all schemas (not just those in search_path) (Thanks: `Joakim Koljonen`_)
 * Allow configurable character to be used for multi-line query continuations. (Thanks: `Owen Stephens`_)
+* Completions after ORDER BY and DISTINCT now take account of table aliases. (Thanks: `Owen Stephens`_)
 
 Bug fixes:
 ----------

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -376,10 +376,7 @@ def suggest_based_on_last_token(token, stmt):
     elif token_v == 'set':
         return (Column(table_refs=stmt.get_tables(),
                        local_tables=stmt.local_tables),)
-    elif token_v in ('by', 'distinct'):
-        return (Column(table_refs=stmt.get_tables(),
-                       local_tables=stmt.local_tables, qualifiable=True),)
-    elif token_v in ('select', 'where', 'having'):
+    elif token_v in ('select', 'where', 'having', 'by', 'distinct'):
         # Check for a table alias or schema qualification
         parent = (stmt.identifier and stmt.identifier.get_parent_name()) or []
         tables = stmt.get_tables()


### PR DESCRIPTION
## Description
Having typed an alias name in an `ORDER BY` or (`SELECT`) `DISTINCT` clause,
the alias was not taken account of, and the completion simply listed all
columns. This change fixes that, and makes the autocompletion behave the
same as in `SELECT` and `WHERE` clauses.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
