### PR TITLE
Add --user option like psql has as well.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -80,6 +80,7 @@ Contributors:
     * Jason Ribeiro
     * Rishi Ramraj
     * Matthieu Guilbert
+    * Alexandr Korsak
 
 
 Creator:

--- a/changelog.rst
+++ b/changelog.rst
@@ -14,7 +14,7 @@ Internal changes:
 * Add an is_special command flag to MetaQuery (Thanks: `Rishi Ramraj`_)
 * Ported Destructive Warning from mycli.
 * Refactor Destructive Warning behave tests (Thanks: `Dick Marinus`_)
-* Add `--user` option, duplicate of `--username`, the same cli option like `psql`
+* Add `--user` option, duplicate of `--username`, the same cli option like `psql` (Thanks: `Alexandr Korsak`_)
 
 Bug Fixes:
 ----------
@@ -835,3 +835,4 @@ Improvements:
 .. _`Jason Ribeiro`: https://github.com/jrib
 .. _`Rishi Ramraj`: https://github.com/RishiRamraj
 .. _`Matthieu Guilbert`: https://github.com/gma2th
+.. _`Alexandr Korsak`: https://github.com/oivoodoo

--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Internal changes:
 * Add an is_special command flag to MetaQuery (Thanks: `Rishi Ramraj`_)
 * Ported Destructive Warning from mycli.
 * Refactor Destructive Warning behave tests (Thanks: `Dick Marinus`_)
+* Add `--user` option, duplicate of `--username`, the same cli option like `psql`
 
 Bug Fixes:
 ----------

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -891,7 +891,7 @@ class PGCli(object):
 @click.option('-U', '--username', 'username_opt', envvar='PGUSER',
         help='Username to connect to the postgres database.')
 @click.option('--user', 'username_opt', envvar='PGUSER',
-        help='Username to connect to the postgres database.')
+              help='Username to connect to the postgres database.')
 @click.option('-W', '--password', 'prompt_passwd', is_flag=True, default=False,
         help='Force password prompt.')
 @click.option('-w', '--no-password', 'never_prompt', is_flag=True,

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -890,6 +890,8 @@ class PGCli(object):
         'postgres instance is listening.', envvar='PGPORT', type=click.INT)
 @click.option('-U', '--username', 'username_opt', envvar='PGUSER',
         help='Username to connect to the postgres database.')
+@click.option('--user', 'username_opt', envvar='PGUSER',
+        help='Username to connect to the postgres database.')
 @click.option('-W', '--password', 'prompt_passwd', is_flag=True, default=False,
         help='Force password prompt.')
 @click.option('-w', '--no-password', 'never_prompt', is_flag=True,


### PR DESCRIPTION
Hi

Today I've just tried to use `pgcli`. Expected to replace `psql` by `pgcli` command in terminal and connect to PG. I had `--user` option there and pgcli asked me to use `--username`. Probably it would be easy for transitions to use the same option name as well for user.

This change will leave `--username` as it is, and add `--user` as optional argument for compatibility.

- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).