### PR TITLE
Search socket dir before falling back to psycopg2 guess

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -292,9 +292,6 @@ class PGCli(object):
         pgspecial_logger.addHandler(handler)
         pgspecial_logger.setLevel(log_level)
 
-    def connect_dsn(self, dsn):
-        self.connect(dsn=dsn)
-
     def connect_uri(self, uri):
         uri = urlparse(uri)
         database = uri.path[1:]  # ignore the leading fwd slash
@@ -854,9 +851,9 @@ def cli(database, username_opt, host, port, prompt_passwd, never_prompt,
     elif '://' in database:
         pgcli.connect_uri(database)
     elif "=" in database:
-        pgcli.connect_dsn(database)
+        pgcli.connect(dsn=database)
     elif os.environ.get('PGSERVICE', None):
-        pgcli.connect_dsn('service={0}'.format(os.environ['PGSERVICE']))
+        pgcli.connect(dsn='service={0}'.format(os.environ['PGSERVICE']))
     else:
         pgcli.connect(database, host, user, port)
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -316,9 +316,23 @@ class PGCli(object):
         # unquote str(each URI part (they may be percent encoded)
         self.connect(**arguments)
 
+    def guess_socketdir(self):
+        candidates = [
+            '/var/run/postgresql',
+            '/var/pgsql_socket',
+            '/usr/local/var/postgres',
+            '/tmp',
+        ]
+
+        for candidate in candidates:
+            if os.path.isdir(candidate):
+                return candidate
+
     def connect(self, database='', host='', user='', port='', passwd='',
                 dsn='', **kwargs):
         # Connect to the database.
+        if not host:
+            host = self.guess_socketdir() or ''
 
         if not user:
             user = getuser()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -124,3 +124,16 @@ def test_port_db_uri(tmpdir):
                                     user='bar',
                                     passwd='foo',
                                     port='2543')
+
+
+def test_search_socketdir():
+    cli = PGCli()
+    with mock.patch('pgcli.main.os.path.isdir', autospec=True) as isdir:
+        isdir.side_effect = iter([
+            False, False, True, AssertionError("not reached"),
+        ])
+
+        socketdir = cli.guess_socketdir()
+
+        assert isdir.called is True
+        assert '/usr/local/var/postgres' == socketdir


### PR DESCRIPTION
Closes: #37 

As suggested in the description of the issue, I just use the first existing socketdir found from a list of well known candidates. This should be enough.