### PR TITLE
Remove the expand_tab option from pgclirc.

### DIFF
--- a/pgcli/key_bindings.py
+++ b/pgcli/key_bindings.py
@@ -12,8 +12,7 @@ def pgcli_bindings(pgcli):
     """Custom key bindings for pgcli."""
     kb = KeyBindings()
 
-    expand_tab = pgcli.config['main'].as_bool('expand_tab')
-    tab_insert_text = ' ' * 4 if expand_tab else '\t'
+    tab_insert_text = ' ' * 4
 
     @kb.add('f2')
     def _(event):

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -143,9 +143,6 @@ enable_pager = True
 # Use keyring to automatically save and load password in a secure manner 
 keyring = True
 
-# When the <Tab> key is pressed on an empty line, use 4 spaces instead of \t
-expand_tab = False
-
 # Custom colors for the completion menu, toolbar, etc.
 [colors]
 completion-menu.completion.current = 'bg:#ffffff #000000'


### PR DESCRIPTION
## Description
This is a follow up to #928.

Picking 4 spaces whenever a user presses the tab key. Removes the option from the config file.
