### PR TITLE
pgcli bash completion script

### DIFF
--- a/pgcli-completion.bash
+++ b/pgcli-completion.bash
@@ -1,0 +1,61 @@
+_pg_databases()
+{
+    # -w was introduced in 8.4, https://launchpad.net/bugs/164772
+    # "Access privileges" in output may contain linefeeds, hence the NF > 1
+    COMPREPLY=( $( compgen -W "$( psql -AtqwlF $'\t' 2>/dev/null | \
+	    awk 'NF > 1 { print $1 }' )" -- "$cur" ) )
+}
+                                                                                                               
+_pg_users()
+{
+    # -w was introduced in 8.4, https://launchpad.net/bugs/164772
+    COMPREPLY=( $( compgen -W "$( psql -Atqwc 'select usename from pg_user' \
+        template1 2>/dev/null )" -- "$cur" ) )
+    [[ ${#COMPREPLY[@]} -eq 0 ]] && COMPREPLY=( $( compgen -u -- "$cur" ) )
+}
+  
+_pgcli()
+{
+    local cur prev words cword
+    _init_completion -s || return
+	
+    case $prev in
+        -h|--host)
+            _known_hosts_real "$cur"
+            return 0
+            ;;
+        -U|--user)
+            _pg_users
+            return 0
+            ;;
+        -d|--dbname)
+            _pg_databases
+            return 0
+            ;;
+        --help|-v|--version|-p|--port|-R|--row-limit)
+            # all other arguments are noop with these
+            return 0
+            ;;
+    esac
+
+    case "$cur" in
+	    --*)
+        	# return list of available options
+       		COMPREPLY=( $( compgen -W '--host --port --user --password --no-password
+ 			              --single-connection --version --dbname --pgclirc --dsn
+  			            --row-limit --help' -- "$cur" ) )
+        [[ $COMPREPLY == *= ]] && compopt -o nospace
+		    return 0
+		    ;;
+	    -)
+		    # only complete long options
+		    compopt -o nospace
+		    COMPREPLY=( -- )
+		    return 0
+		    ;;
+	    *)
+            # return list of available databases
+        	_pg_databases 
+    esac
+} && 
+complete -F _pgcli pgcli


### PR DESCRIPTION
# Pgcli bash completion
Bash completion script for pgcli.
## Description
It allows to <tab> complete database names, users and hosts, plus showing the other available options when calling pgcli from the terminal prompt.
In order to work it steals a couple of functions from psql (postgres CLI client installed by default). 
It is intended to be packaged with the debian package and to be copied on /usr/share/bash-completion/completions/pgcli (filename changes for consistency) upon installation of the package.
Please make the debian package mantainer (Lennart Weller lhw@ring0.de as per `apt-cache show`) aware of it and include it in the relevant section of the installation scripts/package.
I hope it is useful.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
