### PR TITLE
Coloured and customizable boolean output

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,7 @@
 Upcoming
 ========
 
-TODO
+* Colored and customizable booleans in output (Thanks: `Joakim Koljonen`_)
 
 1.8.1
 =====

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -83,10 +83,11 @@ MetaQuery.__new__.__defaults__ = ('', False, 0, False, False, False, False)
 
 OutputSettings = namedtuple(
     'OutputSettings',
-    'table_format dcmlfmt floatfmt missingval expanded max_width case_function'
+    'table_format dcmlfmt floatfmt missingval expanded max_width case_function, '
+    'bool_true, bool_false'
 )
 OutputSettings.__new__.__defaults__ = (
-    None, None, None, '<null>', False, None, lambda x: x
+    None, None, None, '<null>', False, None, lambda x: x, 'True', 'False'
 )
 
 
@@ -155,6 +156,8 @@ class PGCli(object):
         self.wider_completion_menu = c['main'].as_bool('wider_completion_menu')
         self.less_chatty = bool(less_chatty) or c['main'].as_bool('less_chatty')
         self.null_string = c['main'].get('null_string', '<null>')
+        self.false_string = c['main'].get('false_string', 'False')
+        self.true_string = c['main'].get('true_string', 'True')
         self.prompt_format = prompt if prompt is not None else c['main'].get('prompt', self.default_prompt)
         self.on_error = c['main']['on_error'].upper()
         self.decimal_format = c['data_formats']['decimal']
@@ -671,6 +674,8 @@ class PGCli(object):
                 dcmlfmt=self.decimal_format,
                 floatfmt=self.float_format,
                 missingval=self.null_string,
+                bool_false=self.false_string,
+                bool_true=self.true_string,
                 expanded=expanded,
                 max_width=max_width,
                 case_function=(
@@ -979,20 +984,22 @@ def format_output(title, cur, headers, status, settings):
     case_function = settings.case_function
     formatter = TabularOutputFormatter(format_name=table_format)
 
-    def format_array(val):
+    def format_scalar(val):
+        if isinstance(val, bool):
+            return settings.bool_true if val else settings.bool_false
         if val is None:
             return settings.missingval
-        if not isinstance(val, list):
-            return val
-        return '{' + ','.join(text_type(format_array(e)) for e in val) + '}'
+        return val
 
-    def format_arrays(data, headers, **_):
+    def format_maybe_array(val):
+        if not isinstance(val, list):
+            return format_scalar(val)
+        return '{' + ','.join(text_type(format_maybe_array(e)) for e in val) + '}'
+
+    def format_any(data, headers, **_):
         data = list(data)
         for row in data:
-            row[:] = [
-                format_array(val) if isinstance(val, list) else val
-                for val in row
-            ]
+            row[:] = [format_maybe_array(val) for val in row]
 
         return data, headers
 
@@ -1000,10 +1007,9 @@ def format_output(title, cur, headers, status, settings):
         'sep_title': 'RECORD {n}',
         'sep_character': '-',
         'sep_length': (1, 25),
-        'missing_value': settings.missingval,
         'integer_format': settings.dcmlfmt,
         'float_format': settings.floatfmt,
-        'preprocessors': (format_numbers, format_arrays),
+        'preprocessors': (format_numbers, format_any),
         'disable_numparse': True,
         'preserve_whitespace': True
     }

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -126,6 +126,11 @@ multiline_continuation_char = ''
 # The string used in place of a null value.
 null_string = '<null>'
 
+# Representation of boolean False
+false_string = [31mfalse[0m
+# Representation of boolean True
+true_string = [32mtrue[0m
+
 # Custom colors for the completion menu, toolbar, etc.
 [colors]
 Token.Menu.Completions.Completion.Current = 'bg:#ffffff #000000'


### PR DESCRIPTION
## Description
Similar to the configurable NULL output @avdd added last year, this adds two config settings, `false_string` and `true_string`, which control how bools are displayed. The defaults are a red "false" and a green "true", respectively.

![0029-09-24 15 32 45](https://user-images.githubusercontent.com/18589234/30783074-b29541ae-a13d-11e7-8080-6f76d89ec9fb.png)


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
