### PR TITLE
Fix crash in get_server_version when using --single-connection.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -89,7 +89,7 @@ Contributors:
     * Ignacio Campabadal
     * Mikhail Elovskikh (wronglink)
     * Marcin Cieślak (saper)
-    * easteregg
+    * easteregg (verfriemelt-dot-org)
     * Scott Brenstuhl (808sAndBR)
 
 Creator:

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,13 +4,14 @@ Upcoming:
 Features:
 ---------
 
-* keybindings for closing the autocomplete list
-* reconnect automatically when server closes connection
+* Keybindings for closing the autocomplete list. (Thanks: `easteregg`_)
+* Reconnect automatically when server closes connection. (Thanks: `Scott Brenstuhl`_)
 
 Bug fixes:
 ----------
 * Avoid error message on the server side if hstore extension is not installed in the current database (#991). (Thanks: `Marcin Cieślak`_)
 * All pexpect submodules have been moved into the pexpect package as of version 3.0. Use pexpect.TIMEOUT (Thanks: `Marcin Cieślak`_)
+* Fix crash retrieving server version with ``--single-connection``. (Thanks: `Irina Truong`_)
 
 Internal:
 ---------
@@ -942,3 +943,5 @@ Improvements:
 .. _`Ignacio Campabadal`: https://github.com/igncampa
 .. _`Mikhail Elovskikh`: https://github.com/wronglink
 .. _`Marcin Cieślak`: https://github.com/saper
+.. _`Scott Brenstuhl`: https://github.com/808sAndBR
+.. _`easteregg`: https://github.com/verfriemelt-dot-org

--- a/pgcli/completion_refresher.py
+++ b/pgcli/completion_refresher.py
@@ -53,7 +53,7 @@ class CompletionRefresher(object):
         if settings.get('single_connection'):
             executor = pgexecute
         else:
-            # Create a new pgexecute method to popoulate the completions.
+            # Create a new pgexecute method to populate the completions.
             executor = pgexecute.copy()
         # If callbacks is a single function then push it into a list.
         if callable(callbacks):

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -556,7 +556,7 @@ class PGCli(object):
             logger.error("sql: %r, error: %r", text, e)
             logger.error("traceback: %r", traceback.format_exc())
             self._handle_server_closed_connection(text)
-        except PgCliQuitError as e:
+        except (PgCliQuitError, EOFError) as e:
             raise
         except Exception as e:
             logger.error("sql: %r, error: %r", text, e)
@@ -618,7 +618,7 @@ class PGCli(object):
         self.prompt_app = self._build_cli(history)
 
         if not self.less_chatty:
-            print('Server: PostgreSQL', self.pgexecute.get_server_version())
+            print('Server: PostgreSQL', self.pgexecute.server_version)
             print('Version:', __version__)
             print('Chat: https://gitter.im/dbcli/pgcli')
             print('Mail: https://groups.google.com/forum/#!forum/pgcli')


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Fixes the exception:

```
(pgcli) --- src/pgcli ‹master*M?› » pgcli postgres --single-connection                                                                   1 ↵
/Users/irina/.pyenv/versions/3.7.1/envs/pgcli/lib/python3.7/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)
Traceback (most recent call last):
  File "/Users/irina/.pyenv/versions/pgcli/bin/pgcli", line 11, in <module>
    load_entry_point('pgcli', 'console_scripts', 'pgcli')()
  File "/Users/irina/.pyenv/versions/3.7.1/envs/pgcli/lib/python3.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/irina/.pyenv/versions/3.7.1/envs/pgcli/lib/python3.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/irina/.pyenv/versions/3.7.1/envs/pgcli/lib/python3.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/irina/.pyenv/versions/3.7.1/envs/pgcli/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/irina/src/pgcli/pgcli/main.py", line 1062, in cli
    pgcli.run_cli()
  File "/Users/irina/src/pgcli/pgcli/main.py", line 621, in run_cli
    print('Server: PostgreSQL', self.pgexecute.get_server_version())
  File "/Users/irina/src/pgcli/pgcli/pgexecute.py", line 222, in get_server_version
    pass
psycopg2.ProgrammingError: close cannot be used while an asynchronous query is underway
```

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
