### PR TITLE
exclude tests as package from setup.py

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -17,6 +17,7 @@ Internal:
 ---------
 
 * Added tests for special command completion. (Thanks: `Amjith Ramanujam`_)
+* Exclude tests as package from setup.py. (Thanks: `Dick Marinus`_)
 
 2.0.1:
 ======

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     version=version,
     license='BSD',
     url='http://pgcli.com',
-    packages=find_packages(),
+    packages=find_packages(exclude="tests"),
     package_data={'pgcli': ['pgclirc',
                             'packages/pgliterals/pgliterals.json']},
     description=description,


### PR DESCRIPTION
## Description
exclude tests as package from setup.py

fixes #993 

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
