### PR TITLE
Determine hstore OID from the system view

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -88,6 +88,7 @@ Contributors:
     * Daniel Egger
     * Ignacio Campabadal
     * Mikhail Elovskikh (wronglink)
+    * Marcin Cieślak (saper)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,9 @@
 Upcoming:
 =========
 
-TODO
+Bug fixes:
+----------
+* Avoid error message on the server side if hstore extension is not installed in the current database (#991). (Thanks: `Marcin Cieślak`_)
 
 2.0.2:
 ======
@@ -924,3 +926,4 @@ Improvements:
 .. _`Daniel Egger`: https://github.com/DanEEStar
 .. _`Ignacio Campabadal`: https://github.com/igncampa
 .. _`Mikhail Elovskikh`: https://github.com/wronglink
+.. _`Marcin Cieślak`: https://github.com/saper

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -113,7 +113,8 @@ def register_hstore_typecaster(conn):
     """
     with conn.cursor() as cur:
         try:
-            cur.execute("SELECT 'hstore'::regtype::oid")
+            cur.execute(
+                "select t.oid FROM pg_type t WHERE t.typname = 'hstore' and t.typisdefined")
             oid = cur.fetchone()[0]
             ext.register_type(ext.new_type((oid,), "HSTORE", ext.UNICODE))
         except Exception:


### PR DESCRIPTION
Avoid error message on the server side if hstore
extension is not installed in the current database.

Issue: https://github.com/dbcli/pgcli/issues/991