### PR TITLE
Partial fix for #1058.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,11 @@ Features:
 
 * Add `\\G` as a terminator to sql statements that will show the results in expanded mode. This feature is copied from mycli. (Thanks: `Amjith Ramanujam`_)
 
+Bug fixes:
+----------
+
+* Error connecting to PostgreSQL 12beta1 (#1058). (Thanks: `Irina Truong`_)
+
 2.1.1
 =====
 

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -559,7 +559,7 @@ class PGExecute(object):
                         att.attname column_name,
                         att.atttypid::regtype::text type_name,
                         att.atthasdef AS has_default,
-                        def.adsrc as default
+                        pg_catalog.pg_get_expr(def.adbin, def.adrelid, true) as default
                 FROM    pg_catalog.pg_attribute att
                         INNER JOIN pg_catalog.pg_class cls
                             ON att.attrelid = cls.oid


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Fixes crash when connecting to PostgreSQL 12 beta 1 (https://github.com/dbcli/pgcli/issues/1058).

Fix based on poking around with `psql -E` (namely `\\d <table name>`).

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
