### PR TITLE
make keyring optional

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -18,6 +18,7 @@ Bug Fixes:
 ----------
 * Disable pager when using \watch (#837). (Thanks: `Jason Ribeiro`_)
 * Don't offer to reconnect when we can't change a param in realtime (#807). (Thanks: `Amjith Ramanujam`_)
+* Make keyring optional. (Thanks: `Dick Marinus`_)
 
 1.9.1:
 ======

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -433,7 +433,10 @@ class PGCli(object):
                 pgexecute = PGExecute(database, user, passwd, host, port, dsn,
                                       application_name='pgcli', **kwargs)
                 if passwd:
-                    keyring.set_password('pgcli', key, passwd)
+                    try:
+                        keyring.set_password('pgcli', key, passwd)
+                    except keyring.errors.InitError:
+                        pass
             except (OperationalError, InterfaceError) as e:
                 if ('no password supplied' in utf8tounicode(e.args[0]) and
                         auto_passwd_prompt):


### PR DESCRIPTION
## Description
The keyring code seems to fail if you have gnome-keyring installed but aren't running the gnome-keyring-daemon.

Stack trace:
```
2018-05-26 11:22:50,043 (28714/MainThread) pgcli.main ERROR - traceback: 'Traceback (most recent call last):
  File "pgcli/main.py", line 436, in connect
    keyring.set_password(\'pgcli\', key, passwd)
  File "/lib/python3.6/site-packages/keyring/core.py", line 47, in set_password
    _keyring_backend.set_password(service_name, username, password)
  File "/lib/python3.6/site-packages/keyring/backends/SecretService.py", line 80, in set_password
    collection = self.get_preferred_collection()
  File "/lib/python3.6/site-packages/keyring/backends/SecretService.py", line 61, in get_preferred_collection
    raise InitError("Failed to unlock the collection!")
keyring.errors.InitError: Failed to unlock the collection!
```

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
