### PR TITLE
Possibly fix #1040.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,7 @@ Bug fixes:
 ----------
 * Escape switches to VI navigation mode when not canceling completion popup. (Thanks: `Nathan Verzemnieks`_)
 * Allow application_name to be overridden. (Thanks: `raylu`_)
+* Fix for "no attribute KeyringLocked" (#1040). (Thanks: `Irina Truong`_)
 
 2.1.0
 =====

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -47,7 +47,8 @@ from pgspecial.main import (PGSpecial, NO_QUERY, PAGER_OFF, PAGER_LONG_OUTPUT)
 import pgspecial as special
 try:
     import keyring
-except ImportError:
+except:
+    # pep8 will be unhappy about this. But keyring is optional, and we better disable it if it won't load.
     keyring = None
 from .pgcompleter import PGCompleter
 from .pgtoolbar import create_toolbar_tokens_func

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -478,9 +478,8 @@ class PGCli(object):
                 try:
                     keyring.set_password('pgcli', key, passwd)
                 except (
-                    keyring.errors.InitError,
                     RuntimeError,
-                    keyring.errors.KeyringLocked
+                    keyring.errors.KeyringError,
                 ) as e:
                     click.secho(
                         keyring_error_message.format(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Catch the base `KeyringError` vs `KeyringLocked` that does not actually exist in version we require (12.2.0).

Fix for https://github.com/dbcli/pgcli/issues/1040.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
