### PR TITLE
Fix TODO, optionally use POSTGRES_USER, POSTGRES_HOST POSTGRES_PASSWORD from environment

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -16,6 +16,7 @@ Bug Fixes:
 * Fix the way we get host when using DSN (issue #765) (Thanks: `François Pietka`_)
 * Add missing keyword COLUMN after DROP (issue #769) (Thanks: `François Pietka`_)
 * Don't include arguments in function suggestions for backslash commands (Thanks: `Joakim Koljonen`_)
+* Optionally use POSTGRES_USER, POSTGRES_HOST POSTGRES_PASSWORD from environment (Thanks: `Dick Marinus`_)
 
 1.7.0
 =====

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from utils import (POSTGRES_HOST, POSTGRES_USER, create_db, db_connection,
+from utils import (POSTGRES_HOST, POSTGRES_USER, POSTGRES_PASSWORD, create_db, db_connection,
                    drop_tables)
 import pgcli.pgexecute
 
@@ -23,7 +23,7 @@ def cursor(connection):
 @pytest.fixture
 def executor(connection):
     return pgcli.pgexecute.PGExecute(database='_test_db', user=POSTGRES_USER,
-            host=POSTGRES_HOST, password=None, port=None, dsn=None)
+                                     host=POSTGRES_HOST, password=POSTGRES_PASSWORD, port=None, dsn=None)
 
 
 @pytest.fixture

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,9 +3,11 @@ import psycopg2
 import psycopg2.extras
 from pgcli.main import format_output, OutputSettings
 from pgcli.pgexecute import register_json_typecasters
+from os import getenv
 
-# TODO: should this be somehow be divined from environment?
-POSTGRES_USER, POSTGRES_HOST = 'postgres', 'localhost'
+POSTGRES_USER = getenv('PGUSER', 'postgres')
+POSTGRES_HOST = getenv('PGHOST', 'localhost')
+POSTGRES_PASSWORD = getenv('PGPASSWORD', '')
 
 
 def db_connection(dbname=None):


### PR DESCRIPTION
## Description
Fix TODO, optionally use POSTGRES_USER, POSTGRES_HOST POSTGRES_PASSWORD from environment

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.