### PR TITLE
Revert "Add key bindings to consistently move up and down in history …

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,7 +99,6 @@ Contributors:
     * Alexander Zawadzki
     * Pablo A. Bianchi (pabloab)
     * Sebastian Janko (sebojanko)
-    * Pedro Ferrari (petobens)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -11,7 +11,6 @@ Bug fixes:
 
 * Error connecting to PostgreSQL 12beta1 (#1058). (Thanks: `Irina Truong`_)
 * Empty query caused error message (Thanks: `Sebastian Janko`_)
-* History navigation bindings in multiline queries (#1004) (Thanks: `Pedro Ferrari`_)
 
 2.1.1
 =====
@@ -996,4 +995,3 @@ Improvements:
 .. _`Telmo "Trooper"`: https://github.com/telmotrooper
 .. _`Alexander Zawadzki`: https://github.com/zadacka
 .. _`Sebastian Janko`: https://github.com/sebojanko
-.. _`Pedro Ferrari`: https://github.com/petobens

--- a/pgcli/key_bindings.py
+++ b/pgcli/key_bindings.py
@@ -3,11 +3,7 @@ from __future__ import unicode_literals
 import logging
 from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.filters import (
-    completion_is_selected,
-    has_completions,
-    has_selection,
-)
+from prompt_toolkit.filters import completion_is_selected, has_completions
 
 _logger = logging.getLogger(__name__)
 
@@ -99,15 +95,5 @@ def pgcli_bindings(pgcli):
         """Introduces a line break regardless of multi-line mode or not."""
         _logger.debug("Detected alt-enter key.")
         event.app.current_buffer.insert_text("\n")
-
-    @kb.add("c-p", filter=~has_selection)
-    def _(event):
-        """Move up in history."""
-        event.current_buffer.history_backward(count=event.arg)
-
-    @kb.add("c-n", filter=~has_selection)
-    def _(event):
-        """Move down in history."""
-        event.current_buffer.history_forward(count=event.arg)
 
     return kb


### PR DESCRIPTION
…(#1084)"

This reverts commit 19c3e0eeb81f4a231d0ebfd2c18c47215f85e572.

## Description
<!--- Describe your changes in detail. -->



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
