### PR TITLE
Hotfix/not enough values to unpack

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -79,6 +79,7 @@ Contributors:
     * Catherine Devlin
     * Jason Ribeiro
     * Rishi Ramraj
+    * Matthieu Guilbert
 
 
 Creator:

--- a/changelog.rst
+++ b/changelog.rst
@@ -21,6 +21,7 @@ Bug Fixes:
 * Don't offer to reconnect when we can't change a param in realtime (#807). (Thanks: `Amjith Ramanujam`_)
 * Make keyring optional. (Thanks: `Dick Marinus`_)
 * Fix ipython magic connection (#891). (Thanks: `Irina Truong`_)
+* Fix not enough values to unpack
 
 1.9.1:
 ======

--- a/changelog.rst
+++ b/changelog.rst
@@ -21,7 +21,7 @@ Bug Fixes:
 * Don't offer to reconnect when we can't change a param in realtime (#807). (Thanks: `Amjith Ramanujam`_)
 * Make keyring optional. (Thanks: `Dick Marinus`_)
 * Fix ipython magic connection (#891). (Thanks: `Irina Truong`_)
-* Fix not enough values to unpack
+* Fix not enough values to unpack. (Thanks: `Matthieu Guilbert`_)
 
 1.9.1:
 ======
@@ -832,3 +832,4 @@ Improvements:
 .. _`Frederic Aoustin`: https://github.com/fraoustin
 .. _`Jason Ribeiro`: https://github.com/jrib
 .. _`Rishi Ramraj`: https://github.com/RishiRamraj
+.. _`Matthieu Guilbert`: https://github.com/gma2th

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -292,7 +292,7 @@ class PGExecute(object):
         # Remove spaces and EOL
         statement = statement.strip()
         if not statement:  # Empty string
-            yield (None, None, None, None, statement, False)
+            yield (None, None, None, None, statement, False, False)
 
         # Split the sql into separate queries and run each one.
         for sql in sqlparse.split(statement):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Error `not enough values to unpack` is raise when statement is an empty string.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
