### PR TITLE
Include username to password prompt. #823

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -365,7 +365,7 @@ class PGCli(object):
         # If we successfully parsed a password from a URI, there's no need to
         # prompt for it, even with the -W flag
         if self.force_passwd_prompt and not passwd:
-            passwd = click.prompt('Password', hide_input=True,
+            passwd = click.prompt('Password for %s' % user, hide_input=True,
                                   show_default=False, type=str)
 
         # Prompt for a password after 1st attempt to connect without a password
@@ -383,8 +383,9 @@ class PGCli(object):
             except (OperationalError, InterfaceError) as e:
                 if ('no password supplied' in utf8tounicode(e.args[0]) and
                         auto_passwd_prompt):
-                    passwd = click.prompt('Password', hide_input=True,
-                                          show_default=False, type=str)
+                    passwd = click.prompt('Password for %s' % user,
+                                          hide_input=True, show_default=False,
+                                          type=str)
                     pgexecute = PGExecute(database, user, passwd, host, port,
                                           dsn, **kwargs)
                 else:


### PR DESCRIPTION
## Description
As described in ticket #823, this is useful for matching prompt for
different usernames and auto populating passwords. iTerm2 has password
manager that is capable of doing this, but other terminal managers might
be able to do it as well.

`behave`, `pytest` and `pep8radius` are passing locally. I have not tried building `deb` or `rpm` packages, but these changes should not affect that in any way.

I am opened for any feedback you might have. 

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
