### PR TITLE
Disable escape-enter keybinding in vi mode

### DIFF
--- a/pgcli/key_bindings.py
+++ b/pgcli/key_bindings.py
@@ -8,6 +8,7 @@ from prompt_toolkit.filters import (
     is_searching,
     has_completions,
     has_selection,
+    vi_mode,
 )
 
 from .pgbuffer import buffer_should_be_handled
@@ -109,7 +110,7 @@ def pgcli_bindings(pgcli):
         _logger.debug("Detected enter key.")
         event.current_buffer.validate_and_handle()
 
-    @kb.add("escape", "enter")
+    @kb.add("escape", "enter", filter=~vi_mode)
     def _(event):
         """Introduces a line break regardless of multi-line mode or not."""
         _logger.debug("Detected alt-enter key.")


### PR DESCRIPTION
## Description 

Escape then enter intended as two separate key presses is a very common
sequence when using vi mode - returning to normal mode from insert mode
(escape) and then submitting the query (enter). The presence of the
escape-enter key binding overrides this behaviour by inserting
undesirable newlines (newline is be easily inserted when in insert mode
by pressing enter) or by introducing a noticable delay/lag before enter
can be pressed after escape, due to prompt toolkit not being able to
recognise escape immediately (since it may form part of an escape-enter
sequence).