### PR TITLE
Issue 1019 stacktrace on empty query

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -98,6 +98,7 @@ Contributors:
     * Telmo "Trooper" (telmotrooper)
     * Alexander Zawadzki
     * Pablo A. Bianchi (pabloab)
+    * Sebastian Janko (sebojanko)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,7 @@ Bug fixes:
 ----------
 
 * Error connecting to PostgreSQL 12beta1 (#1058). (Thanks: `Irina Truong`_)
+* Empty query caused error message (Thanks: `Sebastian Janko`_)
 
 2.1.1
 =====
@@ -993,3 +994,4 @@ Improvements:
 .. _`VVelox`: https://github.com/VVelox
 .. _`Telmo "Trooper"`: https://github.com/telmotrooper
 .. _`Alexander Zawadzki`: https://github.com/zadacka
+.. _`Sebastian Janko`: https://github.com/sebojanko

--- a/pgcli/magic.py
+++ b/pgcli/magic.py
@@ -43,7 +43,7 @@ def pgcli_line_magic(line):
         conn._pgcli = pgcli
 
     # For convenience, print the connection alias
-    print("Connected: {}".format(conn.name))
+    print ("Connected: {}".format(conn.name))
 
     try:
         pgcli.run_cli()

--- a/pgcli/magic.py
+++ b/pgcli/magic.py
@@ -43,7 +43,7 @@ def pgcli_line_magic(line):
         conn._pgcli = pgcli
 
     # For convenience, print the connection alias
-    print ("Connected: {}".format(conn.name))
+    print("Connected: {}".format(conn.name))
 
     try:
         pgcli.run_cli()

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -674,7 +674,7 @@ class PGCli(object):
             if self.pgspecial.timing_enabled:
                 # Only add humanized time display if > 1 second
                 if query.total_time > 1:
-                    print(
+                    print (
                         "Time: %0.03fs (%s), executed in: %0.03fs (%s)"
                         % (
                             query.total_time,
@@ -684,7 +684,7 @@ class PGCli(object):
                         )
                     )
                 else:
-                    print("Time: %0.03fs" % query.total_time)
+                    print ("Time: %0.03fs" % query.total_time)
 
             # Check if we need to update completions, in order of most
             # to least drastic changes
@@ -713,11 +713,11 @@ class PGCli(object):
         self.prompt_app = self._build_cli(history)
 
         if not self.less_chatty:
-            print("Server: PostgreSQL", self.pgexecute.server_version)
-            print("Version:", __version__)
-            print("Chat: https://gitter.im/dbcli/pgcli")
-            print("Mail: https://groups.google.com/forum/#!forum/pgcli")
-            print("Home: http://pgcli.com")
+            print ("Server: PostgreSQL", self.pgexecute.server_version)
+            print ("Version:", __version__)
+            print ("Chat: https://gitter.im/dbcli/pgcli")
+            print ("Mail: https://groups.google.com/forum/#!forum/pgcli")
+            print ("Home: http://pgcli.com")
 
         try:
             while True:
@@ -761,7 +761,7 @@ class PGCli(object):
 
         except (PgCliQuitError, EOFError):
             if not self.less_chatty:
-                print("Goodbye!")
+                print ("Goodbye!")
 
     def _build_cli(self, history):
         key_bindings = pgcli_bindings(self)
@@ -1186,7 +1186,7 @@ def cli(
 ):
 
     if version:
-        print("Version:", __version__)
+        print ("Version:", __version__)
         sys.exit(0)
 
     config_dir = os.path.dirname(config_location())
@@ -1198,11 +1198,12 @@ def cli(
     if os.path.exists(os.path.expanduser("~/.pgclirc")):
         if not os.path.exists(config_full_path):
             shutil.move(os.path.expanduser("~/.pgclirc"), config_full_path)
-            print("Config file (~/.pgclirc) moved to new location", config_full_path)
+            print ("Config file (~/.pgclirc) moved to new location", config_full_path)
         else:
-            print("Config file is now located at", config_full_path)
-            print(
-                "Please move the existing config file ~/.pgclirc to", config_full_path
+            print ("Config file is now located at", config_full_path)
+            print (
+                "Please move the existing config file ~/.pgclirc to",
+                config_full_path,
             )
     if list_dsn:
         try:

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -674,7 +674,7 @@ class PGCli(object):
             if self.pgspecial.timing_enabled:
                 # Only add humanized time display if > 1 second
                 if query.total_time > 1:
-                    print (
+                    print(
                         "Time: %0.03fs (%s), executed in: %0.03fs (%s)"
                         % (
                             query.total_time,
@@ -684,7 +684,7 @@ class PGCli(object):
                         )
                     )
                 else:
-                    print ("Time: %0.03fs" % query.total_time)
+                    print("Time: %0.03fs" % query.total_time)
 
             # Check if we need to update completions, in order of most
             # to least drastic changes
@@ -713,11 +713,11 @@ class PGCli(object):
         self.prompt_app = self._build_cli(history)
 
         if not self.less_chatty:
-            print ("Server: PostgreSQL", self.pgexecute.server_version)
-            print ("Version:", __version__)
-            print ("Chat: https://gitter.im/dbcli/pgcli")
-            print ("Mail: https://groups.google.com/forum/#!forum/pgcli")
-            print ("Home: http://pgcli.com")
+            print("Server: PostgreSQL", self.pgexecute.server_version)
+            print("Version:", __version__)
+            print("Chat: https://gitter.im/dbcli/pgcli")
+            print("Mail: https://groups.google.com/forum/#!forum/pgcli")
+            print("Home: http://pgcli.com")
 
         try:
             while True:
@@ -761,7 +761,7 @@ class PGCli(object):
 
         except (PgCliQuitError, EOFError):
             if not self.less_chatty:
-                print ("Goodbye!")
+                print("Goodbye!")
 
     def _build_cli(self, history):
         key_bindings = pgcli_bindings(self)
@@ -1186,7 +1186,7 @@ def cli(
 ):
 
     if version:
-        print ("Version:", __version__)
+        print("Version:", __version__)
         sys.exit(0)
 
     config_dir = os.path.dirname(config_location())
@@ -1198,12 +1198,11 @@ def cli(
     if os.path.exists(os.path.expanduser("~/.pgclirc")):
         if not os.path.exists(config_full_path):
             shutil.move(os.path.expanduser("~/.pgclirc"), config_full_path)
-            print ("Config file (~/.pgclirc) moved to new location", config_full_path)
+            print("Config file (~/.pgclirc) moved to new location", config_full_path)
         else:
-            print ("Config file is now located at", config_full_path)
-            print (
-                "Please move the existing config file ~/.pgclirc to",
-                config_full_path,
+            print("Config file is now located at", config_full_path)
+            print(
+                "Please move the existing config file ~/.pgclirc to", config_full_path
             )
     if list_dsn:
         try:

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -859,6 +859,8 @@ class PGCli(object):
             text, self.pgspecial, exception_formatter, on_error_resume
         )
 
+        is_special = None
+
         for title, cur, headers, status, sql, success, is_special in res:
             logger.debug("headers: %r", headers)
             logger.debug("rows: %r", cur)

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -376,6 +376,8 @@ class PGExecute(object):
         for sql in sqlparse.split(statement):
             # Remove spaces, eol and semi-colons.
             sql = sql.rstrip(";")
+            if not sql:
+                continue
 
             try:
                 if pgspecial:


### PR DESCRIPTION
## Description
Changes related to issue #1019.
As advised in the ticket, I added a simple check. After I added this check, I got an error saying the variable `is_special` is undefined so I defined it and set it to `None`.
The output looked like this on my system:
```
sebo@(none):osm_test> ;                                                                                                                                                                                                                      
can't execute an empty query
Time: 0.002s
```

and now it looks like this:
```
sebo@(none):osm_test> ;                                                                                                                                                                                                                      

Time: 0.000s
```


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
