### PR TITLE
#858: make \h in prompt return the first part of the hostname; add \H to return whole hostname

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,6 +74,7 @@ Contributors:
     * Chris Vaughn
     * Frederic Aoustin
     * Pierre Giraud
+    * Andrew Kuchling
 
 
 Creator:

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,14 @@
 Upcoming:
 =========
 
+Features:
+---------
+
+* Change ``\h`` format string in prompt to only return the first part of the hostname,
+  up to the first '.' character.  Add ``\H`` that returns the entire hostname (#858).
+  (Thanks: `Andrew Kuchling`_)
+
+
 Internal changes:
 -----------------
 
@@ -735,6 +743,7 @@ Improvements:
 * Integration tests with Postgres!! (Thanks: https://github.com/macobo)
 
 .. _`Amjith Ramanujam`: https://github.com/amjith
+.. _`Andrew Kuchling`: https://github.com/akuchling
 .. _`Darik Gamble`: https://github.com/darikg
 .. _`Daniel Rocco`: https://github.com/drocco007
 .. _`Jay Zeng`:  https://github.com/jayzeng

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -811,7 +811,10 @@ class PGCli(object):
         string = string.replace('\\dsn_alias', self.dsn_alias or '')
         string = string.replace('\\t', self.now.strftime('%x %X'))
         string = string.replace('\\u', self.pgexecute.user or '(none)')
-        string = string.replace('\\h', self.pgexecute.host or '(none)')
+        host = self.pgexecute.host or '(none)'
+        string = string.replace('\\H', host)
+        short_host, _, _ = host.partition('.')
+        string = string.replace('\\h', short_host)
         string = string.replace('\\d', self.pgexecute.dbname or '(none)')
         string = string.replace('\\p', str(self.pgexecute.port) or '(none)')
         string = string.replace('\\i', str(self.pgexecute.pid) or '(none)')

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -113,7 +113,8 @@ less_chatty = False
 # Postgres prompt
 # \t - Current date and time
 # \u - Username
-# \h - Hostname of the server
+# \h - Short hostname of the server (up to first '.')
+# \H - Hostname of the server
 # \d - Database name
 # \p - Database port
 # \i - Postgres PID


### PR DESCRIPTION
## Description
This patch makes \h in the prompt only return the hostname up to the first period (i.e. db.orgname.org will be displayed as just 'db'), and adds \H which will return the whole hostname.  If there's no '.' in the hostname, \h and \H will produce identical results.

The `get_prompt()` method doesn't seem to have a test suite that exercises all of the format characters; should it?  I did verify that `get_prompt()` is at least invoked by the behave tests.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
