### PR TITLE
Fixes #346: Tab characters are rendered with spaces instead of "^I"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -82,6 +82,7 @@ Contributors:
     * Matthieu Guilbert
     * Alexandr Korsak
     * Saif Hakim
+	* Artur Balabanov
 
 
 Creator:

--- a/changelog.rst
+++ b/changelog.rst
@@ -25,6 +25,7 @@ Bug Fixes:
 * Fix ipython magic connection (#891). (Thanks: `Irina Truong`_)
 * Fix not enough values to unpack. (Thanks: `Matthieu Guilbert`_)
 * Fix unbound local error when destructive_warning is false. (Thanks: `Matthieu Guilbert`_)
+* Render tab characters as 4 spaces instead of `^I`. (Thanks: `Artur Balabanov`_)
 
 1.9.1:
 ======
@@ -838,3 +839,4 @@ Improvements:
 .. _`Matthieu Guilbert`: https://github.com/gma2th
 .. _`Alexandr Korsak`: https://github.com/oivoodoo
 .. _`Saif Hakim`: https://github.com/saifelse
+.. _`Artur Balabanov`: https://github.com/arturbalabanov

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -35,7 +35,8 @@ from prompt_toolkit.document import Document
 from prompt_toolkit.filters import Always, HasFocus, IsDone
 from prompt_toolkit.layout.lexers import PygmentsLexer
 from prompt_toolkit.layout.processors import (ConditionalProcessor,
-                                        HighlightMatchingBracketProcessor)
+                                        HighlightMatchingBracketProcessor,
+                                        TabsProcessor)
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from pygments.lexers.sql import PostgresLexer
@@ -682,10 +683,12 @@ class PGCli(object):
             display_completions_in_columns=self.wider_completion_menu,
             multiline=True,
             extra_input_processors=[
-               # Highlight matching brackets while editing.
-               ConditionalProcessor(
-                   processor=HighlightMatchingBracketProcessor(chars='[](){}'),
-                   filter=HasFocus(DEFAULT_BUFFER) & ~IsDone()),
+                # Highlight matching brackets while editing.
+                ConditionalProcessor(
+                    processor=HighlightMatchingBracketProcessor(chars='[](){}'),
+                    filter=HasFocus(DEFAULT_BUFFER) & ~IsDone()),
+                # Render \t as 4 spaces instead of "^I"
+                TabsProcessor(get_char1=lambda _: ' ', get_char2=lambda _: ' '),
             ])
 
         with self._completer_lock:


### PR DESCRIPTION
## Description
Up to until now tab characters were rendered with the ugly `^I`. This is especially annoying for projects where the coding style is to use tabs instead of spaces and an external editor is being used or a query is copy-pasted into `pgcli`.

## Solution
The solution is quite simple -- `prompt_toolkit` already provides an input processor just for that, so I simply added it to `extra_input_processors` with some sane defaults.

## Further work
The `TabsProcessor` class can accept several arguments to give more control over the tab rendering. I opted out for a simple 4-space rendering as this will probably be desired behaviour in most use cases but, of course, we can extend the configuration to include some of them (most notably `tabstop` which describes the tab length). I thought it would be an overkill but if someone thinks this may be necessary, I can, of course, add it.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
