### PR TITLE
Deprecate Python2.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: required
 language: python
 
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/README.rst
+++ b/README.rst
@@ -281,6 +281,8 @@ choice:
 
     In [3]: my_result = _
 
+Pgcli only runs on Python3.6+ since 2.2.0, if you use an old version of Python,
+you should use install ``pgcli <= 2.2.0``.
 
 Thanks:
 -------

--- a/changelog.rst
+++ b/changelog.rst
@@ -16,6 +16,7 @@ Internal:
 ---------
 
 * Drop Python3.4 support. (Thanks: `laixintao`_)
+* Drop Python2.7 support. (Thanks: `laixintao`_)
 * Fix dead link in development guide. (Thanks: `BrownShibaDog`_)
 
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -363,7 +363,7 @@ class PGCli(object):
                     user=user,
                     host=host,
                     port=port,
-                    **self.pgexecute.extra_args
+                    **self.pgexecute.extra_args,
                 )
             except OperationalError as e:
                 click.secho(str(e), err=True, fg="red")

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -363,7 +363,7 @@ class PGCli(object):
                     user=user,
                     host=host,
                     port=port,
-                    **self.pgexecute.extra_args,
+                    **self.pgexecute.extra_args
                 )
             except OperationalError as e:
                 click.secho(str(e), err=True, fg="red")

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -201,7 +201,7 @@ class PGExecute(object):
         host=None,
         port=None,
         dsn=None,
-        **kwargs,
+        **kwargs
     ):
         self._conn_params = {}
         self.conn = None
@@ -227,7 +227,7 @@ class PGExecute(object):
         host=None,
         port=None,
         dsn=None,
-        **kwargs,
+        **kwargs
     ):
 
         conn_params = self._conn_params.copy()

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -201,7 +201,7 @@ class PGExecute(object):
         host=None,
         port=None,
         dsn=None,
-        **kwargs
+        **kwargs,
     ):
         self._conn_params = {}
         self.conn = None
@@ -227,7 +227,7 @@ class PGExecute(object):
         host=None,
         port=None,
         dsn=None,
-        **kwargs
+        **kwargs,
     ):
 
         conn_params = self._conn_params.copy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target-version = ['py27']
+target-version = ['py36']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target-version = ['py36']
+target-version = ['py35']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: Unix",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -240,10 +240,10 @@ def expanded(request):
 @dbtest
 def test_unicode_support_in_output(executor, expanded):
     run(executor, "create table unicodechars(t text)")
-    run(executor, "insert into unicodechars (t) values ('é')")
+    run(executor, u"insert into unicodechars (t) values ('é')")
 
     # See issue #24, this raises an exception without proper handling
-    assert "é" in run(
+    assert u"é" in run(
         executor, "select * from unicodechars", join=True, expanded=expanded
     )
 
@@ -304,10 +304,10 @@ def test_multiple_queries_with_special_command_same_line(executor, pgspecial):
 def test_multiple_queries_same_line_syntaxerror(executor, exception_formatter):
     result = run(
         executor,
-        "select 'fooé'; invalid syntax é",
+        u"select 'fooé'; invalid syntax é",
         exception_formatter=exception_formatter,
     )
-    assert "fooé" in result[3]
+    assert u"fooé" in result[3]
     assert 'syntax error at or near "invalid"' in result[-1]
 
 
@@ -319,8 +319,8 @@ def pgspecial():
 @dbtest
 def test_special_command_help(executor, pgspecial):
     result = run(executor, "\\?", pgspecial=pgspecial)[1].split("|")
-    assert "Command" in result[1]
-    assert "Description" in result[2]
+    assert u"Command" in result[1]
+    assert u"Description" in result[2]
 
 
 @dbtest
@@ -328,42 +328,42 @@ def test_bytea_field_support_in_output(executor):
     run(executor, "create table binarydata(c bytea)")
     run(executor, "insert into binarydata (c) values (decode('DEADBEEF', 'hex'))")
 
-    assert "\\xdeadbeef" in run(executor, "select * from binarydata", join=True)
+    assert u"\\xdeadbeef" in run(executor, "select * from binarydata", join=True)
 
 
 @dbtest
 def test_unicode_support_in_unknown_type(executor):
-    assert "日本語" in run(executor, "SELECT '日本語' AS japanese;", join=True)
+    assert u"日本語" in run(executor, u"SELECT '日本語' AS japanese;", join=True)
 
 
 @dbtest
 def test_unicode_support_in_enum_type(executor):
-    run(executor, "CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy', '日本語')")
-    run(executor, "CREATE TABLE person (name TEXT, current_mood mood)")
-    run(executor, "INSERT INTO person VALUES ('Moe', '日本語')")
-    assert "日本語" in run(executor, "SELECT * FROM person", join=True)
+    run(executor, u"CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy', '日本語')")
+    run(executor, u"CREATE TABLE person (name TEXT, current_mood mood)")
+    run(executor, u"INSERT INTO person VALUES ('Moe', '日本語')")
+    assert u"日本語" in run(executor, u"SELECT * FROM person", join=True)
 
 
 @requires_json
 def test_json_renders_without_u_prefix(executor, expanded):
-    run(executor, "create table jsontest(d json)")
-    run(executor, """insert into jsontest (d) values ('{"name": "Éowyn"}')""")
+    run(executor, u"create table jsontest(d json)")
+    run(executor, u"""insert into jsontest (d) values ('{"name": "Éowyn"}')""")
     result = run(
-        executor, "SELECT d FROM jsontest LIMIT 1", join=True, expanded=expanded
+        executor, u"SELECT d FROM jsontest LIMIT 1", join=True, expanded=expanded
     )
 
-    assert '{"name": "Éowyn"}' in result
+    assert u'{"name": "Éowyn"}' in result
 
 
 @requires_jsonb
 def test_jsonb_renders_without_u_prefix(executor, expanded):
     run(executor, "create table jsonbtest(d jsonb)")
-    run(executor, """insert into jsonbtest (d) values ('{"name": "Éowyn"}')""")
+    run(executor, u"""insert into jsonbtest (d) values ('{"name": "Éowyn"}')""")
     result = run(
         executor, "SELECT d FROM jsonbtest LIMIT 1", join=True, expanded=expanded
     )
 
-    assert '{"name": "Éowyn"}' in result
+    assert u'{"name": "Éowyn"}' in result
 
 
 @dbtest

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -240,10 +240,10 @@ def expanded(request):
 @dbtest
 def test_unicode_support_in_output(executor, expanded):
     run(executor, "create table unicodechars(t text)")
-    run(executor, u"insert into unicodechars (t) values ('é')")
+    run(executor, "insert into unicodechars (t) values ('é')")
 
     # See issue #24, this raises an exception without proper handling
-    assert u"é" in run(
+    assert "é" in run(
         executor, "select * from unicodechars", join=True, expanded=expanded
     )
 
@@ -304,10 +304,10 @@ def test_multiple_queries_with_special_command_same_line(executor, pgspecial):
 def test_multiple_queries_same_line_syntaxerror(executor, exception_formatter):
     result = run(
         executor,
-        u"select 'fooé'; invalid syntax é",
+        "select 'fooé'; invalid syntax é",
         exception_formatter=exception_formatter,
     )
-    assert u"fooé" in result[3]
+    assert "fooé" in result[3]
     assert 'syntax error at or near "invalid"' in result[-1]
 
 
@@ -319,8 +319,8 @@ def pgspecial():
 @dbtest
 def test_special_command_help(executor, pgspecial):
     result = run(executor, "\\?", pgspecial=pgspecial)[1].split("|")
-    assert u"Command" in result[1]
-    assert u"Description" in result[2]
+    assert "Command" in result[1]
+    assert "Description" in result[2]
 
 
 @dbtest
@@ -328,42 +328,42 @@ def test_bytea_field_support_in_output(executor):
     run(executor, "create table binarydata(c bytea)")
     run(executor, "insert into binarydata (c) values (decode('DEADBEEF', 'hex'))")
 
-    assert u"\\xdeadbeef" in run(executor, "select * from binarydata", join=True)
+    assert "\\xdeadbeef" in run(executor, "select * from binarydata", join=True)
 
 
 @dbtest
 def test_unicode_support_in_unknown_type(executor):
-    assert u"日本語" in run(executor, u"SELECT '日本語' AS japanese;", join=True)
+    assert "日本語" in run(executor, "SELECT '日本語' AS japanese;", join=True)
 
 
 @dbtest
 def test_unicode_support_in_enum_type(executor):
-    run(executor, u"CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy', '日本語')")
-    run(executor, u"CREATE TABLE person (name TEXT, current_mood mood)")
-    run(executor, u"INSERT INTO person VALUES ('Moe', '日本語')")
-    assert u"日本語" in run(executor, u"SELECT * FROM person", join=True)
+    run(executor, "CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy', '日本語')")
+    run(executor, "CREATE TABLE person (name TEXT, current_mood mood)")
+    run(executor, "INSERT INTO person VALUES ('Moe', '日本語')")
+    assert "日本語" in run(executor, "SELECT * FROM person", join=True)
 
 
 @requires_json
 def test_json_renders_without_u_prefix(executor, expanded):
-    run(executor, u"create table jsontest(d json)")
-    run(executor, u"""insert into jsontest (d) values ('{"name": "Éowyn"}')""")
+    run(executor, "create table jsontest(d json)")
+    run(executor, """insert into jsontest (d) values ('{"name": "Éowyn"}')""")
     result = run(
-        executor, u"SELECT d FROM jsontest LIMIT 1", join=True, expanded=expanded
+        executor, "SELECT d FROM jsontest LIMIT 1", join=True, expanded=expanded
     )
 
-    assert u'{"name": "Éowyn"}' in result
+    assert '{"name": "Éowyn"}' in result
 
 
 @requires_jsonb
 def test_jsonb_renders_without_u_prefix(executor, expanded):
     run(executor, "create table jsonbtest(d jsonb)")
-    run(executor, u"""insert into jsonbtest (d) values ('{"name": "Éowyn"}')""")
+    run(executor, """insert into jsonbtest (d) values ('{"name": "Éowyn"}')""")
     result = run(
         executor, "SELECT d FROM jsonbtest LIMIT 1", join=True, expanded=expanded
     )
 
-    assert u'{"name": "Éowyn"}' in result
+    assert '{"name": "Éowyn"}' in result
 
 
 @dbtest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py35, py36, py37
 [testenv]
 deps = pytest>=2.7.0,<=3.0.7
     mock>=1.0.1


### PR DESCRIPTION
So we can use latest version of prompt-toolit.
Relate: https://github.com/dbcli/pgcli/pull/1149



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
