### PR TITLE
README.rst: tidy up redundant instructions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -96,6 +96,7 @@ Contributors:
     * Zhaolong Zhu
     * Zane C. Bowers-Hadley
     * Telmo "Trooper" (telmotrooper)
+    * Alexander Zawadzki
 
 Creator:
 --------

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,10 @@ If you already know how to install python packages, then you can simply do:
 If you don't know how to install python packages, please check the
 `detailed instructions`_.
 
+If you are restricted to using psycopg2 2.7.x then pip will try to install it from a binary. There are some known issues with the psycopg2 2.7 binary - see the `psycopg docs`_ for more information about this and how to force installation from source. psycopg2 2.8 has fixed these problems, and will build from source.
+
 .. _`detailed instructions`: https://github.com/dbcli/pgcli#detailed-installation-instructions
+.. _`psycopg docs`: http://initd.org/psycopg/docs/install.html#change-in-binary-packages-between-psycopg-2-7-and-2-8
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -29,15 +29,7 @@ If you already know how to install python packages, then you can simply do:
 If you don't know how to install python packages, please check the
 `detailed instructions`_.
 
-If you have `problems with psycopg2 wheels`_, use the following flags to install psycopg2 from
-source:
-
-::
-
-    $ pip install pgcli --no-binary :all: psycopg2
-
 .. _`detailed instructions`: https://github.com/dbcli/pgcli#detailed-installation-instructions
-.. _`problems with psycopg2 wheels`: http://initd.org/psycopg/articles/2018/02/08/psycopg-274-released/
 
 Usage
 -----

--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,7 @@ Bug fixes:
 * Fix the broken support for pgservice . (Thanks: `Xavier Francisco`_)
 * Connecting using socket is broken in current master. (#1053). (Thanks: `Irina Truong`_)
 * Allow usage of newer versions of psycopg2 (Thanks: `Telmo "Trooper"`_)
+* Update README in alignment with the usage of newer versions of psycopg2 (Thanks: `Alexander Zawadzki`_)
 
 Internal:
 ---------

--- a/changelog.rst
+++ b/changelog.rst
@@ -978,3 +978,4 @@ Improvements:
 .. _`Xavier Francisco`: https://github.com/Qu4tro
 .. _`VVelox`: https://github.com/VVelox
 .. _`Telmo "Trooper"`: https://github.com/telmotrooper
+.. _`Alexander Zawadzki`: https://github.com/zadacka


### PR DESCRIPTION
Remove the README section which detailed how to force `psycopg2` 2.7 dependency installation from source rather than binary.

`psycopg2` 2.7 would automatically favour installation from binary. A bug affecting some users made it desirable to have the option to install from source instead. The README detailed how to do this using pip's `--no-binary` option (nice!).

`psycopg2` 2.8 has now split the binary and source dependencies into different packages with different names (source: [psycopg2 docs](http://initd.org/psycopg/docs/install.html#change-in-binary-packages-between-psycopg-2-7-and-2-8)) which makes the `--no-binary` instructions redundant. To specify source/binary you now need to explicitly specify the desired package.

As of #1060, installing `pgcli` from pip will result in the installation of `psycopg2` 2.8 from source.

## Description
<!--- Describe your changes in detail. -->



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
