### PR TITLE
Use raw strings where needed to avoid backslash ambiguity

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -367,7 +367,7 @@ class PGCli(object):
         self.pgexecute = pgexecute
 
     def handle_editor_command(self, cli, document):
-        """
+        r"""
         Editor command is any query that is prefixed or suffixed
         by a '\e'. The reason for a while loop is because a user
         might edit a query multiple times.
@@ -929,7 +929,7 @@ def is_select(status):
 def quit_command(sql):
     return (sql.strip().lower() == 'exit'
             or sql.strip().lower() == 'quit'
-            or sql.strip() == '\q'
+            or sql.strip() == r'\q'
             or sql.strip() == ':q')
 
 

--- a/pgcli/packages/parseutils/utils.py
+++ b/pgcli/packages/parseutils/utils.py
@@ -12,12 +12,12 @@ cleanup_regex = {
         # This matches everything except spaces, parens, colon, comma, and period
         'most_punctuations': re.compile(r'([^\.():,\s]+)$'),
         # This matches everything except a space.
-        'all_punctuations': re.compile('([^\s]+)$'),
+        'all_punctuations': re.compile(r'([^\s]+)$'),
         }
 
 
 def last_word(text, include='alphanum_underscore'):
-    """
+    r"""
     Find the last word in a sentence.
 
     >>> last_word('abc')

--- a/pgcli/packages/parseutils/utils.py
+++ b/pgcli/packages/parseutils/utils.py
@@ -5,15 +5,15 @@ from sqlparse.sql import Identifier
 from sqlparse.tokens import Token, Error
 
 cleanup_regex = {
-        # This matches only alphanumerics and underscores.
-        'alphanum_underscore': re.compile(r'(\w+)$'),
-        # This matches everything except spaces, parens, colon, and comma
-        'many_punctuations': re.compile(r'([^():,\s]+)$'),
-        # This matches everything except spaces, parens, colon, comma, and period
-        'most_punctuations': re.compile(r'([^\.():,\s]+)$'),
-        # This matches everything except a space.
-        'all_punctuations': re.compile(r'([^\s]+)$'),
-        }
+    # This matches only alphanumerics and underscores.
+    'alphanum_underscore': re.compile(r'(\w+)$'),
+    # This matches everything except spaces, parens, colon, and comma
+    'many_punctuations': re.compile(r'([^():,\s]+)$'),
+    # This matches everything except spaces, parens, colon, comma, and period
+    'most_punctuations': re.compile(r'([^\.():,\s]+)$'),
+    # This matches everything except a space.
+    'all_punctuations': re.compile(r'([^\s]+)$'),
+}
 
 
 def last_word(text, include='alphanum_underscore'):

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -174,7 +174,7 @@ def _strip_named_query(txt):
     return txt
 
 
-function_body_pattern = re.compile('(\\$.*?\\$)([\s\S]*?)\\1', re.M)
+function_body_pattern = re.compile(r'(\$.*?\$)([\s\S]*?)\1', re.M)
 
 
 def _find_function_body(text):

--- a/pgcli/pgbuffer.py
+++ b/pgcli/pgbuffer.py
@@ -33,7 +33,7 @@ def _is_complete(sql):
 def _multiline_exception(text):
     text = text.strip()
     return (text.startswith('\\') or   # Special Command
-            text.endswith('\e') or     # Ended with \e which should launch the editor.
+            text.endswith(r'\e') or     # Ended with \e which should launch the editor.
             _is_complete(text) or      # A complete SQL command
             (text == 'exit') or        # Exit doesn't need semi-colon
             (text == 'quit') or        # Quit doesn't need semi-colon

--- a/pgcli/pgbuffer.py
+++ b/pgcli/pgbuffer.py
@@ -18,7 +18,6 @@ class PGBuffer(Buffer):
             else:
                 return not _multiline_exception(doc.text)
 
-
         super(self.__class__, self).__init__(*args, is_multiline=is_multiline,
                                              tempfile_suffix='.sql', **kwargs)
 
@@ -32,11 +31,12 @@ def _is_complete(sql):
 
 def _multiline_exception(text):
     text = text.strip()
-    return (text.startswith('\\') or   # Special Command
-            text.endswith(r'\e') or     # Ended with \e which should launch the editor.
-            _is_complete(text) or      # A complete SQL command
-            (text == 'exit') or        # Exit doesn't need semi-colon
-            (text == 'quit') or        # Quit doesn't need semi-colon
-            (text == ':q') or          # To all the vim fans out there
-            (text == '')               # Just a plain enter without any text
-            )
+    return (
+        text.startswith('\\') or  # Special Command
+        text.endswith(r'\e') or  # Ended with \e which should launch the editor
+        _is_complete(text) or  # A complete SQL command
+        (text == 'exit') or  # Exit doesn't need semi-colon
+        (text == 'quit') or  # Quit doesn't need semi-colon
+        (text == ':q') or  # To all the vim fans out there
+        (text == '')  # Just a plain enter without any text
+    )

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -114,7 +114,7 @@ class PGCompleter(Completer):
         self.reserved_words = set()
         for x in self.keywords:
             self.reserved_words.update(x.split())
-        self.name_pattern = re.compile("^[_a-z][_a-z0-9\$]*$")
+        self.name_pattern = re.compile(r"^[_a-z][_a-z0-9\$]*$")
 
         self.databases = []
         self.dbmetadata = {'tables': {}, 'views': {}, 'functions': {},

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -642,7 +642,7 @@ class PGExecute(object):
     def casing(self):
         """Yields the most common casing for names used in db functions"""
         with self.conn.cursor() as cur:
-            query = '''
+            query = r'''
           WITH Words AS (
                 SELECT regexp_split_to_table(prosrc, '\W+') AS Word, COUNT(1)
                 FROM pg_catalog.pg_proc P


### PR DESCRIPTION
## Description
This is rather not really an issue as it is, but this changes allow to avoid ambiguity in slashes interpretation in strings (W1401).

## Checklist
- [ ] I've added this contribution to the `changelog.md`.
- [ ] ~~I've added my name to the `AUTHORS` file (or it's already there).~~
