### PR TITLE
Better * expansion for inserts

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -7,6 +7,7 @@ Upcoming
 * Only set `LESS` environment variable if it's unset. (Thanks: `Irina Truong`_)
 * Quote schema in `SET SCHEMA` statement (issue #469) (Thanks: `Irina Truong`_)
 * Use CLI Helpers for pretty printing query results (Thanks: `Thomas Roten`_).
+* Skip serial columns when expanding * for `INSERT INTO foo(*` (Thanks: `Joakim Koljonen`_).
 
 1.6.0
 =====

--- a/pgcli/packages/parseutils/meta.py
+++ b/pgcli/packages/parseutils/meta.py
@@ -1,6 +1,19 @@
 from collections import namedtuple
 
-ColumnMetadata = namedtuple('ColumnMetadata', ['name', 'datatype', 'foreignkeys'])
+_ColumnMetadata = namedtuple(
+    'ColumnMetadata',
+    ['name', 'datatype', 'foreignkeys', 'default', 'has_default', 'default_value']
+)
+
+
+def ColumnMetadata(
+        name, datatype, foreignkeys=None, default=None, has_default=False, default_value=None
+):
+    return _ColumnMetadata(
+        name, datatype, foreignkeys or [], default, has_default, default_value
+    )
+
+
 ForeignKey = namedtuple('ForeignKey', ['parentschema', 'parenttable',
     'parentcolumn', 'childschema', 'childtable', 'childcolumn'])
 TableMetadata = namedtuple('TableMetadata', 'name columns')

--- a/pgcli/packages/parseutils/meta.py
+++ b/pgcli/packages/parseutils/meta.py
@@ -2,15 +2,15 @@ from collections import namedtuple
 
 _ColumnMetadata = namedtuple(
     'ColumnMetadata',
-    ['name', 'datatype', 'foreignkeys', 'default', 'has_default', 'default_value']
+    ['name', 'datatype', 'foreignkeys', 'default', 'has_default']
 )
 
 
 def ColumnMetadata(
-        name, datatype, foreignkeys=None, default=None, has_default=False, default_value=None
+        name, datatype, foreignkeys=None, default=None, has_default=False
 ):
     return _ColumnMetadata(
-        name, datatype, foreignkeys or [], default, has_default, default_value
+        name, datatype, foreignkeys or [], default, has_default
     )
 
 

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -43,9 +43,9 @@ FromClauseItem.__new__.__defaults__ = (None, tuple(), tuple())
 
 Column = namedtuple(
     'Column',
-    ['table_refs', 'require_last_table', 'local_tables', 'qualifiable']
+    ['table_refs', 'require_last_table', 'local_tables', 'qualifiable', 'context']
 )
-Column.__new__.__defaults__ = (None, None, tuple(), False)
+Column.__new__.__defaults__ = (None, None, tuple(), False, None)
 
 Keyword = namedtuple('Keyword', ['last_token'])
 Keyword.__new__.__defaults__ = (None,)
@@ -377,7 +377,9 @@ def suggest_based_on_last_token(token, stmt):
                 return (Keyword(),)
         prev_prev_tok = prev_tok and p.token_prev(p.token_index(prev_tok))[1]
         if prev_prev_tok and prev_prev_tok.normalized == 'INTO':
-            return (Column(table_refs=stmt.get_tables('insert')),)
+            return (
+                Column(table_refs=stmt.get_tables('insert'), context='insert'),
+            )
         # We're probably in a function argument list
         return (Column(table_refs=extract_tables(stmt.full_text),
                        local_tables=stmt.local_tables, qualifiable=True),)

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -179,21 +179,21 @@ class PGCompleter(Completer):
         """extend column metadata.
 
         :param column_data: list of (schema_name, rel_name, column_name,
-        column_type, default_value) tuples
+        column_type, has_default, default) tuples
         :param kind: either 'tables' or 'views'
 
         :return:
 
         """
         metadata = self.dbmetadata[kind]
-        for schema, relname, colname, datatype, has_default, default_value in column_data:
+        for schema, relname, colname, datatype, has_default, default in column_data:
             (schema, relname, colname) = self.escaped_names(
                 [schema, relname, colname])
             column = ColumnMetadata(
                 name=colname,
                 datatype=datatype,
                 has_default=has_default,
-                default_value=default_value
+                default=default
             )
             metadata[schema][relname][colname] = column
             self.all_completions.add(colname)
@@ -454,7 +454,7 @@ class PGCompleter(Completer):
                     if not col.has_default:
                         return True
                     return not any(
-                        p.match(col.default_value)
+                        p.match(col.default)
                         for p in self.insert_col_skip_patterns
                     )
                 scoped_cols = {

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -180,6 +180,7 @@ class PGCompleter(Completer):
         :param column_data: list of (schema_name, rel_name, column_name,
         column_type, default_value) tuples
         :param kind: either 'tables' or 'views'
+
         :return:
         """
         metadata = self.dbmetadata[kind]

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -158,6 +158,7 @@ class PGCompleter(Completer):
         :param data: list of (schema_name, rel_name) tuples
         :param kind: either 'tables' or 'views'
         :return:
+
         """
 
         data = [self.escaped_names(d) for d in data]
@@ -174,7 +175,7 @@ class PGCompleter(Completer):
             self.all_completions.add(relname)
 
     def extend_columns(self, column_data, kind):
-        """ extend column metadata
+        """extend column metadata
 
         :param column_data: list of (schema_name, rel_name, column_name,
         column_type, default_value) tuples
@@ -183,7 +184,8 @@ class PGCompleter(Completer):
         """
         metadata = self.dbmetadata[kind]
         for schema, relname, colname, datatype, has_default, default_value in column_data:
-            (schema, relname, colname) = self.escaped_names([schema, relname, colname])
+            (schema, relname, colname) = self.escaped_names(
+                [schema, relname, colname])
             column = ColumnMetadata(
                 name=colname,
                 datatype=datatype,
@@ -435,7 +437,8 @@ class PGCompleter(Completer):
             # require_last_table is used for 'tb11 JOIN tbl2 USING (...' which should
             # suggest only columns that appear in the last table and one more
             ltbl = tables[-1].ref
-            other_tbl_cols = set(c.name for t, cs in scoped_cols.items() if t.ref != ltbl for c in cs)
+            other_tbl_cols = set(
+                c.name for t, cs in scoped_cols.items() if t.ref != ltbl for c in cs)
             scoped_cols = {
                 t: [col for col in cols if col.name in other_tbl_cols]
                 for t, cols in scoped_cols.items()
@@ -462,13 +465,21 @@ class PGCompleter(Completer):
                 # User typed x.*; replicate "x." for all columns except the
                 # first, which gets the original (as we only replace the "*"")
                 sep = ', ' + word_before_cursor[:-1]
-                collist = sep.join(self.case(c.completion) for c in flat_cols())
+                collist = sep.join(self.case(c.completion)
+                                   for c in flat_cols())
             else:
                 collist = ', '.join(qualify(c.name, t.ref)
-                    for t, cs in scoped_cols.items() for c in cs)
+                                    for t, cs in scoped_cols.items() for c in cs)
 
-            return [Match(completion=Completion(collist, -1,
-                display_meta='columns', display='*'), priority=(1,1,1))]
+            return [Match(
+                completion=Completion(
+                    collist,
+                    -1,
+                    display_meta='columns',
+                    display='*'
+                ),
+                priority=(1, 1, 1)
+            )]
 
         return self.find_matches(word_before_cursor, flat_cols(),
             meta='column')

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -157,6 +157,7 @@ class PGCompleter(Completer):
 
         :param data: list of (schema_name, rel_name) tuples
         :param kind: either 'tables' or 'views'
+
         :return:
 
         """

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -153,7 +153,7 @@ class PGCompleter(Completer):
         self.casing = dict((word.lower(), word) for word in words)
 
     def extend_relations(self, data, kind):
-        """ extend metadata for tables or views
+        """extend metadata for tables or views.
 
         :param data: list of (schema_name, rel_name) tuples
         :param kind: either 'tables' or 'views'
@@ -175,7 +175,7 @@ class PGCompleter(Completer):
             self.all_completions.add(relname)
 
     def extend_columns(self, column_data, kind):
-        """extend column metadata
+        """extend column metadata.
 
         :param column_data: list of (schema_name, rel_name, column_name,
         column_type, default_value) tuples

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -183,6 +183,7 @@ class PGCompleter(Completer):
         :param kind: either 'tables' or 'views'
 
         :return:
+
         """
         metadata = self.dbmetadata[kind]
         for schema, relname, colname, datatype, has_default, default_value in column_data:

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -417,7 +417,7 @@ class PGExecute(object):
                         att.attname column_name,
                         att.atttypid::regtype::text type_name,
                         att.atthasdef AS has_default,
-                        def.adsrc as default_value
+                        def.adsrc as default
                 FROM    pg_catalog.pg_attribute att
                         INNER JOIN pg_catalog.pg_class cls
                             ON att.attrelid = cls.oid
@@ -437,7 +437,7 @@ class PGExecute(object):
                         att.attname column_name,
                         typ.typname type_name,
                         NULL AS has_default,
-                        NULL AS default_value
+                        NULL AS default
                 FROM    pg_catalog.pg_attribute att
                         INNER JOIN pg_catalog.pg_class cls
                             ON att.attrelid = cls.oid

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -415,12 +415,17 @@ class PGExecute(object):
                 SELECT  nsp.nspname schema_name,
                         cls.relname table_name,
                         att.attname column_name,
-                        att.atttypid::regtype::text type_name
+                        att.atttypid::regtype::text type_name,
+                        att.atthasdef AS has_default,
+                        def.adsrc as default_value
                 FROM    pg_catalog.pg_attribute att
                         INNER JOIN pg_catalog.pg_class cls
                             ON att.attrelid = cls.oid
                         INNER JOIN pg_catalog.pg_namespace nsp
                             ON cls.relnamespace = nsp.oid
+                        LEFT OUTER JOIN pg_attrdef def
+                            ON def.adrelid = att.attrelid
+                            AND def.adnum = att.attnum
                 WHERE   cls.relkind = ANY(%s)
                         AND NOT att.attisdropped
                         AND att.attnum  > 0
@@ -430,7 +435,9 @@ class PGExecute(object):
                 SELECT  nsp.nspname schema_name,
                         cls.relname table_name,
                         att.attname column_name,
-                        typ.typname type_name
+                        typ.typname type_name,
+                        NULL AS has_default,
+                        NULL AS default_value
                 FROM    pg_catalog.pg_attribute att
                         INNER JOIN pg_catalog.pg_class cls
                             ON att.attrelid = cls.oid

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -182,13 +182,13 @@ class MetaData(object):
             for tbl, cols in tbls.items():
                 tables.append((sch, tbl))
                 # Let all columns be text columns
-                tbl_cols.extend([(sch, tbl, col, 'text') for col in cols])
+                tbl_cols.extend([(sch, tbl, col, 'text', False, None) for col in cols])
 
         for sch, tbls in metadata.get('views', {}).items():
             for tbl, cols in tbls.items():
                 views.append((sch, tbl))
                 # Let all columns be text columns
-                view_cols.extend([(sch, tbl, col, 'text') for col in cols])
+                view_cols.extend([(sch, tbl, col, 'text', False, None) for col in cols])
 
         functions = [
             FunctionMetadata(sch, *func_meta)

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -169,6 +169,12 @@ class MetaData(object):
 
         return completers
 
+
+    def _make_col(self, sch, tbl, col):
+        defaults = self.metadata.get('defaults', {}).get(sch, {})
+        return (sch, tbl, col, 'text', (tbl, col) in defaults, defaults.get((tbl, col)))
+
+
     def get_completer(self, settings=None, casing=None):
         metadata = self.metadata
         from pgcli.pgcompleter import PGCompleter
@@ -182,13 +188,13 @@ class MetaData(object):
             for tbl, cols in tbls.items():
                 tables.append((sch, tbl))
                 # Let all columns be text columns
-                tbl_cols.extend([(sch, tbl, col, 'text', False, None) for col in cols])
+                tbl_cols.extend([self._make_col(sch, tbl, col) for col in cols])
 
         for sch, tbls in metadata.get('views', {}).items():
             for tbl, cols in tbls.items():
                 views.append((sch, tbl))
                 # Let all columns be text columns
-                view_cols.extend([(sch, tbl, col, 'text', False, None) for col in cols])
+                view_cols.extend([self._make_col(sch, tbl, col) for col in cols])
 
         functions = [
             FunctionMetadata(sch, *func_meta)

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -169,7 +169,6 @@ class MetaData(object):
 
         return completers
 
-
     def _make_col(self, sch, tbl, col):
         defaults = self.metadata.get('defaults', {}).get(sch, {})
         return (sch, tbl, col, 'text', (tbl, col) in defaults, defaults.get((tbl, col)))

--- a/tests/metadata.py
+++ b/tests/metadata.py
@@ -188,13 +188,15 @@ class MetaData(object):
             for tbl, cols in tbls.items():
                 tables.append((sch, tbl))
                 # Let all columns be text columns
-                tbl_cols.extend([self._make_col(sch, tbl, col) for col in cols])
+                tbl_cols.extend([self._make_col(sch, tbl, col)
+                                 for col in cols])
 
         for sch, tbls in metadata.get('views', {}).items():
             for tbl, cols in tbls.items():
                 views.append((sch, tbl))
                 # Let all columns be text columns
-                view_cols.extend([self._make_col(sch, tbl, col) for col in cols])
+                view_cols.extend([self._make_col(sch, tbl, col)
+                                  for col in cols])
 
         functions = [
             FunctionMetadata(sch, *func_meta)

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -40,7 +40,7 @@ def test_schemata_table_views_and_columns_query(executor):
     run(executor, "create table b(z text)")
     run(executor, "create view d as select 1 as e")
     run(executor, "create schema schema1")
-    run(executor, "create table schema1.c (w text)")
+    run(executor, "create table schema1.c (w text DEFAULT 'meow')")
     run(executor, "create schema schema2")
 
     # schemata
@@ -55,15 +55,18 @@ def test_schemata_table_views_and_columns_query(executor):
     ('public', 'a'), ('public', 'b'), ('schema1', 'c')])
 
     assert set(executor.table_columns()) >= set([
-        ('public', 'a', 'x', 'text'), ('public', 'a', 'y', 'text'),
-        ('public', 'b', 'z', 'text'), ('schema1', 'c', 'w', 'text')])
+        ('public', 'a', 'x', 'text', False, None),
+        ('public', 'a', 'y', 'text', False, None),
+        ('public', 'b', 'z', 'text', False, None),
+        ('schema1', 'c', 'w', 'text', True, "'meow'::text"),
+    ])
 
     # views
     assert set(executor.views()) >= set([
         ('public', 'd')])
 
     assert set(executor.view_columns()) >= set([
-        ('public', 'd', 'e', 'integer')])
+        ('public', 'd', 'e', 'integer', False, None)])
 
 
 @dbtest

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -8,7 +8,7 @@ metadata = {
     'tables': {
         'public': {
             'users': ['id', 'email', 'first_name', 'last_name'],
-            'orders': ['id', 'ordered_date', 'status'],
+            'orders': ['id', 'ordered_date', 'status', 'datestamp'],
             'select': ['id', 'insert', 'ABC']
         },
         'custom': {
@@ -57,6 +57,13 @@ metadata = {
             ('blog', 'entries', 'entryid', 'blog', 'entrytags', 'entryid'),
             ('blog', 'tags', 'tagid', 'blog', 'entrytags', 'tagid'),
         ],
+    },
+    'defaults': {
+        'public': {
+            ('orders', 'id'): "nextval('orders_id_seq'::regclass)",
+            ('orders', 'datestamp'): "now()",
+            ('orders', 'status'): "'PENDING'::text",
+        }
     },
 }
 
@@ -133,6 +140,17 @@ def test_suggested_column_names_from_schema_qualifed_table(completer):
     assert result == set(testdata.columns_functions_and_keywords(
         'products', 'custom'
     ))
+
+
+@parametrize('text', [
+    'INSERT INTO orders(',
+    'INSERT INTO orders (',
+    'INSERT INTO public.orders(',
+    'INSERT INTO public.orders ('
+])
+@parametrize('completer', completers(filtr=True, casing=False))
+def test_suggested_columns_with_insert(completer, text):
+    assert result_set(completer, text) == set(testdata.columns('orders'))
 
 
 @parametrize('completer', completers(filtr=True, casing=False, qualify=no_qual))
@@ -335,7 +353,7 @@ def test_wildcard_column_expansion_with_insert(completer, text):
     position = text.index('*') + 1
     completions = get_result(completer, text, position)
 
-    expected = [wildcard_expansion('id, ordered_date, status')]
+    expected = [wildcard_expansion('ordered_date, status')]
     assert expected == completions
 
 

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -313,17 +313,32 @@ def test_into_suggests_tables_and_schemas():
 ])
 def test_insert_into_lparen_suggests_cols(text):
     suggestions = suggest_type(text, 'INSERT INTO abc (')
-    assert suggestions ==(Column(table_refs=((None, 'abc', None, False),)),)
+    assert suggestions == (
+        Column(
+            table_refs=((None, 'abc', None, False),),
+            context='insert'
+        ),
+    )
 
 
 def test_insert_into_lparen_partial_text_suggests_cols():
     suggestions = suggest_type('INSERT INTO abc (i', 'INSERT INTO abc (i')
-    assert suggestions ==(Column(table_refs=((None, 'abc', None, False),)),)
+    assert suggestions == (
+        Column(
+            table_refs=((None, 'abc', None, False),),
+            context='insert'
+        ),
+    )
 
 
 def test_insert_into_lparen_comma_suggests_cols():
     suggestions = suggest_type('INSERT INTO abc (id,', 'INSERT INTO abc (id,')
-    assert suggestions ==(Column(table_refs=((None, 'abc', None, False),)),)
+    assert suggestions == (
+        Column(
+            table_refs=((None, 'abc', None, False),),
+            context='insert'
+        ),
+    )
 
 
 def test_partially_typed_col_name_suggests_col_names():


### PR DESCRIPTION
## Description
When expanding * for `INSERT INTO tbl(*`, skip columns that have a default value of either some sequence (`nextval(...`) or of `now()`.


## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
