### PR TITLE
Issue 1018 display first 1k rows

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -5,13 +5,13 @@ Features:
 ---------
 
 * Add `\\G` as a terminator to sql statements that will show the results in expanded mode. This feature is copied from mycli. (Thanks: `Amjith Ramanujam`_)
-* Removed limit prompt and added automatic row limit on queries with no LIMIT clause (Thanks:  `Sebastian Janko`_)
+* Removed limit prompt and added automatic row limit on queries with no LIMIT clause (#1079) (Thanks: `Sebastian Janko`_)
 
 Bug fixes:
 ----------
 
 * Error connecting to PostgreSQL 12beta1 (#1058). (Thanks: `Irina Truong`_)
-* Empty query caused error message (Thanks: `Sebastian Janko`_)
+* Empty query caused error message (#1019) (Thanks: `Sebastian Janko`_)
 * History navigation bindings in multiline queries (#1004) (Thanks: `Pedro Ferrari`_)
 
 2.1.1

--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,7 @@ Features:
 ---------
 
 * Add `\\G` as a terminator to sql statements that will show the results in expanded mode. This feature is copied from mycli. (Thanks: `Amjith Ramanujam`_)
+* Removed limit prompt and added automatic row limit on queries with no LIMIT clause (Thanks:  `Sebastian Janko`_)
 
 Bug fixes:
 ----------

--- a/pgcli/magic.py
+++ b/pgcli/magic.py
@@ -43,7 +43,7 @@ def pgcli_line_magic(line):
         conn._pgcli = pgcli
 
     # For convenience, print the connection alias
-    print("Connected: {}".format(conn.name))
+    print ("Connected: {}".format(conn.name))
 
     try:
         pgcli.run_cli()

--- a/pgcli/magic.py
+++ b/pgcli/magic.py
@@ -43,7 +43,7 @@ def pgcli_line_magic(line):
         conn._pgcli = pgcli
 
     # For convenience, print the connection alias
-    print ("Connected: {}".format(conn.name))
+    print("Connected: {}".format(conn.name))
 
     try:
         pgcli.run_cli()

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -878,7 +878,6 @@ class PGCli(object):
             logger.debug("status: %r", status)
 
             if self._should_limit_output(sql):
-                click.echo("limit")
                 cur, status = self._limit_output(cur)
 
             if self.pgspecial.auto_expand or self.auto_expand:

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -827,12 +827,17 @@ class PGCli(object):
 
             return prompt_app
 
-    def _should_limit_output(self, sql):
+    def _should_limit_output(self, sql, cur):
         """returns True if the output should be truncated, False otherwise."""
         if not is_select(sql):
             return False
 
-        return not self._has_limit(sql) and self.row_limit > 0
+        return (
+            not self._has_limit(sql)
+            and self.row_limit != 0
+            and cur
+            and cur.rowcount > self.row_limit
+        )
 
     def _has_limit(self, sql):
         if not sql:
@@ -840,8 +845,10 @@ class PGCli(object):
         return "limit " in sql.lower()
 
     def _limit_output(self, cur):
-        new_cur = itertools.islice(cur, self.row_limit)
-        new_status = "SELECT " + str(self.row_limit)
+        limit = min(self.row_limit, cur.rowcount)
+        new_cur = itertools.islice(cur, limit)
+        new_status = "SELECT " + str(limit)
+        click.secho("The result was limited to %s rows" % limit, fg="red")
 
         return new_cur, new_status
 
@@ -877,7 +884,7 @@ class PGCli(object):
             logger.debug("rows: %r", cur)
             logger.debug("status: %r", status)
 
-            if self._should_limit_output(sql):
+            if self._should_limit_output(sql, cur):
                 cur, status = self._limit_output(cur)
 
             if self.pgspecial.auto_expand or self.auto_expand:

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -877,7 +877,7 @@ class PGCli(object):
             logger.debug("rows: %r", cur)
             logger.debug("status: %r", status)
 
-            if self._should_limit_output(sql, cur):
+            if self._should_limit_output(sql):
                 click.echo("limit")
                 cur, status = self._limit_output(cur)
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -124,7 +124,6 @@ class PgCliQuitError(Exception):
 
 
 class PGCli(object):
-
     default_prompt = "\\u@\\h:\\d> "
     max_len_prompt = 30
 
@@ -674,7 +673,7 @@ class PGCli(object):
             if self.pgspecial.timing_enabled:
                 # Only add humanized time display if > 1 second
                 if query.total_time > 1:
-                    print (
+                    print(
                         "Time: %0.03fs (%s), executed in: %0.03fs (%s)"
                         % (
                             query.total_time,
@@ -684,7 +683,7 @@ class PGCli(object):
                         )
                     )
                 else:
-                    print ("Time: %0.03fs" % query.total_time)
+                    print("Time: %0.03fs" % query.total_time)
 
             # Check if we need to update completions, in order of most
             # to least drastic changes
@@ -713,11 +712,11 @@ class PGCli(object):
         self.prompt_app = self._build_cli(history)
 
         if not self.less_chatty:
-            print ("Server: PostgreSQL", self.pgexecute.server_version)
-            print ("Version:", __version__)
-            print ("Chat: https://gitter.im/dbcli/pgcli")
-            print ("Mail: https://groups.google.com/forum/#!forum/pgcli")
-            print ("Home: http://pgcli.com")
+            print("Server: PostgreSQL", self.pgexecute.server_version)
+            print("Version:", __version__)
+            print("Chat: https://gitter.im/dbcli/pgcli")
+            print("Mail: https://groups.google.com/forum/#!forum/pgcli")
+            print("Home: http://pgcli.com")
 
         try:
             while True:
@@ -761,7 +760,7 @@ class PGCli(object):
 
         except (PgCliQuitError, EOFError):
             if not self.less_chatty:
-                print ("Goodbye!")
+                print("Goodbye!")
 
     def _build_cli(self, history):
         key_bindings = pgcli_bindings(self)
@@ -828,11 +827,23 @@ class PGCli(object):
 
             return prompt_app
 
-    def _should_show_limit_prompt(self, status, cur):
-        """returns True if limit prompt should be shown, False otherwise."""
-        if not is_select(status):
+    def _should_limit_output(self, sql, cur):
+        """returns True if the output should be truncated, False otherwise."""
+        if not is_select(sql):
             return False
-        return self.row_limit > 0 and cur and (cur.rowcount > self.row_limit)
+
+        return not self._has_limit(sql) and self.row_limit > 0
+
+    def _has_limit(self, sql):
+        if not sql:
+            return False
+        return "limit " in sql.lower()
+
+    def _limit_output(self, cur):
+        new_cur = itertools.islice(cur, self.row_limit)
+        new_status = "SELECT " + str(self.row_limit)
+
+        return new_cur, new_status
 
     def _evaluate_command(self, text):
         """Used to run a command entered by the user during CLI operation
@@ -865,14 +876,10 @@ class PGCli(object):
             logger.debug("headers: %r", headers)
             logger.debug("rows: %r", cur)
             logger.debug("status: %r", status)
-            threshold = self.row_limit
-            if self._should_show_limit_prompt(status, cur):
-                click.secho(
-                    "The result set has more than %s rows." % threshold, fg="red"
-                )
-                if not click.confirm("Do you want to continue?"):
-                    click.secho("Aborted!", err=True, fg="red")
-                    break
+
+            if self._should_limit_output(sql, cur):
+                click.echo("limit")
+                cur, status = self._limit_output(cur)
 
             if self.pgspecial.auto_expand or self.auto_expand:
                 max_width = self.prompt_app.output.get_size().columns
@@ -1184,9 +1191,8 @@ def cli(
     list_dsn,
     warn,
 ):
-
     if version:
-        print ("Version:", __version__)
+        print("Version:", __version__)
         sys.exit(0)
 
     config_dir = os.path.dirname(config_location())
@@ -1198,12 +1204,11 @@ def cli(
     if os.path.exists(os.path.expanduser("~/.pgclirc")):
         if not os.path.exists(config_full_path):
             shutil.move(os.path.expanduser("~/.pgclirc"), config_full_path)
-            print ("Config file (~/.pgclirc) moved to new location", config_full_path)
+            print("Config file (~/.pgclirc) moved to new location", config_full_path)
         else:
-            print ("Config file is now located at", config_full_path)
-            print (
-                "Please move the existing config file ~/.pgclirc to",
-                config_full_path,
+            print("Config file is now located at", config_full_path)
+            print(
+                "Please move the existing config file ~/.pgclirc to", config_full_path
             )
     if list_dsn:
         try:
@@ -1416,12 +1421,12 @@ def format_output(title, cur, headers, status, settings):
                     column_types.append(int)
                 else:
                     column_types.append(text_type)
+
         formatted = formatter.format_output(cur, headers, **output_kwargs)
         if isinstance(formatted, (text_type)):
             formatted = iter(formatted.splitlines())
         first_line = next(formatted)
         formatted = itertools.chain([first_line], formatted)
-
         if not expanded and max_width and len(first_line) > max_width and headers:
             formatted = formatter.format_output(
                 cur, headers, format_name="vertical", column_types=None, **output_kwargs

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -673,7 +673,7 @@ class PGCli(object):
             if self.pgspecial.timing_enabled:
                 # Only add humanized time display if > 1 second
                 if query.total_time > 1:
-                    print(
+                    print (
                         "Time: %0.03fs (%s), executed in: %0.03fs (%s)"
                         % (
                             query.total_time,
@@ -683,7 +683,7 @@ class PGCli(object):
                         )
                     )
                 else:
-                    print("Time: %0.03fs" % query.total_time)
+                    print ("Time: %0.03fs" % query.total_time)
 
             # Check if we need to update completions, in order of most
             # to least drastic changes
@@ -712,11 +712,11 @@ class PGCli(object):
         self.prompt_app = self._build_cli(history)
 
         if not self.less_chatty:
-            print("Server: PostgreSQL", self.pgexecute.server_version)
-            print("Version:", __version__)
-            print("Chat: https://gitter.im/dbcli/pgcli")
-            print("Mail: https://groups.google.com/forum/#!forum/pgcli")
-            print("Home: http://pgcli.com")
+            print ("Server: PostgreSQL", self.pgexecute.server_version)
+            print ("Version:", __version__)
+            print ("Chat: https://gitter.im/dbcli/pgcli")
+            print ("Mail: https://groups.google.com/forum/#!forum/pgcli")
+            print ("Home: http://pgcli.com")
 
         try:
             while True:
@@ -760,7 +760,7 @@ class PGCli(object):
 
         except (PgCliQuitError, EOFError):
             if not self.less_chatty:
-                print("Goodbye!")
+                print ("Goodbye!")
 
     def _build_cli(self, history):
         key_bindings = pgcli_bindings(self)
@@ -827,7 +827,7 @@ class PGCli(object):
 
             return prompt_app
 
-    def _should_limit_output(self, sql, cur):
+    def _should_limit_output(self, sql):
         """returns True if the output should be truncated, False otherwise."""
         if not is_select(sql):
             return False
@@ -1192,7 +1192,7 @@ def cli(
     warn,
 ):
     if version:
-        print("Version:", __version__)
+        print ("Version:", __version__)
         sys.exit(0)
 
     config_dir = os.path.dirname(config_location())
@@ -1204,11 +1204,12 @@ def cli(
     if os.path.exists(os.path.expanduser("~/.pgclirc")):
         if not os.path.exists(config_full_path):
             shutil.move(os.path.expanduser("~/.pgclirc"), config_full_path)
-            print("Config file (~/.pgclirc) moved to new location", config_full_path)
+            print ("Config file (~/.pgclirc) moved to new location", config_full_path)
         else:
-            print("Config file is now located at", config_full_path)
-            print(
-                "Please move the existing config file ~/.pgclirc to", config_full_path
+            print ("Config file is now located at", config_full_path)
+            print (
+                "Please move the existing config file ~/.pgclirc to",
+                config_full_path,
             )
     if list_dsn:
         try:

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -109,7 +109,7 @@ vi = False
 # Possible values "STOP" or "RESUME"
 on_error = STOP
 
-# Set threshold for row limit prompt. Use 0 to disable prompt.
+# Set threshold for row limit. Use 0 to disable limiting.
 row_limit = 1000
 
 # Skip intro on startup and goodbye on exit

--- a/tests/test_rowlimit.py
+++ b/tests/test_rowlimit.py
@@ -44,36 +44,36 @@ def low_count():
     return low_count_cursor
 
 
-def test_row_limit_with_LIMIT_clause():
+def test_row_limit_with_LIMIT_clause(LIMIT, over_limit):
     cli = PGCli(row_limit=LIMIT)
     stmt = "SELECT * FROM students LIMIT 1000"
 
-    result = cli._should_limit_output(stmt)
+    result = cli._should_limit_output(stmt, over_limit)
     assert result is False
 
     cli = PGCli(row_limit=0)
-    result = cli._should_limit_output(stmt)
+    result = cli._should_limit_output(stmt, over_limit)
     assert result is False
 
 
-def test_row_limit_without_LIMIT_clause():
+def test_row_limit_without_LIMIT_clause(LIMIT, over_limit):
     cli = PGCli(row_limit=LIMIT)
     stmt = "SELECT * FROM students"
 
-    result = cli._should_limit_output(stmt)
+    result = cli._should_limit_output(stmt, over_limit)
     assert result is True
 
     cli = PGCli(row_limit=0)
-    result = cli._should_limit_output(stmt)
+    result = cli._should_limit_output(stmt, over_limit)
     assert result is False
 
 
-def test_row_limit_on_non_select():
+def test_row_limit_on_non_select(over_limit):
     cli = PGCli()
-    stmt = "UPDATE students set name='Boby'"
-    result = cli._should_limit_output(stmt)
+    stmt = "UPDATE students SET name='Boby'"
+    result = cli._should_limit_output(stmt, over_limit)
     assert result is False
 
     cli = PGCli(row_limit=0)
-    result = cli._should_limit_output(stmt)
+    result = cli._should_limit_output(stmt, over_limit)
     assert result is False

--- a/tests/test_rowlimit.py
+++ b/tests/test_rowlimit.py
@@ -1,6 +1,7 @@
-from pgcli.main import PGCli
-from mock import Mock
 import pytest
+from mock import Mock
+
+from pgcli.main import PGCli
 
 
 # We need this fixtures beacause we need PGCli object to be created
@@ -43,40 +44,36 @@ def low_count():
     return low_count_cursor
 
 
-def test_default_row_limit(low_count, over_default):
-    cli = PGCli()
-    stmt = "SELECT * FROM students"
-    result = cli._should_show_limit_prompt(stmt, low_count)
+def test_row_limit_with_LIMIT_clause():
+    cli = PGCli(row_limit=LIMIT)
+    stmt = "SELECT * FROM students LIMIT 1000"
+
+    result = cli._should_limit_output(stmt)
     assert result is False
 
-    result = cli._should_show_limit_prompt(stmt, over_default)
-    assert result is True
+    cli = PGCli(row_limit=0)
+    result = cli._should_limit_output(stmt)
+    assert result is False
 
 
-def test_set_row_limit(over_default, over_limit, LIMIT):
+def test_row_limit_without_LIMIT_clause():
     cli = PGCli(row_limit=LIMIT)
     stmt = "SELECT * FROM students"
-    result = cli._should_show_limit_prompt(stmt, over_default)
-    assert result is False
 
-    result = cli._should_show_limit_prompt(stmt, over_limit)
+    result = cli._should_limit_output(stmt)
     assert result is True
 
-
-def test_no_limit(over_limit):
     cli = PGCli(row_limit=0)
-    stmt = "SELECT * FROM students"
-
-    result = cli._should_show_limit_prompt(stmt, over_limit)
+    result = cli._should_limit_output(stmt)
     assert result is False
 
 
-def test_row_limit_on_non_select(over_default):
+def test_row_limit_on_non_select():
     cli = PGCli()
     stmt = "UPDATE students set name='Boby'"
-    result = cli._should_show_limit_prompt(stmt, None)
+    result = cli._should_limit_output(stmt)
     assert result is False
 
     cli = PGCli(row_limit=0)
-    result = cli._should_show_limit_prompt(stmt, over_default)
+    result = cli._should_limit_output(stmt)
     assert result is False


### PR DESCRIPTION
Opening this PR instead of https://github.com/dbcli/pgcli/pull/1079.

The original PR had some extra commits in it, and I could not find a way to get rid of them.

## Description
I added the changes requested in #1018 to show only the `row_limit` amount of rows if there isn't a LIMIT clause in the query. If LIMIT exists, the output is not truncated.
Also, I completely removed the warning message.

I don't know why some tests regarding output fail, I'll check that and try to fix it.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
