### PR TITLE
allow passing -u flag (lowercase) to specify username

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -86,6 +86,7 @@ Contributors:
     * Kenny Do
     * Max Rothman
     * Daniel Egger
+    * Ignacio Campabadal
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,11 @@
 Upcoming:
 =========
 
+Features:
+---------
+
+* Allows passing the ``-u`` flag to specify a username
+
 Internal:
 ---------
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,7 +4,7 @@ Upcoming:
 Features:
 ---------
 
-* Allows passing the ``-u`` flag to specify a username
+* Allows passing the ``-u`` flag to specify a username. (Thanks: `Ignacio Campabadal`_)
 
 Internal:
 ---------
@@ -28,7 +28,7 @@ Internal:
 
 * Clean up and add behave logging. (Thanks: `Dick Marinus`_)
 * Require prompt_toolkit>=2.0.6. (Thanks: `Dick Marinus`_)
-* Improve development guide (Thanks: `Ignacio Campabadal`_)
+* Improve development guide. (Thanks: `Ignacio Campabadal`_)
 
 2.0.0:
 ======

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -942,7 +942,7 @@ class PGCli(object):
 @click.option('-p', '--port', default=5432, help='Port number at which the '
         'postgres instance is listening.', envvar='PGPORT', type=click.INT)
 @click.option('-U', '--username', 'username_opt', help='Username to connect to the postgres database.')
-@click.option('--user', 'username_opt', help='Username to connect to the postgres database.')
+@click.option('-u', '--user', 'username_opt', help='Username to connect to the postgres database.')
 @click.option('-W', '--password', 'prompt_passwd', is_flag=True, default=False,
               help='Force password prompt.')
 @click.option('-w', '--no-password', 'never_prompt', is_flag=True,


### PR DESCRIPTION
## Description
closes #776 

allows users to specify a username by passing a lowercase 'u', as in `pgcli -u username`

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
