### PR TITLE
Enable suspend using C-Z.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -7,6 +7,7 @@ Bug fixes:
 * Fix for loading/saving named queries from provided config file (#938). (Thanks: `Daniel Egger`_)
 * Set default port in `connect_uri` when none is given. (Thanks: `Daniel Egger`_)
 * Fix for error listing databases (#951). (Thanks: `Irina Truong`_)
+* Enable Ctrl-Z to suspend the app (Thanks: `Amjith Ramanujam`_).
 
 Internal:
 ---------
@@ -830,7 +831,7 @@ Improvements:
 * Faster test runs on TravisCI. (Thanks: https://github.com/macobo)
 * Integration tests with Postgres!! (Thanks: https://github.com/macobo)
 
-.. _`Amjith Ramanujam`: https://github.com/amjith
+.. _`Amjith Ramanujam`: https://blog.amjith.com
 .. _`Andrew Kuchling`: https://github.com/akuchling
 .. _`Darik Gamble`: https://github.com/darikg
 .. _`Daniel Rocco`: https://github.com/drocco007

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -729,6 +729,7 @@ class PGCli(object):
                 key_bindings=key_bindings,
                 enable_open_in_editor=True,
                 enable_system_prompt=True,
+                enable_suspend=True,
                 editing_mode=EditingMode.VI if self.vi_mode else EditingMode.EMACS,
                 search_ignore_case=True)
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
In the new version of prompt-toolkit C-Z was not suspending the app. It is now fixed. 


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
