### PR TITLE
Fixes "object has no attribute watch_command"

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,10 @@
 Upcoming
 ========
 
-TODO
+Bug fixes:
+
+* Fix for missing keyring. (Thanks: `Kenny Do`_)
+* Fix for "-l" Flag Throws Error (#909). (Thanks: `Irina Truong`_)
 
 1.10.0
 ======
@@ -845,3 +848,4 @@ Improvements:
 .. _`Alexandr Korsak`: https://github.com/oivoodoo
 .. _`Saif Hakim`: https://github.com/saifelse
 .. _`Artur Balabanov`: https://github.com/arturbalabanov
+.. _`Kenny Do`: https://github.com/kennydo

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -136,6 +136,7 @@ class PGCli(object):
         self.never_passwd_prompt = never_passwd_prompt
         self.pgexecute = pgexecute
         self.dsn_alias = None
+        self.watch_command = None
 
         # Load config.
         c = self.config = get_config(pgclirc_file)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Fix for this error:

`AttributeError: 'PGCli' object has no attribute 'watch_command'"`

see https://github.com/dbcli/pgcli/issues/909

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
