### PR TITLE
upgrade coverage to 5.x

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ tox>=1.9.2
 behave>=1.2.4
 pexpect==3.3
 pre-commit>=1.16.0
-coverage==4.3.4
+coverage==5.0.4
 codecov>=1.5.1
 docutils>=0.13.1
 autopep8==1.3.3


### PR DESCRIPTION
## Description

This fixes the coverage issue from #1157 , it tunes out that the version of `coverage.py` we are using is broken on Python3.8, which produces some phantom lines. see https://github.com/nedbat/coveragepy/issues/714 (which is actually interesting).

So simply upgrade coverage.py solves the problen.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
