### PR TITLE
Make it possible to use SSL with pgcli

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,6 @@
-Many thanks to the following contributors. 
+Many thanks to the following contributors.
 
-Project Lead: 
+Project Lead:
 -------------
     * Irina Truong
 
@@ -13,7 +13,7 @@ Core Devs:
     * Daniel Rocco
     * Karl-Aksel Puulmann
     * Dick Marinus
-    
+
 Contributors:
 -------------
     * Brett
@@ -64,6 +64,7 @@ Contributors:
     * Hraban Luyat
     * Jackson Popkin
     * Gustavo Castro
+    * Alexander Schmolck
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,7 @@ Features:
 * Completions after ORDER BY and DISTINCT now take account of table aliases. (Thanks: `Owen Stephens`_)
 * Narrow keyword candidates based on previous keyword. (Thanks: `Étienne Bersac`_)
 * Opening an external editor will edit the last-run query. (Thanks: `Thomas Roten`_)
+* Support query options in postgres URIs such as ?sslcert=foo.pem (Thanks: `Alexander Schmolck`_)
 
 Bug fixes:
 ----------
@@ -690,3 +691,4 @@ Improvements:
 .. _`Étienne Bersac`: https://github.com/bersace
 .. _`Thomas Roten`: https://github.com/tsroten
 .. _`Gustavo Castro`: https://github.com/gustavo-castro
+.. _`Alexander Schmolck`: https://github.com/aschmolck

--- a/pgcli/completion_refresher.py
+++ b/pgcli/completion_refresher.py
@@ -59,7 +59,8 @@ class CompletionRefresher(object):
             # Create a new pgexecute method to popoulate the completions.
             e = pgexecute
             executor = PGExecute(
-                e.dbname, e.user, e.password, e.host, e.port, e.dsn)
+                e.dbname, e.user, e.password, e.host, e.port, e.dsn,
+                **e.extra_args)
 
         # If callbacks is a single function then push it into a list.
         if callable(callbacks):

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -146,17 +146,18 @@ class PGExecute(object):
         FROM pg_catalog.pg_database d
         ORDER BY 1'''
 
-    def __init__(self, database, user, password, host, port, dsn):
+    def __init__(self, database, user, password, host, port, dsn, **kwargs):
         self.dbname = database
         self.user = user
         self.password = password
         self.host = host
         self.port = port
         self.dsn = dsn
+        self.extra_args = {k: unicode2utf8(v) for k, v in kwargs.items()}
         self.connect()
 
     def connect(self, database=None, user=None, password=None, host=None,
-            port=None, dsn=None):
+                port=None, dsn=None, **kwargs):
 
         db = (database or self.dbname)
         user = (user or self.user)
@@ -164,6 +165,7 @@ class PGExecute(object):
         host = (host or self.host)
         port = (port or self.port)
         dsn = (dsn or self.dsn)
+        kwargs = (kwargs or self.extra_args)
         pid = -1
         if dsn:
             if password:
@@ -172,11 +174,12 @@ class PGExecute(object):
             cursor = conn.cursor()
         else:
             conn = psycopg2.connect(
-                    database=unicode2utf8(db),
-                    user=unicode2utf8(user),
-                    password=unicode2utf8(password),
-                    host=unicode2utf8(host),
-                    port=unicode2utf8(port))
+                database=unicode2utf8(db),
+                user=unicode2utf8(user),
+                password=unicode2utf8(password),
+                host=unicode2utf8(host),
+                port=unicode2utf8(port),
+                **kwargs)
 
             cursor = conn.cursor()
 
@@ -653,4 +656,3 @@ class PGExecute(object):
             cur.execute(query)
             for row in cur:
                 yield row[0]
-

--- a/tests/test_completion_refresher.py
+++ b/tests/test_completion_refresher.py
@@ -79,6 +79,7 @@ def test_refresh_with_callbacks(refresher):
     callbacks = [Mock()]
     pgexecute_class = Mock()
     pgexecute = Mock()
+    pgexecute.extra_args = {}
     special = Mock()
 
     with patch('pgcli.completion_refresher.PGExecute', pgexecute_class):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -91,11 +91,36 @@ def test_quoted_db_uri(tmpdir):
     with mock.patch.object(PGCli, 'connect') as mock_connect:
         cli = PGCli(pgclirc_file=str(tmpdir.join("rcfile")))
         cli.connect_uri('postgres://bar%5E:%5Dfoo@baz.com/testdb%5B')
-    mock_connect.assert_called_with('testdb[', 'baz.com', 'bar^', None, ']foo')
+    mock_connect.assert_called_with(database='testdb[',
+                                    port=None,
+                                    host='baz.com',
+                                    user='bar^',
+                                    passwd=']foo')
+
+
+def test_ssl_db_uri(tmpdir):
+    with mock.patch.object(PGCli, 'connect') as mock_connect:
+        cli = PGCli(pgclirc_file=str(tmpdir.join("rcfile")))
+        cli.connect_uri(
+            'postgres://bar%5E:%5Dfoo@baz.com/testdb%5B?'
+            'sslmode=verify-full&sslcert=m%79.pem&sslkey=my-key.pem&sslrootcert=c%61.pem')
+    mock_connect.assert_called_with(database='testdb[',
+                                    host='baz.com',
+                                    port=None,
+                                    user='bar^',
+                                    passwd=']foo',
+                                    sslmode='verify-full',
+                                    sslcert='my.pem',
+                                    sslkey='my-key.pem',
+                                    sslrootcert='ca.pem')
 
 
 def test_port_db_uri(tmpdir):
     with mock.patch.object(PGCli, 'connect') as mock_connect:
         cli = PGCli(pgclirc_file=str(tmpdir.join("rcfile")))
         cli.connect_uri('postgres://bar:foo@baz.com:2543/testdb')
-    mock_connect.assert_called_with('testdb', 'baz.com', 'bar', '2543', 'foo')
+    mock_connect.assert_called_with(database='testdb',
+                                    host='baz.com',
+                                    user='bar',
+                                    passwd='foo',
+                                    port='2543')


### PR DESCRIPTION
## Description
This adds support for additional url query params which make stuff like

```
pgcli "postgres://user:pass@host.invalid/db?\
sslmode=verify-full&sslcert=my.pem&sslkey=my-key.pem&sslrootcert=ca.pem"
```

work. More generally it allows one to pass through various extra connection
options.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
