### PR TITLE
Fix bug that made `keyring` usage not optional when run headlessly

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -82,7 +82,8 @@ Contributors:
     * Matthieu Guilbert
     * Alexandr Korsak
     * Saif Hakim
-	* Artur Balabanov
+    * Artur Balabanov
+    * Kenny Do
 
 
 Creator:

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -442,7 +442,7 @@ class PGCli(object):
                 if passwd:
                     try:
                         keyring.set_password('pgcli', key, passwd)
-                    except keyring.errors.InitError:
+                    except (keyring.errors.InitError, RuntimeError):
                         pass
             except (OperationalError, InterfaceError) as e:
                 if ('no password supplied' in utf8tounicode(e.args[0]) and


### PR DESCRIPTION
## Description
We run `pgcli` on a headless server, shared by many users.

With the release of 1.10.0 and its new dependency on `keyring`, we noticed that when we tried to connect to our database with username specified via `-U` and password specified via the `PGPASSWORD` environment variable, we would just get this error and then exit:
```
No recommended backend was available. Install the keyrings.alt package if you want to use the non-recommended backends. See README.rst for details.
```
We would really prefer not to have to set up `keyring` per use on headless systems per https://keyring.readthedocs.io/en/latest/?badge=latest#using-keyring-on-headless-linux-systems, since that'd require pulling in way more dependencies.

After we installed `keyring.alt` as the string specified, we were then prompted for an encryption password so that `keyring` could store the password onto the disk. This feature is not desired. And it doesn't look like there's any way to make keyring *not* do this, or to force it to use a different backend.

Based on the changelog entry about making keyring optional, it sounds like it's the case that `pgcli` should not have a hard dependency on using `keyring`'s features. This error about `keyring` not being able to find a backend is a `RuntimeError`, not a `keyring.errors.InitError`, so I added it to the try-catch to be ignored.

I've verified that this works by running
```
PGPASSWORD=... pgcli -h ...amazonaws.com -p 5439 -U kedo -d dbname
```
on my headless system with this branch installed and verifying I get the pgcli prompt instead of the process just ending.

## Checklist
- [ ] I've added this contribution to the `changelog.rst`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
