### PR TITLE
The unix_socket_directories setting may not be present.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -9,6 +9,7 @@ Internal changes:
 Bug Fixes:
 ----------
 * Do NOT quote the database names in the completion menu (Thanks: `Amjith Ramanujam`_)
+* Fix error in ``unix_socket_directories`` (#805). (Thanks: `Irina Truong`_)
 
 1.8.1
 =====

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -506,7 +506,8 @@ class PGExecute(object):
             _logger.debug('Socket directory Query. sql: %r',
                           self.socket_directory_query)
             cur.execute(self.socket_directory_query)
-            return cur.fetchone()[0]
+            result = cur.fetchone()
+            return result[0] if result else ''
 
     def foreignkeys(self):
         """Yields ForeignKey named tuples"""


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

An attempt to fix https://github.com/dbcli/pgcli/issues/805. The `unix_socket_directories` setting may not be present in `pg_settings` view. I'm not sure if this will fully fix the problem, as I was not able to completely reproduce the conditions. But the safeguard is needed when retrieving the setting anyway.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
