### PR TITLE
Adding time option for the Prompt Format

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,6 +63,7 @@ Contributors:
     * AlexTes
     * Hraban Luyat
     * Jackson Popkin
+    * Gustavo Castro
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -3,6 +3,7 @@ Upcoming
 
 Features:
 ---------
+* Add time option for prompt (Thanks: `Gustavo Castro`_)
 * Suggest objects from all schemas (not just those in search_path) (Thanks: `Joakim Koljonen`_)
 * Casing for column headers (Thanks: `Joakim Koljonen`_)
 * Allow configurable character to be used for multi-line query continuations. (Thanks: `Owen Stephens`_)

--- a/changelog.rst
+++ b/changelog.rst
@@ -688,3 +688,4 @@ Improvements:
 .. _`Dick Marinus`: https://github.com/meeuw
 .. _`Étienne Bersac`: https://github.com/bersace
 .. _`Thomas Roten`: https://github.com/tsroten
+.. _`Gustavo Castro`: https://github.com/gustavo-castro

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -11,7 +11,7 @@ import threading
 import shutil
 import functools
 import humanize
-import datetime
+import datetime as dt
 from time import time, sleep
 from codecs import open
 
@@ -153,7 +153,7 @@ class PGCli(object):
         self.decimal_format = c['data_formats']['decimal']
         self.float_format = c['data_formats']['float']
 
-        self.now = datetime.datetime.today()
+        self.now = dt.datetime.today()
 
         self.completion_refresher = CompletionRefresher()
 
@@ -494,7 +494,7 @@ class PGCli(object):
                 else:
                     query = self.execute_command(document.text, query)
 
-                self.now = datetime.datetime.today()
+                self.now = dt.datetime.today()
 
                 # Allow PGCompleter to learn user's preferred keywords, etc.
                 with self._completer_lock:
@@ -729,7 +729,7 @@ class PGCli(object):
                 Document(text=text, cursor_position=cursor_positition), None)
 
     def get_prompt(self, string):
-        string = string.replace('\\t', self.now.strftime('%d/%m/%y %H:%M:%S'))
+        string = string.replace('\\t', self.now.strftime('%x %X'))
         string = string.replace('\\u', self.pgexecute.user or '(none)')
         string = string.replace('\\h', self.pgexecute.host or '(none)')
         string = string.replace('\\d', self.pgexecute.dbname or '(none)')

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -11,6 +11,7 @@ import threading
 import shutil
 import functools
 import humanize
+import datetime
 from time import time, sleep
 from codecs import open
 
@@ -151,6 +152,8 @@ class PGCli(object):
         self.on_error = c['main']['on_error'].upper()
         self.decimal_format = c['data_formats']['decimal']
         self.float_format = c['data_formats']['float']
+
+        self.now = datetime.datetime.today()
 
         self.completion_refresher = CompletionRefresher()
 
@@ -491,6 +494,8 @@ class PGCli(object):
                 else:
                     query = self.execute_command(document.text, query)
 
+                self.now = datetime.datetime.today()
+
                 # Allow PGCompleter to learn user's preferred keywords, etc.
                 with self._completer_lock:
                     self.completer.extend_query_history(document.text)
@@ -724,6 +729,7 @@ class PGCli(object):
                 Document(text=text, cursor_position=cursor_positition), None)
 
     def get_prompt(self, string):
+        string = string.replace('\\t', self.now.strftime('%d/%m/%y %H:%M:%S'))
         string = string.replace('\\u', self.pgexecute.user or '(none)')
         string = string.replace('\\h', self.pgexecute.host or '(none)')
         string = string.replace('\\d', self.pgexecute.dbname or '(none)')


### PR DESCRIPTION
## Description
I added a date option for the prompt (as asked for in #580 ). To use it, you just have to add "\\t" to the Prompt Format option.



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
