### PR TITLE
Take account of table aliases when completing function args (#1048)

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,7 @@ Features:
 
 * Add `\\G` as a terminator to sql statements that will show the results in expanded mode. This feature is copied from mycli. (Thanks: `Amjith Ramanujam`_)
 * Removed limit prompt and added automatic row limit on queries with no LIMIT clause (#1079) (Thanks: `Sebastian Janko`_)
+* Function argument completions now take account of table aliases (#1048). (Thanks: `Owen Stephens`_)
 
 Bug fixes:
 ----------

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -532,8 +532,8 @@ def suggest_based_on_last_token(token, stmt):
 
 def _suggest_expression(token_v, stmt):
     """
-    Return suggestions for an expression, taking account of the partially-typed
-    identifiers parent, which may be a table alias or schema name.
+    Return suggestions for an expression, taking account of any partially-typed
+    identifier's parent, which may be a table alias or schema name.
     """
     parent = stmt.identifier.get_parent_name() if stmt.identifier else []
     tables = stmt.get_tables()

--- a/tests/test_smart_completion_multiple_schemata.py
+++ b/tests/test_smart_completion_multiple_schemata.py
@@ -229,7 +229,7 @@ def test_suggested_column_names_in_function(completer):
         completer, "SELECT MAX( from custom.products", len("SELECT MAX(")
     )
     assert completions_to_set(result) == completions_to_set(
-        testdata.columns("products", "custom")
+        testdata.columns_functions_and_keywords("products", "custom")
     )
 
 

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -287,7 +287,9 @@ def test_suggested_cased_always_qualified_column_names(completer):
 @parametrize("completer", completers(casing=False, qualify=no_qual))
 def test_suggested_column_names_in_function(completer):
     result = get_result(completer, "SELECT MAX( from users", len("SELECT MAX("))
-    assert completions_to_set(result) == completions_to_set(testdata.columns("users"))
+    assert completions_to_set(result) == completions_to_set(
+        (testdata.columns_functions_and_keywords("users"))
+    )
 
 
 @parametrize("completer", completers(casing=False))

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -101,10 +101,14 @@ def test_where_equals_any_suggests_columns_or_keywords():
     assert set(suggestions) == cols_etc("tabl", last_keyword="WHERE")
 
 
-def test_lparen_suggests_cols():
+def test_lparen_suggests_cols_and_funcs():
     suggestion = suggest_type("SELECT MAX( FROM tbl", "SELECT MAX(")
     assert set(suggestion) == set(
-        [Column(table_refs=((None, "tbl", None, False),), qualifiable=True)]
+        [
+            Column(table_refs=((None, "tbl", None, False),), qualifiable=True),
+            Function(schema=None),
+            Keyword("("),
+        ]
     )
 
 
@@ -268,6 +272,23 @@ def test_distinct_and_order_by_suggestions_with_aliases(
 )
 def test_distinct_and_order_by_suggestions_with_alias_given(text, text_before):
     suggestions = suggest_type(text, text_before)
+    assert set(suggestions) == set(
+        [
+            Column(
+                table_refs=(TableReference(None, "tbl", "x", False),),
+                local_tables=(),
+                qualifiable=False,
+            ),
+            Table(schema="x"),
+            View(schema="x"),
+            Function(schema="x"),
+        ]
+    )
+
+
+def test_function_arguments_with_alias_given():
+    suggestions = suggest_type("SELECT avg(x. FROM tbl x, tbl2 y", "SELECT avg(x.")
+
     assert set(suggestions) == set(
         [
             Column(


### PR DESCRIPTION
## Description

Fixes #1048 so that autocompletion of function arguments takes account of table aliases. 

Now, when given 
```
CREATE TABLE test_table(foo text, bar text);
CREATE TABLE other_test_table(baz integer);
```

When the cursor is at `^` in:
```
SELECT length(tt. FROM test_table tt, other_test_table ott
                ^
```
the autocomplete options are given as
```
bar column
foo column
```
as expected.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
