### PR TITLE
keybinding for dismissing autocompletelist

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -89,6 +89,7 @@ Contributors:
     * Ignacio Campabadal
     * Mikhail Elovskikh (wronglink)
     * Marcin Cieślak (saper)
+    * easteregg
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,11 @@
 Upcoming:
 =========
 
+Features:
+---------
+
+* keybindings for closing the autocomplete list
+
 Bug fixes:
 ----------
 * Avoid error message on the server side if hstore extension is not installed in the current database (#991). (Thanks: `Marcin Cieślak`_)

--- a/pgcli/key_bindings.py
+++ b/pgcli/key_bindings.py
@@ -41,6 +41,16 @@ def pgcli_bindings(pgcli):
         else:
             b.start_completion(select_first=True)
 
+    @kb.add('escape')
+    def _(event):
+        """Force closing of autocompletion."""
+        _logger.debug('Detected <Esc> key.')
+
+        event.current_buffer.complete_state = None
+        event.app.current_buffer.complete_state = None
+
+
+
     @kb.add('c-space')
     def _(event):
         """
@@ -71,7 +81,6 @@ def pgcli_bindings(pgcli):
         _logger.debug('Detected enter key.')
 
         event.current_buffer.complete_state = None
-        b = event.app.current_buffer
-        b.complete_state = None
+        event.app.current_buffer.complete_state = None
 
     return kb


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

i added the esc key in `pgcli/key_bindings.py` to dismiss the autocomplete. The main reason for this, that it sometimes tends to get in the way of the source, especially if you have multiline selects pasted into pgcli.

since im not that profound into python and its libs you could maybe improve the current solution.

thank you for maintaining this greate piece of software!

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
