### PR TITLE
Use pexpect.TIMEOUT instead of pexpect.exceptions.TIMEOUT

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,7 @@ Upcoming:
 Bug fixes:
 ----------
 * Avoid error message on the server side if hstore extension is not installed in the current database (#991). (Thanks: `Marcin Cieślak`_)
+* All pexpect submodules have been moved into the pexpect package as of version 3.0. Use pexpect.TIMEOUT (Thanks: `Marcin Cieślak`_)
 
 2.0.2:
 ======

--- a/tests/features/steps/wrappers.py
+++ b/tests/features/steps/wrappers.py
@@ -16,7 +16,7 @@ def expect_exact(context, expected, timeout):
     timedout = False
     try:
         context.cli.expect_exact(expected, timeout=timeout)
-    except pexpect.exceptions.TIMEOUT:
+    except pexpect.TIMEOUT:
         timedout = True
     if timedout:
         # Strip color codes out of the output.


### PR DESCRIPTION
All pexpect submodules have been moved into the pexpect package as of version 3.0.