### PR TITLE
Add keybinding for alt-enter to introduce a line break

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -97,6 +97,7 @@ Contributors:
     * Zane C. Bowers-Hadley
     * Telmo "Trooper" (telmotrooper)
     * Alexander Zawadzki
+    * Pablo A. Bianchi (pabloab)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -889,6 +889,7 @@ Features:
 * Cancel a command using Ctrl+C. (Thanks: https://github.com/macobo)
 * Faster startup by reading all columns and tables in a single query. (Thanks: https://github.com/macobo)
 * Improved psql compliance with env vars and password prompting. (Thanks: `Darik Gamble`_)
+* Pressing Alt-Enter will introduce a line break. This is a way to break up the query into multiple lines without switching to multi-line mode. (Thanks: https://github.com/pabloab).
 
 Bug Fixes:
 ----------

--- a/pgcli/key_bindings.py
+++ b/pgcli/key_bindings.py
@@ -90,10 +90,10 @@ def pgcli_bindings(pgcli):
         event.current_buffer.complete_state = None
         event.app.current_buffer.complete_state = None
 
-    @kb.add('escape', 'enter')
+    @kb.add("escape", "enter")
     def _(event):
         """Introduces a line break regardless of multi-line mode or not."""
-        _logger.debug('Detected alt-enter key.')
-        event.app.current_buffer.insert_text('\n')
+        _logger.debug("Detected alt-enter key.")
+        event.app.current_buffer.insert_text("\n")
 
     return kb

--- a/pgcli/key_bindings.py
+++ b/pgcli/key_bindings.py
@@ -90,4 +90,10 @@ def pgcli_bindings(pgcli):
         event.current_buffer.complete_state = None
         event.app.current_buffer.complete_state = None
 
+    @kb.add('escape', 'enter')
+    def _(event):
+        """Introduces a line break regardless of multi-line mode or not."""
+        _logger.debug('Detected alt-enter key.')
+        event.app.current_buffer.insert_text('\n')
+
     return kb


### PR DESCRIPTION
## Description

Use Alt-Enter to insert a multi-line statement without switching to multi-line mode. Already did it by @amjith [on mycli](https://github.com/dbcli/mycli/pull/748/).

Requested in [#738 of mycli](https://github.com/dbcli/mycli/issues/738).

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
