### PR TITLE
Fix for tests breaking after tee.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
   - "3.5"
   - "3.6"
 
-install: 
-  - pip install . docutils pytest mock codecov==1.5.1 behave pexpect==3.3
+install:
+  - pip install . docutils pytest mock codecov==1.5.1 behave pexpect==3.3 retrying>=1.3.3
   - pip install git+https://github.com/hayd/pep8radius.git
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
   - "3.6"
 
 install:
-  - pip install . docutils pytest mock codecov==1.5.1 behave pexpect==3.3 retrying>=1.3.3
-  - pip install git+https://github.com/hayd/pep8radius.git
+  - pip install .
+  - pip install -r requirements-dev.txt
 
 script:
   - set -e

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,10 @@
 Upcoming
 ========
 
-TODO
+Internal changes:
+-----------------
+
+* Fix errors in the ``tee`` test (#795 and #797). (Thanks: `Irina Truong`_)
 
 1.8.1
 =====

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,6 @@ tox>=1.9.2
 behave>=1.2.4
 pexpect==3.3
 coverage==4.3.4
-pep8radius
+pep8radius>=0.9.2
+retrying>=1.3.3
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,6 @@ pexpect==3.3
 coverage==4.3.4
 codecov>=1.5.1
 docutils>=0.13.1
-retrying>=1.3.3
 
 # we want the latest possible version of pep8radius
 git+https://github.com/hayd/pep8radius.git

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,9 @@ tox>=1.9.2
 behave>=1.2.4
 pexpect==3.3
 coverage==4.3.4
-pep8radius>=0.9.2
+codecov>=1.5.1
+docutils>=0.13.1
 retrying>=1.3.3
 
+# we want the latest possible version of pep8radius
+git+https://github.com/hayd/pep8radius.git

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -134,6 +134,7 @@ def after_scenario(context, _):
                 '{0}> '.format(dbname),
                 timeout=5
             )
+        context.cli.sendcontrol('u')
         context.cli.sendcontrol('d')
         context.cli.expect_exact(pexpect.EOF, timeout=5)
 

--- a/tests/features/iocommands.feature
+++ b/tests/features/iocommands.feature
@@ -12,6 +12,6 @@ Feature: I/O commands
       and we wait for prompt
       and we query "select 123456"
       and we wait for prompt
-      and we notee output
+      and we stop teeing output
       and we wait for prompt
       then we see 123456 in tee output

--- a/tests/features/steps/iocommands.py
+++ b/tests/features/steps/iocommands.py
@@ -5,7 +5,6 @@ import os.path
 import wrappers
 
 from behave import when, then
-from retrying import retry
 
 
 @when('we start external editor providing a file name')
@@ -76,13 +75,8 @@ def step_notee_output(context):
 
 @then(u'we see 123456 in tee output')
 def step_see_123456_in_ouput(context):
-
-    @retry(stop_max_delay=3000)  # stop trying after 3 seconds
-    def assert_tee_output():
-        with open(context.tee_file_name) as f:
-            assert '123456' in f.read()
-
-    assert_tee_output()
+    with open(context.tee_file_name) as f:
+        assert '123456' in f.read()
     if os.path.exists(context.tee_file_name):
         os.remove(context.tee_file_name)
     context.atprompt = True


### PR DESCRIPTION
## Description

This is an attempt to fix the `tee` test breaking: https://github.com/dbcli/pgcli/issues/795.

Also, this fixes the error in `notee` test which should not be `notee` (that's a mycli command) but `\o`: https://github.com/dbcli/pgcli/issues/797.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
