### PR TITLE
Fix usage of pgservice

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -398,11 +398,12 @@ class PGCli(object):
                 dsn='', **kwargs):
         # Connect to the database.
 
-        if not user:
-            user = getuser()
+        if not dsn:
+            if not user:
+                user = getuser()
 
-        if not database:
-            database = user
+            if not database:
+                database = user
 
         # If password prompt is not forced but no password is provided, try
         # getting it from environment variable.

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -398,12 +398,11 @@ class PGCli(object):
                 dsn='', **kwargs):
         # Connect to the database.
 
-        if not dsn:
-            if not user:
-                user = getuser()
+        if not user:
+            user = getuser()
 
-            if not database:
-                database = user
+        if not database:
+            database = user
 
         # If password prompt is not forced but no password is provided, try
         # getting it from environment variable.

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -232,14 +232,21 @@ class PGExecute(object):
             'dsn': dsn,
         }
         new_params.update(kwargs)
+
+        if 'dsn' in new_params:
+            new_params = {
+                'dsn': new_params['dsn'],
+                'password': new_params['password']
+            }
+
+            if 'password' in new_params:
+                new_params['dsn'] = "{0} password={1}".format(
+                    new_params['dsn'], new_params.pop('password')
+                )
+
         conn_params.update({
             k: unicode2utf8(v) for k, v in new_params.items() if v
         })
-
-        if 'password' in conn_params and 'dsn' in conn_params:
-            conn_params['dsn'] = "{0} password={1}".format(
-                conn_params['dsn'], conn_params.pop('password')
-            )
 
         conn = psycopg2.connect(**conn_params)
         cursor = conn.cursor()

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -233,7 +233,7 @@ class PGExecute(object):
         }
         new_params.update(kwargs)
         conn_params.update({
-            k: unicode2utf8(v) for k, v in new_params.items() if v is not None
+            k: unicode2utf8(v) for k, v in new_params.items() if v
         })
 
         if 'password' in conn_params and 'dsn' in conn_params:


### PR DESCRIPTION
## Description
<!--- Describe your problem as fully as you can. -->
Using services don't work (but they did in the previous release):
`PGSERVICE=spacex pgcli` or `pgcli service=spacex`
By not working I mean: It tries to get a connection with my user account and this is the error message that I get: `FATAL:  database "me" does not exist`

Might be helpful to know the PR that caused the issue: #978 

This PR implements a quick fix for this issue.

Changes:
     First part removes defaults, if dsn is set. Hopefully they're not needed since we're using dsn (might be totally in the wrong here).
     Second part cleans the dict properly (as empty attributes are mostly empty strings and not None objects). Seems like an issue. Not sure if this was triggered by my use-case.

Like mentioned in #1034, this PR lacks some love at this moment. Feel free to suggest / push for improvements.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
