### PR TITLE
Fix tests

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,6 +73,7 @@ Contributors:
     * Bojan Delić
     * Chris Vaughn
     * Frederic Aoustin
+    * Pierre Giraud
 
 
 Creator:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,6 @@ pexpect==3.3
 coverage==4.3.4
 codecov>=1.5.1
 docutils>=0.13.1
-
+autopep8==1.3.3
 # we want the latest possible version of pep8radius
 git+https://github.com/hayd/pep8radius.git

--- a/tests/features/steps/iocommands.py
+++ b/tests/features/steps/iocommands.py
@@ -18,7 +18,7 @@ def step_edit_file(context):
         os.path.basename(context.editor_file_name)))
     wrappers.expect_exact(
         context, 'Entering Ex mode.  Type "visual" to go to Normal mode.', timeout=2)
-    wrappers.expect_exact(context, '\r\n:', timeout=2)
+    wrappers.expect_exact(context, ':', timeout=2)
 
 
 @when('we type sql in the editor')


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Currently the build tests are broken. This PR fixes them.
There was a wrong assertion on the context when using `ex` external editor.

Also there seem to a bug in the last version of autopep8. Pinning the version to 1.3.3 seem to work.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
