### PR TITLE
Bump cli_helpers dependency to 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requirements = [
     'sqlparse >=0.2.2,<0.3.0',
     'configobj >= 5.0.6',
     'humanize >= 0.5.1',
-    'cli_helpers >= 0.2.3, < 1.0.0',
+    'cli_helpers >= 1.0.0, < 2.0.0',
 ]
 
 


### PR DESCRIPTION
This is in order to deal with https://github.com/dbcli/cli_helpers/issues/25, which breaks builds  under some environments

## Description
https://github.com/dbcli/cli_helpers/issues/25 breaks installation due to the usage of a nonexistent `tasks` module. It works in some cases, but on some virtualenvs it does not. cli_helpers released 1.0.0 in which their setup was updated

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
