### PR TITLE
Update setuptools before install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ python:
   - "3.5"
   - "3.6"
 
+before_install:
+  - which python
+  - which pip
+  - pip install -U pip
+
 install:
   - pip install .
   - pip install -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 before_install:
   - which python
   - which pip
-  - pip install -U pip
+  - pip install -U setuptools
 
 install:
   - pip install .


### PR DESCRIPTION
Trying to figure out `AttributeError: _DistInfoDistribution__dep_map` in python 3.4 in travis.

Seems to be fixed by updating either pip or setuptools.