### PR TITLE
Add application name

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,7 @@ Internal changes:
 -----------------
 
 * Mark tests requiring a running database server as dbtest (Thanks: `Dick Marinus`_)
+* Add ``application_name`` to help identify pgcli connection to database (issue #868) (Thanks: `François Pietka`_)
 
 1.9.1:
 ======

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -260,7 +260,7 @@ class PGCli(object):
             db, user, host, port = infos
             try:
                 self.pgexecute.connect(database=db, user=user, host=host,
-                                       port=port)
+                                       port=port, application_name='pgcli')
             except OperationalError as e:
                 click.secho(str(e), err=True, fg='red')
                 click.echo("Previous connection kept")
@@ -403,7 +403,7 @@ class PGCli(object):
         try:
             try:
                 pgexecute = PGExecute(database, user, passwd, host, port, dsn,
-                                      **kwargs)
+                                      application_name='pgcli', **kwargs)
             except (OperationalError, InterfaceError) as e:
                 if ('no password supplied' in utf8tounicode(e.args[0]) and
                         auto_passwd_prompt):
@@ -411,7 +411,8 @@ class PGCli(object):
                                           hide_input=True, show_default=False,
                                           type=str)
                     pgexecute = PGExecute(database, user, passwd, host, port,
-                                          dsn, **kwargs)
+                                          dsn, application_name='pgcli',
+                                          **kwargs)
                 else:
                     raise e
 

--- a/tests/features/basic_commands.feature
+++ b/tests/features/basic_commands.feature
@@ -10,6 +10,10 @@ Feature: run the cli,
      When we send source command
       then we see help output
 
+  Scenario: check our application_name
+     When we run query to check application_name
+      then we see found
+
   Scenario: run the cli and exit
      When we send "ctrl + d"
       then dbcli exits

--- a/tests/features/steps/basic_commands.py
+++ b/tests/features/steps/basic_commands.py
@@ -10,6 +10,7 @@ import tempfile
 
 from behave import when
 import wrappers
+from textwrap import dedent
 
 
 @when('we run dbcli')
@@ -47,3 +48,26 @@ def step_send_source_command(context):
         context.cli.sendline('\i {0}'.format(f.name))
         wrappers.expect_exact(
             context, context.conf['pager_boundary'] + '\r\n', timeout=5)
+
+
+@when(u'we run query to check application_name')
+def step_check_application_name(context):
+    context.cli.sendline(
+        "SELECT 'found' FROM pg_stat_activity WHERE application_name = 'pgcli' HAVING COUNT(*) > 0;"
+    )
+
+
+@then(u'we see found')
+def step_see_found(context):
+    wrappers.expect_exact(
+        context,
+        context.conf['pager_boundary'] + '\r' + dedent('''
+            +------------+\r
+            | ?column?   |\r
+            |------------|\r
+            | found      |\r
+            +------------+\r
+            SELECT 1\r
+        ''') + context.conf['pager_boundary'],
+        timeout=5
+    )


### PR DESCRIPTION
## Description
Adding `application_name` to help identify `pgcli` connections to postgres.

Fix #868

## Checklist
- [x] I've added this contribution to the `changelog.md`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
