### PR TITLE
Changelog update to release 2.0.0.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -3,6 +3,11 @@ Upcoming:
 
 TODO
 
+2.0.0:
+======
+
+* Update to ``prompt-toolkit`` 2.0. (Thanks: `Jonathan Slenders`_, `Dick Marinus`_, `Irina Truong`_)
+
 1.11.0
 ======
 


### PR DESCRIPTION
Changelog update to release 2.0.0.

The only change is updating to prompt-toolkit 2.0.