### PR TITLE
Do NOT escape database names.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,10 @@ Internal changes:
 * Use temporary dir as config location in tests
 * Fix errors in the ``tee`` test (#795 and #797). (Thanks: `Irina Truong`_)
 
+Bug Fixes:
+----------
+* Do NOT quote the database names in the completion menu (Thanks: `Amjith Ramanujam`_)
+
 1.8.1
 =====
 

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -138,7 +138,6 @@ class PGCompleter(Completer):
         return [self.escape_name(name) for name in names]
 
     def extend_database_names(self, databases):
-        databases = self.escaped_names(databases)
         self.databases.extend(databases)
 
     def extend_keywords(self, additional_keywords):


### PR DESCRIPTION
## Description
Don't quote the database names regardless of the mixed case.


## Checklist
- [X] I've added this contribution to the `changelog.md`.

