### PR TITLE
Increase timeout for quitting pgcli

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,7 @@ Internal changes:
 -----------------
 * Use temporary dir as config location in tests
 * Fix errors in the ``tee`` test (#795 and #797). (Thanks: `Irina Truong`_)
+* Increase timeout for quitting pgcli. (Thanks: `Dick Marinus`_)
 
 Bug Fixes:
 ----------

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -146,7 +146,7 @@ def after_scenario(context, _):
             )
         context.cli.sendcontrol('c')
         context.cli.sendcontrol('d')
-        context.cli.expect_exact(pexpect.EOF, timeout=5)
+        context.cli.expect_exact(pexpect.EOF, timeout=10)
 
 # TODO: uncomment to debug a failure
 # def after_step(context, step):


### PR DESCRIPTION
## Description
Increase timeout for quitting pgcli

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
