### PR TITLE
Use ctrl + c instead of ctrl + u to clean up command line after tests.

### DIFF
--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -144,7 +144,7 @@ def after_scenario(context, _):
                 '{0}> '.format(dbname),
                 timeout=5
             )
-        context.cli.sendcontrol('u')
+        context.cli.sendcontrol('c')
         context.cli.sendcontrol('d')
         context.cli.expect_exact(pexpect.EOF, timeout=5)
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

This uses Ctrl + C to clean up after test scenario (thanks @meeuw).

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- ~[ ] I've added this contribution to the `changelog.md`~.
- ~[ ] I've added my name to the `AUTHORS` file (or it's already there)~.
