### PR TITLE
Removed support for Python 3.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,11 @@ Features:
 
 * Add support for `\T` command to change format output. (Thanks: `Frederic Aoustin`_).
 
+Internal changes:
+-----------------
+
+* Removed support for Python 3.3. (Thanks: `Irina Truong`_)
+
 1.8.2
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36
+envlist = py27, py34, py35, py36
 [testenv]
 deps = pytest
     mock


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Removed support for Python 3.3 (end-of-life).

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `changelog.md`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
