### PR TITLE
Avoid reconnect prompt after error if connection is still valid

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -81,6 +81,7 @@ Contributors:
     * Rishi Ramraj
     * Matthieu Guilbert
     * Alexandr Korsak
+    * Saif Hakim
 
 
 Creator:

--- a/changelog.rst
+++ b/changelog.rst
@@ -20,7 +20,7 @@ Internal changes:
 Bug Fixes:
 ----------
 * Disable pager when using \watch (#837). (Thanks: `Jason Ribeiro`_)
-* Don't offer to reconnect when we can't change a param in realtime (#807). (Thanks: `Amjith Ramanujam`_)
+* Don't offer to reconnect when we can't change a param in realtime (#807). (Thanks: `Amjith Ramanujam`_ and `Saif Hakim`_)
 * Make keyring optional. (Thanks: `Dick Marinus`_)
 * Fix ipython magic connection (#891). (Thanks: `Irina Truong`_)
 * Fix not enough values to unpack. (Thanks: `Matthieu Guilbert`_)

--- a/changelog.rst
+++ b/changelog.rst
@@ -837,3 +837,4 @@ Improvements:
 .. _`Rishi Ramraj`: https://github.com/RishiRamraj
 .. _`Matthieu Guilbert`: https://github.com/gma2th
 .. _`Alexandr Korsak`: https://github.com/oivoodoo
+.. _`Saif Hakim`: https://github.com/saifelse

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -353,22 +353,17 @@ class PGExecute(object):
 
     def _must_raise(self, e):
         """Return true if e is an error that should not be caught in ``run``.
-
-        ``OperationalError``s are raised for errors that are not under the
-        control of the programmer. Usually that means unexpected disconnects,
-        which we shouldn't catch; we handle uncaught errors by prompting the
-        user to reconnect. We *do* want to catch OperationalErrors caused by a
-        lock being unavailable, as reconnecting won't solve that problem.
+        
+        An uncaught error will prompt the user to reconnect; as long as we
+        detect that the connection is stil open, we catch the error, as
+        reconnecting won't solve that problem.
 
         :param e: DatabaseError. An exception raised while executing a query.
 
         :return: Bool. True if ``run`` must raise this exception.
 
         """
-        return (isinstance(e, psycopg2.OperationalError) and
-                (not e.pgcode or
-                 psycopg2.errorcodes.lookup(e.pgcode) not in
-                 ('LOCK_NOT_AVAILABLE', 'CANT_CHANGE_RUNTIME_PARAM')))
+        return self.conn.closed != 0
 
     def execute_normal_sql(self, split_sql):
         """Returns tuple (title, rows, headers, status)"""

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -353,7 +353,7 @@ class PGExecute(object):
 
     def _must_raise(self, e):
         """Return true if e is an error that should not be caught in ``run``.
-        
+
         An uncaught error will prompt the user to reconnect; as long as we
         detect that the connection is stil open, we catch the error, as
         reconnecting won't solve that problem.


### PR DESCRIPTION
## Description
Instead of whitelisting all errors that do not require reconnecting, we simply
only reconnect if we detect a disconnect has occurred.

psql notably behaves in a similar way: https://git.io/fbxuc#L1461

Fixes #807

## Testing
1. In one shell:
    ```
    CREATE TABLE hello ( id integer, PRIMARY KEY(id));
    BEGIN;
    LOCK TABLE hello IN ACCESS EXCLUSIVE MODE;
    ```

2. In another shell:
    ```
    BEGIN;
    LOCK TABLE hello IN ACCESS EXCLUSIVE MODE;
    ```
3. Hitting Ctrl-C, results in: `^Ccanceling statement due to user request`
4. Hitting a lock timeout:
    ```
    ROLLBACK;
    BEGIN;
    SET lock_timeout = 3;
    LOCK TABLE hello IN ACCESS EXCLUSIVE MODE;
    ```
    similarly results in `canceling statement due to lock timeout`

5. Attempting to perform another statement behaves as expected:
    ```
    postgres@localhost:mytestdb> SELECT count(*) FROM hello;
    current transaction is aborted, commands ignored until end of transaction block
   ```
6. Running `SELECT count(*) FROM hello;` after stopping the database
    correctly prompts `Connection reset. Reconnect (Y/n):`

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
