### PR TITLE
Use RST style links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,12 +65,12 @@ The `pgcli` is written using prompt_toolkit_.
 
 * Primitive support for ``psql`` back-slash commands.
 * Pretty prints tabular data.
-  Note: `pgcli` uses [tabulate](https://github.com/dbcli/pgcli/blob/master/pgcli/packages/tabulate.py)
-  package to pretty-print tables. This library does smart formatting of numbers,
-  which can sometimes lead to unexpected output. See
-  [this issue](https://github.com/dbcli/pgcli/issues/617) for more details.
+  Note: `pgcli` uses the `tabulate`_ package to pretty-print tables. This library does smart formatting 
+  of numbers, which can sometimes lead to unexpected output. See `this issue`_ for more details.
 
 .. _prompt_toolkit: https://github.com/jonathanslenders/python-prompt-toolkit
+.. _tabulate: https://github.com/dbcli/pgcli/blob/master/pgcli/packages/tabulate.py
+.. _this issue: https://github.com/dbcli/pgcli/issues/617
 
 Config
 ------


### PR DESCRIPTION
Fix some incorrectly formatted links using markdown syntax.