### PR TITLE
 Fix exception in thread completion_refresh caused by KeyError in extend_foreignkeys call

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -104,6 +104,7 @@ Contributors:
     * Jonas Jelten
     * BrownShibaDog
     * George Thomas(thegeorgeous)
+    * Anton Troyanov
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,7 @@ Features:
 Bug fixes:
 
 * Fix warning raised for using `is not` to compare string literal
+* Fix exception in thread completion_refresh caused by KeyError in extend_foreignkeys call
 
 Internal:
 ---------

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -275,6 +275,8 @@ class PGCompleter(Completer):
             parentschema, childschema = e([fk.parentschema, fk.childschema])
             parenttable, childtable = e([fk.parenttable, fk.childtable])
             childcol, parcol = e([fk.childcolumn, fk.parentcolumn])
+            if childtable not in meta[childschema]:
+                continue
             childcolmeta = meta[childschema][childtable][childcol]
             parcolmeta = meta[parentschema][parenttable][parcol]
             fk = ForeignKey(

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -275,8 +275,6 @@ class PGCompleter(Completer):
             parentschema, childschema = e([fk.parentschema, fk.childschema])
             parenttable, childtable = e([fk.parenttable, fk.childtable])
             childcol, parcol = e([fk.childcolumn, fk.parentcolumn])
-            if childtable not in meta[childschema]:
-                continue
             childcolmeta = meta[childschema][childtable][childcol]
             parcolmeta = meta[parentschema][parenttable][parcol]
             fk = ForeignKey(

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -515,11 +515,12 @@ class PGExecute(object):
             cur.execute(self.schemata_query)
             return [x[0] for x in cur.fetchall()]
 
-    def _relations(self, kinds=("r", "v", "m")):
+    def _relations(self, kinds=("r", "p", "v", "m")):
         """Get table or view name metadata
 
         :param kinds: list of postgres relkind filters:
                 'r' - table
+                'p' - partitioned table
                 'v' - view
                 'm' - materialized view
         :return: (schema_name, rel_name) tuples
@@ -534,7 +535,7 @@ class PGExecute(object):
 
     def tables(self):
         """Yields (schema_name, table_name) tuples"""
-        for row in self._relations(kinds=["r"]):
+        for row in self._relations(kinds=["r", "p"]):
             yield row
 
     def views(self):
@@ -545,11 +546,12 @@ class PGExecute(object):
         for row in self._relations(kinds=["v", "m"]):
             yield row
 
-    def _columns(self, kinds=("r", "v", "m")):
+    def _columns(self, kinds=("r", "p", "v", "m")):
         """Get column metadata for tables and views
 
         :param kinds: kinds: list of postgres relkind filters:
                 'r' - table
+                'p' - partitioned table
                 'v' - view
                 'm' - materialized view
         :return: list of (schema_name, relation_name, column_name, column_type) tuples
@@ -603,7 +605,7 @@ class PGExecute(object):
                 yield row
 
     def table_columns(self):
-        for row in self._columns(kinds=["r"]):
+        for row in self._columns(kinds=["r", "p"]):
             yield row
 
     def view_columns(self):


### PR DESCRIPTION
## Description
When starting pgcli you could see such an Exception
```
Exception in thread completion_refresh:
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.8/3.8.1/Frameworks/Python.framework/Versions/3.8/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
postgres@localhost:postgres>   File "/usr/local/Cellar/python@3.8/3.8.1/Frameworks/Python.framework/Versions/3.8/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/Cellar/pgcli/2.2.0_1/libexec/lib/python3.8/site-packages/pgcli/completion_refresher.py", line 65, in _bg_refresh
                                 refresher(completer, executor)
  File "/usr/local/Cellar/pgcli/2.2.0_1/libexec/lib/python3.8/site-packages/pgcli/completion_refresher.py", line 110, in refresh_tables
    completer.extend_foreignkeys(executor.foreignkeys())
  File "/usr/local/Cellar/pgcli/2.2.0_1/libexec/lib/python3.8/site-packages/pgcli/pgcompleter.py", line 278, in extend_foreignkeys
    childcolmeta = meta[childschema][childtable][childcol]s-mode     Refreshing completions...
KeyError: {table_name_here}
```

Error occurs when your schema contains partitioned table with foreign key.
More information can be found here:
https://github.com/dbcli/pgcli/issues/675#issuecomment-503631853

I've added a simple if-statement to check if key exists just not to throw an exeption. 

I think at least those two issues are connected to that error:
https://github.com/dbcli/pgcli/issues/1133
https://github.com/dbcli/pgcli/issues/675


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)