### PR TITLE
correct typo in pgclirc comment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -71,6 +71,7 @@ Contributors:
     * Isank
     * Marcin Sztolcman
     * Bojan Delić
+    * Chris Vaughn
 
 
 Creator:

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -157,7 +157,7 @@ Token.Toolbar.Transaction.Failed = 'bg:#222222 #ff005f bold'
 # Named queries are queries you can execute by name.
 [named queries]
 
-# DNS to call by -D option
+# DSN to call by -D option
 [alias_dsn]
 # example_dsn = postgresql://[user[:password]@][netloc][:port][/dbname]
 


### PR DESCRIPTION
## Description
This PR is to a correct a small typo `DNS` -> `DSN` in a comment in the pgclirc. 


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).