### PR TITLE
Signed tags also need a message. Mhm.

### DIFF
--- a/release.py
+++ b/release.py
@@ -60,7 +60,7 @@ def commit_for_release(version_file, ver):
 
 
 def create_git_tag(tag_name):
-    run_step('git', 'tag', '-s', tag_name)
+    run_step('git', 'tag', '-s', '-m', tag_name, tag_name)
 
 
 def create_source_tarball():


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Fixed the release script; `tag -s` command won't work (will get stuck expecting user input) if a message is not provided.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- ~[ ] I've added this contribution to the `changelog.md`~.
- ~[ ] I've added my name to the `AUTHORS` file (or it's already there)~.
