### PR TITLE
Switch PR template changelog ext from .md to .rst

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,5 @@
 
 ## Checklist
 <!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
-- [ ] I've added this contribution to the `changelog.md`.
+- [ ] I've added this contribution to the `changelog.rst`.
 - [ ] I've added my name to the `AUTHORS` file (or it's already there).


### PR DESCRIPTION
## Description
Changelog is `changelog.rst`, not `changelog.md`, this PR edits the GitHub PR template to use the correct filename.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.md`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
