### PR TITLE
Update Homebrew install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ If you already know how to install python packages, then you can simply do:
 
     or
 
-    $ brew install pgcli  # Only on OS X
+    $ brew tap-pin dbcli/tap && brew install pgcli  # Only on macOS
 
 If you don't know how to install python packages, please check the 
 `detailed instructions`__.
@@ -92,21 +92,18 @@ My email: amjith.r@gmail.com, Twitter: `@amjithr <http://twitter.com/amjithr>`_
 Detailed Installation Instructions:
 -----------------------------------
 
-OS X:
-=====
+macOS:
+======
 
-Easiest way to install pgcli is using brew. Please be aware that this will
-install postgres via brew if it wasn't installed via brew.
+The easiest way to install pgcli is using Homebrew. Please be aware that this will
+install postgres if you don't have it installed.
 
 ::
 
+    $ brew tap-pin dbcli/tap
     $ brew install pgcli
 
 Done!
-
-If you have postgres installed via a different means (such as PostgresApp), you
-can ``brew install --build-from-source pgcli`` which will skip installing
-postgres via brew if postgres is available in the path.
 
 Alternatively, you can install ``pgcli`` as a python package using a package
 manager called called ``pip``. You will need postgres installed on your system

--- a/changelog.rst
+++ b/changelog.rst
@@ -3,6 +3,7 @@ Upcoming
 
 * Refresh completions after `COMMIT` or `ROLLBACK`. (Thanks: `Irina Truong`_)
 * Fixed DSN aliases not being read from custom pgclirc (issue #717). (Thanks: `Irina Truong`_).
+* Use dbcli's Homebrew tap for installing pgcli on macOS (issue #718) (Thanks: `Thomas Roten`_).
 
 1.6.0
 =====


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Updates the macOS installation instructions to use dbcli's Homebrew tap.

This address #718.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
