### PR TITLE
Fix typo in parseutils.meta.FunctionMetadata

### DIFF
--- a/pgcli/packages/parseutils/meta.py
+++ b/pgcli/packages/parseutils/meta.py
@@ -67,7 +67,7 @@ class FunctionMetadata(object):
             # E.g. 'SELECT unnest FROM unnest(...);'
             return [ColumnMetadata(self.func_name, self.return_type, [])]
 
-        return [ColumnMetadata(name, type, [])
+        return [ColumnMetadata(name, typ, [])
             for name, typ, mode in zip(
                 self.arg_names, self.arg_types, self.arg_modes)
             if mode in ('o', 'b', 't')] # OUT, INOUT, TABLE


### PR DESCRIPTION
## Description
Just noticed that it was "type" instead of "typ" in the list comprehension.
I'm not sure what cases this issue was covering, so sorry, I have no idea what to write in changelog.
It's also too minor to add myself to the `AUTHORS` :)

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
