### PR TITLE
[WIP] Build pgcli with 3.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
+dist: xenial
+
+sudo: required
+
 language: python
+
 python:
   - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 before_install:
   - which python
@@ -43,4 +49,4 @@ services:
   - postgresql
 
 addons:
-  postgresql: "9.3"
+  postgresql: "9.6"

--- a/changelog.rst
+++ b/changelog.rst
@@ -9,6 +9,11 @@ Bug fixes:
 * Pgcli no longer works with password containing spaces (#1043). (Thanks: `Irina Truong`_)
 * Load keyring only when keyring is enabled in the config file (#1041). (Thanks: `Zhaolong Zhu`_)
 
+Internal:
+---------
+
+* Add python 3.7 to travis build matrix. (Thanks: `Irina Truong`_)
+
 2.1.0
 =====
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: SQL',
         'Topic :: Database',
         'Topic :: Database :: Front-Ends',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, py37
 [testenv]
-deps = pytest
-    mock
-    pgspecial
-    humanize
-    psycopg2
+deps = pytest>=2.7.0,<=3.0.7
+    mock>=1.0.1
+    behave>=1.2.4
+    pexpect==3.3
 commands = py.test
     behave tests/features
 passenv = PGHOST


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Python 3.7. Looks like this can only be done with `xenial` and `sudo` in travis right now.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
