### PR TITLE
Allow escape to switch to vi navigation mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -91,6 +91,7 @@ Contributors:
     * Marcin Cieślak (saper)
     * easteregg (verfriemelt-dot-org)
     * Scott Brenstuhl (808sAndBR)
+    * Nathan Verzemnieks
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,10 @@
+Upcoming:
+=========
+
+Bug fixes:
+----------
+* Escape switches to VI navigation mode when not canceling completion popup. (Thanks: `Nathan Verzemnieks`_)
+
 2.1.0
 =====
 
@@ -950,3 +957,4 @@ Improvements:
 .. _`Marcin Cieślak`: https://github.com/saper
 .. _`Scott Brenstuhl`: https://github.com/808sAndBR
 .. _`easteregg`: https://github.com/verfriemelt-dot-org
+.. _`Nathan Verzemnieks`: https://github.com/njvrzm

--- a/pgcli/key_bindings.py
+++ b/pgcli/key_bindings.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import logging
 from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.filters import completion_is_selected
+from prompt_toolkit.filters import completion_is_selected, has_completions
 
 _logger = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ def pgcli_bindings(pgcli):
         else:
             buff.insert_text(tab_insert_text, fire_event=False)
 
-    @kb.add('escape')
+    @kb.add('escape', filter=has_completions)
     def _(event):
         """Force closing of autocompletion."""
         _logger.debug('Detected <Esc> key.')


### PR DESCRIPTION
## Description

#1007, letting `escape` dismiss autocomplete dialogs, had the unintended side effect of disabling the use of `escape` to switch to vi navigation mode. This PR restores that.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
