### PR TITLE
Keep callables

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,6 +75,7 @@ Contributors:
     * Frederic Aoustin
     * Pierre Giraud
     * Andrew Kuchling
+    * Catherine Devlin
 
 
 Creator:

--- a/changelog.rst
+++ b/changelog.rst
@@ -745,6 +745,7 @@ Bug Fixes:
 ----------
 * Fix the broken behavior of \d+. (Thanks: https://github.com/macobo)
 * Fix a crash during auto-completion. (Thanks: https://github.com/Erethon)
+* Avoid losing pre_run_callables on error in editing.  (Thanks: https://github.com/catherinedevlin)
 
 Improvements:
 -------------

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -441,19 +441,20 @@ class PGCli(object):
         # It's internal api of prompt_toolkit that may change. This was added to fix #668.
         # We may find a better way to do it in the future.
         saved_callables = cli.application.pre_run_callables
-        while special.editor_command(document.text):
-            filename = special.get_filename(document.text)
-            query = (special.get_editor_query(document.text) or
-                     self.get_last_query())
-            sql, message = special.open_external_editor(filename, sql=query)
-            if message:
-                # Something went wrong. Raise an exception and bail.
-                raise RuntimeError(message)
-            cli.current_buffer.document = Document(sql, cursor_position=len(sql))
-            cli.application.pre_run_callables = []
-            document = cli.run()
-            continue
-        cli.application.pre_run_callables = saved_callables
+        try:
+            while special.editor_command(document.text):
+                filename = special.get_filename(document.text)
+                query = (special.get_editor_query(document.text) or
+                        self.get_last_query())
+                sql, message = special.open_external_editor(filename, sql=query)
+                if message:
+                    # Something went wrong. Raise an exception and bail.
+                    raise RuntimeError(message)
+                cli.current_buffer.document = Document(sql, cursor_position=len(sql))
+                cli.application.pre_run_callables = []
+                document = cli.run()
+        finally:
+            cli.application.pre_run_callables = saved_callables
         return document
 
     def execute_command(self, text, query):


### PR DESCRIPTION
## Description

Enclosed the code to run the text editor in a try/finally, and moved the restoration of saved pre-run callables to the "finally", so that throwing an error won't result in losing the saved callables

## Checklist

- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
