### PR TITLE
Amjith/remove continuation char

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,7 @@ Features:
 ---------
 
 * Add fish-style auto-suggestion from history. (Thanks: `Amjith Ramanujam`_)
+* Remove the ``...`` in the continuation prompt and use empty space instead. (Thanks: `Amjith Ramanujam`_)
 
 Bug Fixes:
 ----------

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -121,7 +121,7 @@ prompt = '\u@\h:\d> '
 min_num_menu_lines = 4
 
 # Character used to left pad multi-line queries to match the prompt size.
-multiline_continuation_char = '.'
+multiline_continuation_char = ''
 
 # Custom colors for the completion menu, toolbar, etc.
 [colors]


### PR DESCRIPTION
## Description
Change the continuation char from `....` to empty string. This allows folks to copy and paste sql statements easily from the REPL.


## Checklist
- [x] I've added this contribution to the `changelog.md`.
~- [ ] I've added my name to the `AUTHORS` file (or it's already there).~
