### PR TITLE
Revert abs imports in tests.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
-from __future__ import print_function, absolute_import
+from __future__ import print_function
 
 import os
 import pytest
-from tests.utils import (POSTGRES_HOST, POSTGRES_USER, POSTGRES_PASSWORD, create_db, db_connection,
-                         drop_tables)
+from utils import (POSTGRES_HOST, POSTGRES_USER, POSTGRES_PASSWORD, create_db, db_connection,
+                   drop_tables)
 import pgcli.pgexecute
 
 

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, print_function, absolute_import
+from __future__ import unicode_literals, print_function
 
 import copy
 import os
 import sys
-import tests.features.db_utils as dbutils
-import tests.features.fixture_utils as fixutils
+import db_utils as dbutils
+import fixture_utils as fixutils
 import pexpect
 import tempfile
 import shutil
 
 
-from tests.features.steps import wrappers
+from steps import wrappers
 
 
 def before_all(context):
@@ -102,7 +102,7 @@ def before_all(context):
                                    context.conf['pass'], context.conf['dbname'],
                                    context.conf['port'])
 
-    context.fixture_data = fixutils.read_fixture_files(fixture_dir)
+    context.fixture_data = fixutils.read_fixture_files()
 
     # use temporary directory as config home
     context.env_config_home = tempfile.mkdtemp(prefix='pgcli_home_')

--- a/tests/features/fixture_utils.py
+++ b/tests/features/fixture_utils.py
@@ -19,9 +19,7 @@ def read_fixture_lines(filename):
 
 
 def read_fixture_files():
-    """
-    Read all files inside fixture_data directory.
-    """
+    """Read all files inside fixture_data directory."""
     current_dir = os.path.dirname(__file__)
     fixture_dir = os.path.join(current_dir, 'fixture_data/')
     print('reading fixture data: {}'.format(fixture_dir))

--- a/tests/features/fixture_utils.py
+++ b/tests/features/fixture_utils.py
@@ -18,10 +18,13 @@ def read_fixture_lines(filename):
     return lines
 
 
-def read_fixture_files(fixture_dir):
+def read_fixture_files():
     """
     Read all files inside fixture_data directory.
     """
+    current_dir = os.path.dirname(__file__)
+    fixture_dir = os.path.join(current_dir, 'fixture_data/')
+    print('reading fixture data: {}'.format(fixture_dir))
     fixture_dict = {}
     for filename in os.listdir(fixture_dir):
         if filename not in ['.', '..']:

--- a/tests/features/steps/auto_vertical.py
+++ b/tests/features/steps/auto_vertical.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8
-from __future__ import unicode_literals, print_function, absolute_import
+from __future__ import unicode_literals, print_function
 
 from textwrap import dedent
 from behave import then, when
-from tests.features.steps import wrappers
+import wrappers
 
 
 @when('we run dbcli with {arg}')

--- a/tests/features/steps/basic_commands.py
+++ b/tests/features/steps/basic_commands.py
@@ -4,13 +4,13 @@ Steps for behavioral style tests are defined in this module.
 Each step is defined by the string decorating it.
 This string is used to call the step in "*.feature" file.
 """
-from __future__ import unicode_literals, print_function, absolute_import
+from __future__ import unicode_literals, print_function
 
 import tempfile
 
 from behave import when, then
 from textwrap import dedent
-from tests.features.steps import wrappers
+import wrappers
 
 
 @when('we run dbcli')

--- a/tests/features/steps/crud_database.py
+++ b/tests/features/steps/crud_database.py
@@ -4,12 +4,12 @@ Steps for behavioral style tests are defined in this module.
 Each step is defined by the string decorating it.
 This string is used to call the step in "*.feature" file.
 """
-from __future__ import unicode_literals, print_function, absolute_import
+from __future__ import unicode_literals, print_function
 
 import pexpect
 
 from behave import when, then
-from tests.features.steps import wrappers
+import wrappers
 
 
 @when('we create database')

--- a/tests/features/steps/crud_table.py
+++ b/tests/features/steps/crud_table.py
@@ -4,11 +4,11 @@ Steps for behavioral style tests are defined in this module.
 Each step is defined by the string decorating it.
 This string is used to call the step in "*.feature" file.
 """
-from __future__ import unicode_literals, print_function, absolute_import
+from __future__ import unicode_literals, print_function
 
 from behave import when, then
 from textwrap import dedent
-from tests.features.steps import wrappers
+import wrappers
 
 
 @when('we create table')

--- a/tests/features/steps/expanded.py
+++ b/tests/features/steps/expanded.py
@@ -5,11 +5,11 @@ Each step is defined by the string decorating it. This string is used
 to call the step in "*.feature" file.
 
 """
-from __future__ import unicode_literals, print_function, absolute_import
+from __future__ import unicode_literals, print_function
 
 from behave import when, then
 from textwrap import dedent
-from tests.features.steps import wrappers
+import wrappers
 
 
 @when('we prepare the test data')

--- a/tests/features/steps/iocommands.py
+++ b/tests/features/steps/iocommands.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8
-from __future__ import unicode_literals, print_function, absolute_import
+from __future__ import unicode_literals, print_function
 import os
 import os.path
 
 from behave import when, then
-from tests.features.steps import wrappers
+import wrappers
 
 
 @when('we start external editor providing a file name')

--- a/tests/features/steps/named_queries.py
+++ b/tests/features/steps/named_queries.py
@@ -4,10 +4,10 @@ Steps for behavioral style tests are defined in this module.
 Each step is defined by the string decorating it.
 This string is used to call the step in "*.feature" file.
 """
-from __future__ import unicode_literals, print_function, absolute_import
+from __future__ import unicode_literals, print_function
 
 from behave import when, then
-from tests.features.steps import wrappers
+import wrappers
 
 
 @when('we save a named query')

--- a/tests/features/steps/specials.py
+++ b/tests/features/steps/specials.py
@@ -4,10 +4,10 @@ Steps for behavioral style tests are defined in this module.
 Each step is defined by the string decorating it.
 This string is used to call the step in "*.feature" file.
 """
-from __future__ import unicode_literals, print_function, absolute_import
+from __future__ import unicode_literals, print_function
 
 from behave import when, then
-from tests.features.steps import wrappers
+import wrappers
 
 
 @when('we refresh completions')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import unicode_literals, print_function, absolute_import
+from __future__ import unicode_literals, print_function
 import os
 import platform
 import mock
@@ -14,7 +14,7 @@ from pgcli.main import (
     obfuscate_process_password, format_output, PGCli, OutputSettings
 )
 from pgspecial.main import (PAGER_OFF, PAGER_LONG_OUTPUT, PAGER_ALWAYS)
-from tests.utils import dbtest, run
+from utils import dbtest, run
 from collections import namedtuple
 
 

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -1,12 +1,12 @@
 # coding=UTF-8
-from __future__ import print_function, absolute_import
+from __future__ import print_function
 
 import pytest
 import psycopg2
 from mock import patch
 from pgcli.packages.parseutils.meta import FunctionMetadata
 from textwrap import dedent
-from tests.utils import run, dbtest, requires_json, requires_jsonb
+from utils import run, dbtest, requires_json, requires_jsonb
 from pgcli.main import PGCli
 
 

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -1,7 +1,7 @@
-from __future__ import unicode_literals, print_function, absolute_import
+from __future__ import unicode_literals, print_function
 
 import itertools
-from tests.metadata import (MetaData, alias, name_join, fk_join, join,
+from metadata import (MetaData, alias, name_join, fk_join, join,
     schema, table, function, wildcard_expansion, column,
     get_result, result_set, qual, no_qual, parametrize)
 

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -1,6 +1,6 @@
-from __future__ import unicode_literals, print_function, absolute_import
+from __future__ import unicode_literals, print_function
 
-from tests.metadata import (MetaData, alias, name_join, fk_join, join, keyword,
+from metadata import (MetaData, alias, name_join, fk_join, join, keyword,
     schema, table, view, function, column, wildcard_expansion,
     get_result, result_set, qual, no_qual, parametrize)
 from prompt_toolkit.completion import Completion


### PR DESCRIPTION
This reverts `absolute_imports` change in tests, because that came with a drawback: `tests` having to be a package, being installed into and polluting `site-packages`. Should we perhaps have `tests` inside `pgcli` package? Challenge for another day.