### PR TITLE
Add COLUMN as possible keyword after DROP

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,7 @@ Bug Fixes:
 ----------
 
 * Fix the way we get host when using DSN (issue #765) (Thanks: `François Pietka`_)
+* Add missing keyword COLUMN after DROP (issue #769) (Thanks: `François Pietka`_)
 
 1.7.0
 =====

--- a/pgcli/packages/pgliterals/pgliterals.json
+++ b/pgcli/packages/pgliterals/pgliterals.json
@@ -110,6 +110,7 @@
             "AGGREGATE",
             "CAST",
             "COLLATION",
+            "COLUMN",
             "CONVERSION",
             "DATABASE",
             "DOMAIN",


### PR DESCRIPTION
## Description
Fix #769
Add missing keyword COLUMN after DROP.

## Checklist
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
