### PR TITLE
Allow application_name to be overridden

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -92,6 +92,7 @@ Contributors:
     * easteregg (verfriemelt-dot-org)
     * Scott Brenstuhl (808sAndBR)
     * Nathan Verzemnieks
+    * raylu
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -959,3 +959,4 @@ Improvements:
 .. _`Scott Brenstuhl`: https://github.com/808sAndBR
 .. _`easteregg`: https://github.com/verfriemelt-dot-org
 .. _`Nathan Verzemnieks`: https://github.com/njvrzm
+.. _`raylu`: https://github.com/benchling

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,7 @@ Upcoming:
 Bug fixes:
 ----------
 * Escape switches to VI navigation mode when not canceling completion popup. (Thanks: `Nathan Verzemnieks`_)
+* Allow application_name to be overridden. (Thanks: `raylu`_)
 
 2.1.0
 =====

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -293,7 +293,7 @@ class PGCli(object):
             db, user, host, port = infos
             try:
                 self.pgexecute.connect(database=db, user=user, host=host,
-                                       port=port, application_name='pgcli')
+                                       port=port, **self.pgexecute.extra_args)
             except OperationalError as e:
                 click.secho(str(e), err=True, fg='red')
                 click.echo("Previous connection kept")
@@ -404,6 +404,8 @@ class PGCli(object):
         if not database:
             database = user
 
+        kwargs.setdefault('application_name', 'pgcli')
+
         # If password prompt is not forced but no password is provided, try
         # getting it from environment variable.
         if not self.force_passwd_prompt and not passwd:
@@ -462,15 +464,14 @@ class PGCli(object):
         try:
             try:
                 pgexecute = PGExecute(database, user, passwd, host, port, dsn,
-                                      application_name='pgcli', **kwargs)
+                                      **kwargs)
             except (OperationalError, InterfaceError) as e:
                 if should_ask_for_password(e):
                     passwd = click.prompt('Password for %s' % user,
                                           hide_input=True, show_default=False,
                                           type=str)
                     pgexecute = PGExecute(database, user, passwd, host, port,
-                                          dsn, application_name='pgcli',
-                                          **kwargs)
+                                          dsn, **kwargs)
                 else:
                     raise e
             if passwd and keyring and self.keyring_enabled:

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -199,6 +199,7 @@ class PGExecute(object):
         self.host = None
         self.port = None
         self.server_version = None
+        self.extra_args = None
         self.connect(database, user, password, host, port, dsn, **kwargs)
 
     def copy(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,6 +13,7 @@ except ImportError:
 from pgcli.main import (
     obfuscate_process_password, format_output, PGCli, OutputSettings, COLOR_CODE_REGEX
 )
+from pgcli.pgexecute import PGExecute
 from pgspecial.main import (PAGER_OFF, PAGER_LONG_OUTPUT, PAGER_ALWAYS)
 from utils import dbtest, run
 from collections import namedtuple
@@ -309,3 +310,12 @@ def test_multihost_db_uri(tmpdir):
                                     user='bar',
                                     passwd='foo',
                                     port='2543,2543,2543')
+
+
+def test_application_name_db_uri(tmpdir):
+    with mock.patch.object(PGExecute, '__init__') as mock_pgexecute:
+        mock_pgexecute.return_value = None
+        cli = PGCli(pgclirc_file=str(tmpdir.join("rcfile")))
+        cli.connect_uri('postgres://bar@baz.com/?application_name=cow')
+    mock_pgexecute.assert_called_with('bar', 'bar', None, 'baz.com', u'', u'',
+                                      application_name='cow')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -317,5 +317,5 @@ def test_application_name_db_uri(tmpdir):
         mock_pgexecute.return_value = None
         cli = PGCli(pgclirc_file=str(tmpdir.join("rcfile")))
         cli.connect_uri('postgres://bar@baz.com/?application_name=cow')
-    mock_pgexecute.assert_called_with('bar', 'bar', None, 'baz.com', u'', u'',
+    mock_pgexecute.assert_called_with('bar', 'bar', '', 'baz.com', '', '',
                                       application_name='cow')


### PR DESCRIPTION
## Description
We had existing invocations of pgcli like `pgcli postgres://bar@baz.com/?application_name=cow`.
8cd3309b18fc015fc89da3236330f7b35297a998 / https://github.com/dbcli/pgcli/pull/869 broke these with errors like

    Traceback (most recent call last):
      File "[...]/lib/python2.7/site-packages/pgcli/ main.py", line 466, in connect
        application_name='pgcli', **kwargs)
    TypeError: type object got multiple values for keyword argument 'application_name'

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file.