### PR TITLE
Allow psycopg2 up to 2.8.2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -95,6 +95,7 @@ Contributors:
     * raylu
     * Zhaolong Zhu
     * Zane C. Bowers-Hadley
+    * Telmo "Trooper" (telmotrooper)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -11,7 +11,7 @@ Bug fixes:
 * No longer depend on sqlparse as being less than 0.3.0 with the release of sqlparse 0.3.0. (Thanks: `VVelox`_)
 * Fix the broken support for pgservice . (Thanks: `Xavier Francisco`_)
 * Connecting using socket is broken in current master. (#1053). (Thanks: `Irina Truong`_)
-* Allow usage of psycopg2 up to 2.8.2 (Thanks: `Telmo "Trooper"`_)
+* Allow usage of newer versions of psycopg2 (Thanks: `Telmo "Trooper"`_)
 
 Internal:
 ---------

--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,7 @@ Bug fixes:
 * No longer depend on sqlparse as being less than 0.3.0 with the release of sqlparse 0.3.0. (Thanks: `VVelox`_)
 * Fix the broken support for pgservice . (Thanks: `Xavier Francisco`_)
 * Connecting using socket is broken in current master. (#1053). (Thanks: `Irina Truong`_)
+* Allow usage of psycopg2 up to 2.8.2 (Thanks: `Telmo "Trooper"`_)
 
 Internal:
 ---------
@@ -975,3 +976,4 @@ Improvements:
 .. _`Zhaolong Zhu`: https://github.com/zzl0
 .. _`Xavier Francisco`: https://github.com/Qu4tro
 .. _`VVelox`: https://github.com/VVelox
+.. _`Telmo "Trooper"`: https://github.com/telmotrooper

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requirements = [
     "click >= 4.1",
     "Pygments >= 2.0",  # Pygments has to be Capitalcased. WTF?
     "prompt_toolkit>=2.0.6,<2.1.0",
-    "psycopg2 >= 2.7.4,<2.8",
+    "psycopg2 >= 2.7.4,<=2.8.2",
     "sqlparse >=0.3.0,<0.4",
     "configobj >= 5.0.6",
     "humanize >= 0.5.1",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requirements = [
     "click >= 4.1",
     "Pygments >= 2.0",  # Pygments has to be Capitalcased. WTF?
     "prompt_toolkit>=2.0.6,<2.1.0",
-    "psycopg2 >= 2.7.4,<=2.8.2",
+    "psycopg2 >= 2.7.4",
     "sqlparse >=0.3.0,<0.4",
     "configobj >= 5.0.6",
     "humanize >= 0.5.1",


### PR DESCRIPTION
This fixes the issue with pgcli not working on Arch Linux, since the package `python2-psycopg2` is already on 2.8.2.

## Description
<!--- Describe your changes in detail. -->



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
