### PR TITLE
Fix link to pgspecial project

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -66,7 +66,7 @@ Adding PostgreSQL Special (Meta) Commands
 -----------------------------------------
 
 If you want to work on adding new meta-commands (such as `\dp`, `\ds`, `dy`),
-you need to contribute to `pgspecial <https://github.com/pgcli/pgspecial/>`_
+you need to contribute to `pgspecial <https://github.com/dbcli/pgspecial/>`_
 project.
 
 Building RPM and DEB packages


### PR DESCRIPTION
## Description

The link to the `pgspecial` points to a 404 page (wrong organization).

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).

No need to add my name for such a small fix in my opinion. Looking forward to contributing more.
