### PR TITLE
Remove build dir before running sdist

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,7 @@ Internal:
 
 * (Fixup) Clean up and add behave logging. (Thanks: `Marcin Cieślak`_, `Dick Marinus`_)
 * Override VISUAL environment variable for behave tests. (Thanks: `Marcin Cieślak`_)
+* Remove build dir before running sdist. (Thanks: `Dick Marinus`_)
 
 2.0.2:
 ======

--- a/release.py
+++ b/release.py
@@ -67,7 +67,7 @@ def create_git_tag(tag_name):
 
 
 def create_distribution_files():
-    run_step('python', 'setup.py', 'sdist', 'bdist_wheel')
+    run_step('python', 'setup.py', 'clean', '--all', 'sdist', 'bdist_wheel')
 
 
 def upload_distribution_files():


### PR DESCRIPTION
## Description
Remove build dir before running sdist
fixes #993

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
