### PR TITLE
Fix: Unable to drop previously connected-to database

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -105,6 +105,7 @@ Contributors:
     * BrownShibaDog
     * George Thomas(thegeorgeous)
     * Yoni Nakache(lazydba247)
+    * Gantsev Denis
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,7 @@ Features:
 Bug fixes:
 
 * Fix warning raised for using `is not` to compare string literal
+* Close open connection in completion_refresher thread
 
 Internal:
 ---------

--- a/pgcli/completion_refresher.py
+++ b/pgcli/completion_refresher.py
@@ -84,7 +84,7 @@ class CompletionRefresher(object):
         for callback in callbacks:
             callback(completer)
 
-        if not settings.get("single_connection"):
+        if not settings.get("single_connection") and executor.conn:
             # close connection established with pgexecute.copy()
             executor.conn.close()
 

--- a/pgcli/completion_refresher.py
+++ b/pgcli/completion_refresher.py
@@ -84,6 +84,10 @@ class CompletionRefresher(object):
         for callback in callbacks:
             callback(completer)
 
+        if not settings.get("single_connection"):
+            # close connection established with pgexecute.copy()
+            executor.conn.close()
+
 
 def refresher(name, refreshers=CompletionRefresher.refreshers):
     """Decorator to populate the dictionary of refreshers with the current


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Closing connection explicitly in completion_refresher thread easily fixes https://github.com/dbcli/pgcli/issues/1151

Before fix:
```
postgres=# select datid, datname, pid, application_name, client_addr, state from pg_stat_activity where datname != '';
 datid | datname  |  pid  |     application_name     | client_addr | state  
-------+----------+-------+--------------------------+-------------+--------
 12707 | postgres |  4092 | psql                     |             | active
 19780 | mydb1    | 17843 | pgcli-completion_refresh | ::1         | idle
 12707 | postgres | 17825 | pgcli-completion_refresh | ::1         | idle
 19780 | mydb1    | 17841 | pgcli-MainThread         | ::1         | idle
(4 rows)

...

postgres=# select datid, datname, pid, application_name, client_addr, state from pg_stat_activity where datname != '';
 datid | datname  |  pid  |     application_name     | client_addr | state  
-------+----------+-------+--------------------------+-------------+--------
 12707 | postgres |  4092 | psql                     |             | active
 19780 | mydb1    | 17843 | pgcli-completion_refresh | ::1         | idle
 12707 | postgres | 17825 | pgcli-completion_refresh | ::1         | idle
 12707 | postgres | 20221 | pgcli-completion_refresh | ::1         | idle
 12707 | postgres | 20219 | pgcli-MainThread         | ::1         | idle
(5 rows)

...

postgres=# select datid, datname, pid, application_name, client_addr, state from pg_stat_activity where datname != '';
 datid | datname  |  pid  |     application_name     | client_addr | state  
-------+----------+-------+--------------------------+-------------+--------
 12707 | postgres |  4092 | psql                     |             | active
 19780 | mydb1    | 17843 | pgcli-completion_refresh | ::1         | idle
 12707 | postgres | 17825 | pgcli-completion_refresh | ::1         | idle
 12707 | postgres | 20221 | pgcli-completion_refresh | ::1         | idle
 19780 | mydb1    | 20259 | pgcli-completion_refresh | ::1         | idle
 19780 | mydb1    | 20240 | pgcli-MainThread         | ::1         | idle
(6 rows)

```
After fix:
```
postgres=# select datid, datname, pid, application_name, client_addr, state, query from pg_stat_activity where datname != '';
 datid | datname  |  pid  | application_name | client_addr | state  |                                                       query                                                        
-------+----------+-------+------------------+-------------+--------+--------------------------------------------------------------------------------------------------------------------
 12707 | postgres |  4092 | psql             |             | active | select datid, datname, pid, application_name, client_addr, state, query from pg_stat_activity where datname != '';
 19791 | mydb2    | 22461 | pgcli-MainThread | ::1         | idle   | select t.oid FROM pg_type t WHERE t.typname = 'hstore' and t.typisdefined
(2 rows)

...

postgres=# select datid, datname, pid, application_name, client_addr, state, query from pg_stat_activity where datname != '';
 datid | datname  |  pid  | application_name | client_addr | state  |                                                       query                                                        
-------+----------+-------+------------------+-------------+--------+--------------------------------------------------------------------------------------------------------------------
 12707 | postgres |  4092 | psql             |             | active | select datid, datname, pid, application_name, client_addr, state, query from pg_stat_activity where datname != '';
 19780 | mydb1    | 22495 | pgcli-MainThread | ::1         | idle   | select t.oid FROM pg_type t WHERE t.typname = 'hstore' and t.typisdefined
(2 rows)

```
P.S. I ran `black`, but `pre-commit` is buggy and assumes python3.7, while I am inside virtualenv with python3.8..
## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
