### PR TITLE
Change the casing default to 'auto'.

### DIFF
--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -38,7 +38,7 @@ generate_aliases = False
 log_file = default
 
 # keyword casing preference. Possible values "lower", "upper", "auto"
-keyword_casing = upper
+keyword_casing = auto
 
 # casing_file location.
 # In Unix/Linux: ~/.config/pgcli/casing


### PR DESCRIPTION
## Description
User `auto` as the default casing in config file.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
~~[ ] I've added this contribution to the `changelog.md`.~~
~~[ ] I've added my name to the `AUTHORS` file (or it's already there).~~
