### PR TITLE
Add \G as a temporary way to use expanded mode.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,10 @@
 Upcoming:
 =========
 
-TODO
+Features:
+---------
+
+* Add `\\G` as a terminator to sql statements that will show the results in expanded mode. This feature is copied from mycli. (Thanks: `Amjith Ramanujam`_)
 
 2.1.1
 =====

--- a/pgcli/pgbuffer.py
+++ b/pgcli/pgbuffer.py
@@ -33,6 +33,7 @@ def _multiline_exception(text):
     return (
         text.startswith("\\")
         or text.endswith(r"\e")  # Special Command
+        or text.endswith(r"\G")  # Special Command
         or _is_complete(text)  # Ended with \e which should launch the editor
         or (text == "exit")  # A complete SQL command
         or (text == "quit")  # Exit doesn't need semi-colon

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -380,7 +380,7 @@ class PGExecute(object):
             try:
                 if pgspecial:
                     # \G is treated specially since we have to set the expanded output.
-                    if sql.endswith('\\G'):
+                    if sql.endswith("\\G"):
                         if not pgspecial.expanded_output:
                             pgspecial.expanded_output = True
                             self.reset_expanded = True

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -213,6 +213,7 @@ class PGExecute(object):
         self.server_version = None
         self.extra_args = None
         self.connect(database, user, password, host, port, dsn, **kwargs)
+        self.reset_expanded = None
 
     def copy(self):
         """Returns a clone of the current executor."""
@@ -378,6 +379,13 @@ class PGExecute(object):
 
             try:
                 if pgspecial:
+                    # \G is treated specially since we have to set the expanded output.
+                    if sql.endswith('\\G'):
+                        if not pgspecial.expanded_output:
+                            pgspecial.expanded_output = True
+                            self.reset_expanded = True
+                        sql = sql[:-2].strip()
+
                     # First try to run each query as special
                     _logger.debug("Trying a pgspecial command. sql: %r", sql)
                     try:
@@ -411,6 +419,10 @@ class PGExecute(object):
 
                 if not on_error_resume:
                     break
+            finally:
+                if self.reset_expanded:
+                    pgspecial.expanded_output = False
+                    self.reset_expanded = None
 
     def _must_raise(self, e):
         """Return true if e is an error that should not be caught in ``run``.

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -86,6 +86,7 @@ def test_bools_are_treated_as_strings(executor):
         SELECT 1"""
     )
 
+
 @dbtest
 def test_expanded_slash_G(executor, pgspecial):
     # Tests whether we reset the expanded output after a \G.
@@ -93,6 +94,7 @@ def test_expanded_slash_G(executor, pgspecial):
     run(executor, """insert into test values(True)""")
     results = run(executor, """select * from test \G""", pgspecial=pgspecial)
     assert pgspecial.expanded_output == False
+
 
 @dbtest
 def test_schemata_table_views_and_columns_query(executor):

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -86,6 +86,13 @@ def test_bools_are_treated_as_strings(executor):
         SELECT 1"""
     )
 
+@dbtest
+def test_expanded_slash_G(executor, pgspecial):
+    # Tests whether we reset the expanded output after a \G.
+    run(executor, """create table test(a boolean)""")
+    run(executor, """insert into test values(True)""")
+    results = run(executor, """select * from test \G""", pgspecial=pgspecial)
+    assert pgspecial.expanded_output == False
 
 @dbtest
 def test_schemata_table_views_and_columns_query(executor):


### PR DESCRIPTION
This feature is copied from mycli to enable temporary expanded mode. 

eg: `SELECT * FROM table_name \G` will show results in expanded mode. 

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
