### PR TITLE
Remove shebang and git execute permission from pgcli/main.py.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,9 @@
 Upcoming
 ========
 
-TBD
+Internal changes:
+-----------------
+* Remove shebang and git execute permission from pgcli/main.py. (Thanks: `Dick Marinus`_)
 
 1.8.0
 =====

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import unicode_literals
 from __future__ import print_function
 


### PR DESCRIPTION
## Description
Remove shebang and git execute permission from pgcli/main.py.

pgcli/main.py can't be executed directly because of the package structure.
removal of the shebang is required for packaging in Fedora


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
