### PR TITLE
Set default port in `connect_uri` when none is given, fixes #958

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -895,7 +895,8 @@ class PGCli(object):
         short_host, _, _ = host.partition('.')
         string = string.replace('\\h', short_host)
         string = string.replace('\\d', self.pgexecute.dbname or '(none)')
-        string = string.replace('\\p', str(self.pgexecute.port) or '(none)')
+        string = string.replace('\\p', str(
+            self.pgexecute.port) if self.pgexecute.port is not None else '5432')
         string = string.replace('\\i', str(self.pgexecute.pid) or '(none)')
         string = string.replace('\\#', "#" if (self.pgexecute.superuser) else ">")
         string = string.replace('\\n', "\n")


### PR DESCRIPTION
## Description
When there is no port given in a connection URI the sytem should assume the default port 5432.



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
