### PR TITLE
add main file to allow python3 -m pgcli execution

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,10 +1,19 @@
+Upcoming:
+======
+
+Features:
+---------
+
+* Add `__main__.py` file to execute pgcli as a package directly (#1123).
+* Add support for ANSI escape sequences for coloring the prompt (#1122).
+
+
 2.2.0:
 ======
 
 Features:
 ---------
 
-* Add support for ANSI escape sequences for coloring the prompt (#1123).
 * Add `\\G` as a terminator to sql statements that will show the results in expanded mode. This feature is copied from mycli. (Thanks: `Amjith Ramanujam`_)
 * Removed limit prompt and added automatic row limit on queries with no LIMIT clause (#1079) (Thanks: `Sebastian Janko`_)
 * Function argument completions now take account of table aliases (#1048). (Thanks: `Owen Stephens`_)

--- a/pgcli/__main__.py
+++ b/pgcli/__main__.py
@@ -1,0 +1,9 @@
+"""
+pgcli package main entry point
+"""
+
+from .main import cli
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Description

To execute pgcli as python package, I've added a [`__main__.py`](https://docs.python.org/3/library/__main__.html) file.

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [ ] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
