### PR TITLE
Don't include args in function suggestions for backslash commands

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,7 @@ Bug Fixes:
 ----------
 
 * Fix the way we get host when using DSN (issue #765) (Thanks: `François Pietka`_)
+* Don't include arguments in function suggestions for backslash commands (Thanks: `Joakim Koljonen`_)
 
 1.7.0
 =====

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -279,8 +279,12 @@ def suggest_special(text):
     elif cmd[1:] in SPECIALS_SUGGESTION:
         rel_type = SPECIALS_SUGGESTION[cmd[1:]]
         if schema:
+            if rel_type == Function:
+                return (Function(schema=schema, usage='special'),)
             return (rel_type(schema=schema),)
         else:
+            if rel_type == Function:
+                return (Schema(), Function(schema=None, usage='special'),)
             return (Schema(), rel_type(schema=None))
 
     if cmd in ['\\n', '\\ns', '\\nd']:

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -653,7 +653,10 @@ class PGCompleter(Completer):
             alias = False
 
             def filt(f): return True
-        arg_mode = 'signature' if suggestion.usage == 'signature' else 'call'
+        arg_mode = {
+            'signature': 'signature',
+            'special': None,
+        }.get(suggestion.usage, 'call')
         # Function overloading means we way have multiple functions of the same
         # name at this point, so keep unique names only
         funcs = set(

--- a/tests/test_pgspecial.py
+++ b/tests/test_pgspecial.py
@@ -56,12 +56,12 @@ def test_d_dot_suggests_schema_qualified_tables_or_views():
 def test_df_suggests_schema_or_function():
     suggestions = suggest_type('\\df xxx', '\\df xxx')
     assert set(suggestions) == set([
-        Function(schema=None),
+        Function(schema=None, usage='special'),
         Schema(),
     ])
 
     suggestions = suggest_type('\\df myschema.xxx', '\\df myschema.xxx')
-    assert suggestions == (Function(schema='myschema'),)
+    assert suggestions == (Function(schema='myschema', usage='special'),)
 
 
 def test_leading_whitespace_ok():

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -35,13 +35,13 @@ testdata = MetaData(metadata)
 
 cased_users_col_names = ['ID', 'PARENTID', 'Email', 'First_Name', 'last_name']
 cased_users2_col_names = ['UserID', 'UserName']
-cased_funcs = [
+cased_func_names = [
     'Custom_Fun', '_custom_fun', 'Custom_Func1', 'custom_func2', 'set_returning_func'
 ]
 cased_tbls = ['Users', 'Orders']
 cased_views = ['User_Emails', 'Functions']
 casing = (
-    ['SELECT', 'PUBLIC'] + cased_funcs + cased_tbls + cased_views
+    ['SELECT', 'PUBLIC'] + cased_func_names + cased_tbls + cased_views
     + cased_users_col_names + cased_users2_col_names
 )
 # Lists for use in assertions
@@ -145,6 +145,12 @@ def test_user_function_name_completion_matches_anywhere(completer):
         function('_custom_fun()', -2),
         function('custom_func1()', -2),
         function('custom_func2()', -2)])
+
+
+@parametrize('completer', completers(casing=True))
+def test_list_functions_for_special(completer):
+    result = result_set(completer, r'\df ')
+    assert result == set([schema('PUBLIC')] + [function(f) for f in cased_func_names])
 
 
 @parametrize('completer', completers(casing=False, qualify=no_qual))

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -150,7 +150,9 @@ def test_user_function_name_completion_matches_anywhere(completer):
 @parametrize('completer', completers(casing=True))
 def test_list_functions_for_special(completer):
     result = result_set(completer, r'\df ')
-    assert result == set([schema('PUBLIC')] + [function(f) for f in cased_func_names])
+    assert result == set(
+        [schema('PUBLIC')] + [function(f) for f in cased_func_names]
+    )
 
 
 @parametrize('completer', completers(casing=False, qualify=no_qual))


### PR DESCRIPTION
## Description
E.g. after `\df`, we want to suggest only function names.
@amjith, you feel like merging this?


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
