### PR TITLE
use cursor from psycopg in pgcli

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Internal changes:
 -----------------
 * Preliminary work for a future change in outputting results that uses less memory. (Thanks: `Dick Marinus`_)
 * Remove import workaround for OrderedDict, required for python < 2.7. (Thanks: `Andrew Speed`_)
+* Use less memory when formatting results for display (Thanks: `Dick Marinus`_).
 
 Bug Fixes:
 ----------


### PR DESCRIPTION
## Description
use cursor from psycopg in pgcli

I'm not sure if you should/can use hardcoded numbers to match the `type_code` of Cursor.description

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.