### PR TITLE
Use other prompt (prompt_dsn) when connecting using --dsn parameter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -68,6 +68,7 @@ Contributors:
     * Donnell Muse
     * Andrew Speed
     * Dmitry B
+    * Marcin Sztolcman
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,5 +1,6 @@
 Upcoming
 ========
+* Use other prompt (prompt_dsn) when connecting using --dsn parameter
 
 Internal changes:
 -----------------

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -111,7 +111,7 @@ row_limit = 1000
 less_chatty = False
 
 # Postgres prompt
-# \t - current date and time
+# \t - Current date and time
 # \u - Username
 # \h - Hostname of the server
 # \d - Database name
@@ -122,8 +122,8 @@ less_chatty = False
 prompt = '\u@\h:\d> '
 
 # Postgres prompt when using --dsn option
-# \t - current date and time
-# \dsn - seelcted DSN alias
+# \t - Current date and time
+# \dsn - Selected DSN alias
 # \p - Database port
 # \i - Postgres PID
 # \# - "@" sign if logged in as superuser, '>' in other case

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -111,11 +111,24 @@ row_limit = 1000
 less_chatty = False
 
 # Postgres prompt
+# \t - current date and time
 # \u - Username
 # \h - Hostname of the server
 # \d - Database name
+# \p - Database port
+# \i - Postgres PID
+# \# - "@" sign if logged in as superuser, '>' in other case
 # \n - Newline
 prompt = '\u@\h:\d> '
+
+# Postgres prompt when using --dsn option
+# \t - current date and time
+# \dsn - seelcted DSN alias
+# \p - Database port
+# \i - Postgres PID
+# \# - "@" sign if logged in as superuser, '>' in other case
+# \n - Newline
+prompt_dsn = '\dsn> '
 
 # Number of lines to reserve for the suggestion menu
 min_num_menu_lines = 4


### PR DESCRIPTION
## Description
I use `--dsn`/`-D` and dsn_aliases very often, and I am connecting often to databases called identically but on different hosts (for example on testing env, on stage env etc). There is no host specified in this case (dsn_alias isn't parsed by pgcli itself, but passed to PGExecute, so it's unusable). But I found dsn alias very useful in prompt. I decided to use different prompts for both cases (connecting with --dsn option and without).

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
