### PR TITLE
setup: Simplify getting module version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,7 @@
-import re
-import ast
 import platform
 from setuptools import setup, find_packages
 
-_version_re = re.compile(r"__version__\s+=\s+(.*)")
-
-with open("pgcli/__init__.py", "rb") as f:
-    version = str(
-        ast.literal_eval(_version_re.search(f.read().decode("utf-8")).group(1))
-    )
+from pgcli import __version__
 
 description = "CLI for Postgres Database. With auto-completion and syntax highlighting."
 
@@ -36,7 +29,7 @@ setup(
     name="pgcli",
     author="Pgcli Core Team",
     author_email="pgcli-dev@googlegroups.com",
-    version=version,
+    version=__version__,
     license="BSD",
     url="http://pgcli.com",
     packages=find_packages(),


### PR DESCRIPTION
## Description
Get version of module for setup.py in simpler way - just import it.
Unless you are planning to release postfixed versions (like x.y.z-dev) often, there is IMO no need to use regular expressions and ast to determine version number.
In case this is intentional, regular expression alone should be sufficient solution.

## Checklist
- [ ] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
