### PR TITLE
Encourage users to use SSL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Usage
 
     or
 
-    $ pgcli postgresql://[user[:password]@][netloc][:port][/dbname]
+    $ pgcli postgresql://[user[:password]@][netloc][:port][/dbname][?extra=value[&other=other-value]]
 
 Examples:
 
@@ -56,7 +56,7 @@ Examples:
 
     $ pgcli local_database
 
-    $ pgcli postgres://amjith:pa$$w0rd@example.com:5432/app_db
+    $ pgcli postgres://amjith:pa$$w0rd@example.com:5432/app_db?sslmode=verify-ca&sslrootcert=/myrootcert
 
 Features
 --------

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -359,7 +359,7 @@ class PGCli(object):
                          user=fixup_possible_percent_encoding(uri.username),
                          port=fixup_possible_percent_encoding(uri.port),
                          passwd=fixup_possible_percent_encoding(uri.password))
-        # Deal with extra params e.g. ?sslmode=verify-ca&ssl-cert=/mycert
+        # Deal with extra params e.g. ?sslmode=verify-ca&sslrootcert=/myrootcert
         if uri.query:
             arguments = dict(
                 {k: v for k, (v,) in parse_qs(uri.query).items()},


### PR DESCRIPTION
## Description
There's already a code comment illustrating how you could use SSL with PostgreSQL. This PR:
  - Alters that comment to replace `ssl-cert` ([has an extra dash not found in PostgreSQL 1.0 settings](https://www.postgresql.org/docs/10/static/libpq-connect.html#LIBPQ-PARAMKEYWORDS)) with `sslrootcert` (which could be used to [connect securely to Redshift](https://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html))
  - Documents how to use extra options (adds SSL to the example)

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
