### PR TITLE
Use psycopg2 to get database details

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -10,7 +10,7 @@ Features:
 Bug Fixes:
 ----------
 
-There are no bugs :)
+* Fix the way we get host when using DSN (issue #765) (Thanks: `François Pietka`_)
 
 1.7.0
 =====

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -203,9 +203,11 @@ class PGExecute(object):
             # When we connect using a DSN, we don't really know what db,
             # user, etc. we connected to. Let's read it.
             # Note: moved this after setting autocommit because of #664.
-            db, user, host, port = self._select_one(
-                cursor,
-                'select current_database(), current_user, inet_server_addr(), inet_server_port()')
+            dsn_parameters = conn.get_dsn_parameters()
+            db = dsn_parameters['dbname']
+            user = dsn_parameters['user']
+            host = dsn_parameters['host']
+            port = dsn_parameters['port']
 
         self.dbname = db
         self.user = user


### PR DESCRIPTION
## Description
Use psycopg2 to get database details when connected.

Fix #765 

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
