### PR TITLE
Drop wcwidth dependency

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -16,6 +16,7 @@ Internal changes:
 * Remove import workaround for OrderedDict, required for python < 2.7. (Thanks: `Andrew Speed`_)
 * Use less memory when formatting results for display (Thanks: `Dick Marinus`_).
 * Port auto_vertical feature test from mycli to pgcli. (Thanks: `Dick Marinus`_)
+* Drop wcwidth dependency (Thanks: `Dick Marinus`_)
 
 Bug Fixes:
 ----------

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ install_requirements = [
     'sqlparse >=0.2.2,<0.3.0',
     'configobj >= 5.0.6',
     'humanize >= 0.5.1',
-    'wcwidth >= 0.1.6',
     'cli_helpers >= 0.2.0, < 1.0.0',
 ]
 


### PR DESCRIPTION
## Description
Drop wcwidth dependency (this is only used in cli_helpers which is a dependency for pgcli)

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
