### PR TITLE
Disable pager when using \watch

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,10 @@ Internal changes:
 * Mark tests requiring a running database server as dbtest (Thanks: `Dick Marinus`_)
 * Add ``application_name`` to help identify pgcli connection to database (issue #868) (Thanks: `François Pietka`_)
 
+Bug Fixes:
+----------
+* Disable pager when using \watch (#837). (Thanks: `Jason Ribeiro`_)
+
 1.9.1:
 ======
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -564,15 +564,15 @@ class PGCli(object):
                 # Initialize default metaquery in case execution fails
                 query = MetaQuery(query=document.text, successful=False)
 
-                watch_command, timing = special.get_watch_command(document.text)
-                if watch_command:
-                    while watch_command:
+                self.watch_command, timing = special.get_watch_command(document.text)
+                if self.watch_command:
+                    while self.watch_command:
                         try:
-                            query = self.execute_command(watch_command, query)
+                            query = self.execute_command(self.watch_command, query)
                             click.echo('Waiting for {0} seconds before repeating'.format(timing))
                             sleep(timing)
                         except KeyboardInterrupt:
-                            watch_command = None
+                            self.watch_command = None
                 else:
                     query = self.execute_command(document.text, query)
 
@@ -840,7 +840,7 @@ class PGCli(object):
         return self.query_history[-1][0] if self.query_history else None
 
     def echo_via_pager(self, text, color=None):
-        if self.pgspecial.pager_config == PAGER_OFF:
+        if self.pgspecial.pager_config == PAGER_OFF or self.watch_command:
             click.echo(text, color=color)
         else:
             click.echo_via_pager(text, color)


### PR DESCRIPTION
## Description
Disable pager when using watch (#850).


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
