### PR TITLE
Fix warning raised for using `is not` to compare string literal

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -103,6 +103,7 @@ Contributors:
     * Martin Matejek (mmtj)
     * Jonas Jelten
     * BrownShibaDog
+    * George Thomas(thegeorgeous)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -7,11 +7,15 @@ Features:
 * Add `__main__.py` file to execute pgcli as a package directly (#1123).
 * Add support for ANSI escape sequences for coloring the prompt (#1122).
 
+Bug fixes:
+
+* Fix warning raised for using `is not` to compare string literal
+
 Internal:
 ---------
 
 * Fix dead link in development guide. (Thanks: `BrownShibaDog`_)
-  
+
 2.2.0:
 ======
 
@@ -1023,3 +1027,4 @@ Improvements:
 .. _`Sebastian Janko`: https://github.com/sebojanko
 .. _`Pedro Ferrari`: https://github.com/petobens
 .. _`BrownShibaDog`: https://github.com/BrownShibaDog
+.. _`thegeorgeous`: https://github.com/thegeorgeous

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1258,7 +1258,7 @@ def cli(
     if list_databases:
         database = "postgres"
 
-    if dsn is not "":
+    if dsn != "":
         try:
             cfg = load_config(pgclirc, config_full_path)
             dsn_config = cfg["alias_dsn"][dsn]


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->

Using `is not` for comparing string literals raises warning that != should be
used.

Fixes #1138 

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
