### PR TITLE
behave quit pgcli nicely

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -17,6 +17,7 @@ Internal changes:
 -----------------
 * Run pep8 checks in travis (Thanks: `Irina Truong`_).
 * Add pager wrapper for behave tests (Thanks: `Dick Marinus`_).
+* Behave quit pgcli nicely (Thanks: `Dick Marinus`_).
 
 1.5.1
 =====

--- a/tests/features/steps/basic_commands.py
+++ b/tests/features/steps/basic_commands.py
@@ -20,6 +20,7 @@ def step_run_cli(context):
     cli_cmd = context.conf.get('cli_command')
     context.cli = pexpect.spawnu(cli_cmd, cwd='..')
     context.exit_sent = False
+    context.currentdb = context.conf['dbname']
 
 
 @when('we wait for prompt')

--- a/tests/features/steps/crud_database.py
+++ b/tests/features/steps/crud_database.py
@@ -49,6 +49,7 @@ def step_db_connect_dbserver(context):
     Send connect to database.
     """
     context.cli.sendline('\\connect postgres')
+    context.currentdb = 'postgres'
 
 
 @then('dbcli exits')
@@ -65,6 +66,7 @@ def step_see_prompt(context):
     Wait to see the prompt.
     """
     wrappers.expect_exact(context, '{0}> '.format(context.conf['dbname']), timeout=5)
+    context.atprompt = True
 
 
 @then('we see help output')
@@ -78,7 +80,7 @@ def step_see_db_created(context):
     """
     Wait to see create database output.
     """
-    wrappers.expect_exact(context, 'CREATE DATABASE', timeout=2)
+    wrappers.expect_pager(context, 'CREATE DATABASE\r\n', timeout=5)
 
 
 @then('we see database dropped')
@@ -86,7 +88,7 @@ def step_see_db_dropped(context):
     """
     Wait to see drop database output.
     """
-    wrappers.expect_exact(context, 'DROP DATABASE', timeout=2)
+    wrappers.expect_pager(context, 'DROP DATABASE\r\n', timeout=2)
 
 
 @then('we see database connected')

--- a/tests/features/steps/iocommands.py
+++ b/tests/features/steps/iocommands.py
@@ -38,7 +38,7 @@ def step_edit_done_sql(context):
     for match in 'select * from abc'.split(' '):
         wrappers.expect_exact(context, match, timeout=1)
     # Cleanup the command line.
-    context.cli.sendcontrol('u')
+    context.cli.sendcontrol('c')
     # Cleanup the edited file.
     if context.editor_file_name and os.path.exists(context.editor_file_name):
         os.remove(context.editor_file_name)


### PR DESCRIPTION
## Description
behave quit pgcli nicely so that coverage can be collected, before this patch pgcli was killed by pexpect at the end of a feature test


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
