### PR TITLE
support ansi escape sequences for prompt colors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -101,6 +101,7 @@ Contributors:
     * Sebastian Janko (sebojanko)
     * Pedro Ferrari (petobens)
     * Martin Matejek (mmtj)
+    * Jonas Jelten
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,7 @@ Upcoming:
 Features:
 ---------
 
+* Add support for ANSI escape sequences for coloring the prompt (#1123).
 * Add `\\G` as a terminator to sql statements that will show the results in expanded mode. This feature is copied from mycli. (Thanks: `Amjith Ramanujam`_)
 * Removed limit prompt and added automatic row limit on queries with no LIMIT clause (#1079) (Thanks: `Sebastian Janko`_)
 * Function argument completions now take account of table aliases (#1048). (Thanks: `Owen Stephens`_)

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -36,6 +36,7 @@ from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
 from prompt_toolkit.shortcuts import PromptSession, CompleteStyle
 from prompt_toolkit.document import Document
 from prompt_toolkit.filters import HasFocus, IsDone
+from prompt_toolkit.formatted_text import ANSI
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.layout.processors import (
     ConditionalProcessor,
@@ -776,7 +777,8 @@ class PGCli(object):
             ):
                 prompt = self.get_prompt("\\d> ")
 
-            return [("class:prompt", prompt)]
+            prompt = prompt.replace("\\x1b", "\x1b")
+            return ANSI(prompt)
 
         def get_continuation(width, line_number, is_soft_wrap):
             continuation = self.multiline_continuation_char * (width - 1) + " "

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -126,6 +126,7 @@ less_chatty = False
 # \# - "@" sign if logged in as superuser, '>' in other case
 # \n - Newline
 # \dsn_alias - name of dsn alias if -D option is used (empty otherwise)
+# \x1b[...m - insert ANSI escape sequence
 prompt = '\u@\h:\d> '
 
 # Number of lines to reserve for the suggestion menu


### PR DESCRIPTION
## Description

support for ansi escape sequences:

my config file:
```
prompt = '\x1b[37m[\h] \x1b[92;1m\u\x1b[36m@\x1b[34m\d\x1b[0m \# '
```

resulting pgcli prompt:

![2019-11-25-224203_1069x118_scrot](https://user-images.githubusercontent.com/673543/69580569-1d2a8d00-0fd5-11ea-8847-b89546a43016.png)



## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [ ] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
