### PR TITLE
Behave tests should also accept pgport.

### DIFF
--- a/tests/features/db_utils.py
+++ b/tests/features/db_utils.py
@@ -6,17 +6,17 @@ from psycopg2 import connect
 from psycopg2.extensions import AsIs
 
 
-def create_db(hostname='localhost', username=None, password=None,
-              dbname=None):
+def create_db(hostname='localhost', username=None, password=None, dbname=None, port=None):
     """
     Create test database.
     :param hostname: string
     :param username: string
     :param password: string
     :param dbname: string
+    :param port: int
     :return:
     """
-    cn = create_cn(hostname, password, username, 'postgres')
+    cn = create_cn(hostname, password, username, 'postgres', port)
 
     # ISOLATION_LEVEL_AUTOCOMMIT = 0
     # Needed for DB creation.
@@ -28,11 +28,11 @@ def create_db(hostname='localhost', username=None, password=None,
 
     cn.close()
 
-    cn = create_cn(hostname, password, username, dbname)
+    cn = create_cn(hostname, password, username, dbname, port)
     return cn
 
 
-def create_cn(hostname, password, username, dbname):
+def create_cn(hostname, password, username, dbname, port):
     """
     Open connection to database.
     :param hostname:
@@ -41,18 +41,15 @@ def create_cn(hostname, password, username, dbname):
     :param dbname: string
     :return: psycopg2.connection
     """
-    if password:
-        cn = connect(host=hostname, user=username, database=dbname,
-                     password=password)
-    else:
-        cn = connect(user=username, database=dbname)
+    cn = connect(host=hostname, user=username, database=dbname,
+                 password=password, port=port)
 
     print('Created connection: {0}.'.format(cn.dsn))
     return cn
 
 
 def drop_db(hostname='localhost', username=None, password=None,
-            dbname=None):
+            dbname=None, port=None):
     """
     Drop database.
     :param hostname: string
@@ -60,7 +57,7 @@ def drop_db(hostname='localhost', username=None, password=None,
     :param password: string
     :param dbname: string
     """
-    cn = create_cn(hostname, password, username, 'postgres')
+    cn = create_cn(hostname, password, username, 'postgres', port)
 
     # ISOLATION_LEVEL_AUTOCOMMIT = 0
     # Needed for DB drop.

--- a/tests/features/db_utils.py
+++ b/tests/features/db_utils.py
@@ -7,14 +7,15 @@ from psycopg2.extensions import AsIs
 
 
 def create_db(hostname='localhost', username=None, password=None, dbname=None, port=None):
-    """
-    Create test database.
+    """Create test database.
+
     :param hostname: string
     :param username: string
     :param password: string
     :param dbname: string
     :param port: int
     :return:
+
     """
     cn = create_cn(hostname, password, username, 'postgres', port)
 

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -46,12 +46,22 @@ def before_all(context):
             'pg_test_pass',
             os.getenv('PGPASSWORD', None)
         ),
+        'port': context.config.userdata.get(
+            'pg_test_port',
+            os.getenv('PGPORT', '5432')
+        ),
+        'cli_command': (
+            context.config.userdata.get('pg_cli_command', None) or
+            '{python} -c "{startup}"'.format(
+                python=sys.executable,
+                startup='; '.join([
+                    "import coverage",
+                    "coverage.process_startup()",
+                    "import pgcli.main",
+                    "pgcli.main.cli()"]))),
         'dbname': db_name_full,
         'dbname_tmp': db_name_full + '_tmp',
         'vi': vi,
-        'cli_command': context.config.userdata.get('pg_cli_command', None) or
-                       sys.executable +
-        ' -c "import coverage; coverage.process_startup(); import pgcli.main; pgcli.main.cli()"',
         'pager_boundary': '---boundary---',
     }
     os.environ['PAGER'] = "{0} {1} {2}".format(
@@ -65,24 +75,24 @@ def before_all(context):
         'PGUSER': os.environ.get('PGUSER', None),
         'PGHOST': os.environ.get('PGHOST', None),
         'PGPASSWORD': os.environ.get('PGPASSWORD', None),
+        'PGPORT': os.environ.get('PGPORT', None),
     }
 
     # Set new env vars.
     os.environ['PGDATABASE'] = context.conf['dbname']
     os.environ['PGUSER'] = context.conf['user']
     os.environ['PGHOST'] = context.conf['host']
+    os.environ['PGPORT'] = context.conf['port']
 
     if context.conf['pass']:
         os.environ['PGPASSWORD'] = context.conf['pass']
     else:
         if 'PGPASSWORD' in os.environ:
             del os.environ['PGPASSWORD']
-        if 'PGHOST' in os.environ:
-            del os.environ['PGHOST']
 
     context.cn = dbutils.create_db(context.conf['host'], context.conf['user'],
-                                   context.conf['pass'],
-                                   context.conf['dbname'])
+                                   context.conf['pass'], context.conf['dbname'],
+                                   context.conf['port'])
 
     context.fixture_data = fixutils.read_fixture_files()
 
@@ -93,7 +103,8 @@ def after_all(context):
     """
     dbutils.close_cn(context.cn)
     dbutils.drop_db(context.conf['host'], context.conf['user'],
-                    context.conf['pass'], context.conf['dbname'])
+                    context.conf['pass'], context.conf['dbname'],
+                    context.conf['port'])
 
     # Restore env vars.
     for k, v in context.pgenv.items():


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Fixes the problem with behave tests disregarding PGHOST and PGPORT. This is needed if using a dockerized postgres instance for testing.

Example command that did not work before:

`PGHOST=localhost PGUSER=postgres PGPORT=8432 behave`

(note the non-standard port because it's forwarded from the docker container).

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- ~[ ] I've added this contribution to the `changelog.md`~.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
