### PR TITLE
User option should take precedence over environment variable.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Bug fixes:
 * Fixed external editor bug (issue #668). (Thanks: `Irina Truong`_).
 * Standardize command line option names. (Thanks: `Russell Davies`_)
 * Improve handling of ``lock_not_available`` error (issue #700). (Thanks: `Jackson Popkin <https://github.com/jdpopkin>`_)
+* Fixed user option precedence (issue #697). (Thanks: `Irina Truong`_).
 
 Internal changes:
 -----------------

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -793,7 +793,7 @@ def cli(database, username_opt, host, port, prompt_passwd, never_prompt,
 
     # Choose which ever one has a valid value.
     database = database or dbname
-    user = username or username_opt
+    user = username_opt or username
 
     if dsn is not '':
         try:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Fix for #697.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
