### PR TITLE
show_bottom_toolbar - Feature to Show/Hide Toolbar

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -106,6 +106,7 @@ Contributors:
     * George Thomas(thegeorgeous)
     * Yoni Nakache(lazydba247)
     * Gantsev Denis
+    * Stephano Paraskeva
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -7,6 +7,7 @@ Features:
 * Add `__main__.py` file to execute pgcli as a package directly (#1123).
 * Add support for ANSI escape sequences for coloring the prompt (#1122).
 * Add support for partitioned tables (relkind "p").
+* Add config option show_bottom_toolbar.
 
 Bug fixes:
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -7,7 +7,6 @@ Features:
 * Add `__main__.py` file to execute pgcli as a package directly (#1123).
 * Add support for ANSI escape sequences for coloring the prompt (#1122).
 * Add support for partitioned tables (relkind "p").
-* Add show_bottom_toolbar config option.
 
 Bug fixes:
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -7,6 +7,7 @@ Features:
 * Add `__main__.py` file to execute pgcli as a package directly (#1123).
 * Add support for ANSI escape sequences for coloring the prompt (#1122).
 * Add support for partitioned tables (relkind "p").
+* Add show_bottom_toolbar config option.
 
 Bug fixes:
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -160,7 +160,6 @@ class PGCli(object):
         prompt_dsn=None,
         auto_vertical_output=False,
         warn=None,
-        show_bottom_toolbar=False,
     ):
 
         self.force_passwd_prompt = force_passwd_prompt

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -212,7 +212,9 @@ class PGCli(object):
         self.decimal_format = c["data_formats"]["decimal"]
         self.float_format = c["data_formats"]["float"]
         self.initialize_keyring()
-        self.show_bottom_toolbar = bool(show_bottom_toolbar) or c["main"].as_bool("show_bottom_toolbar")
+        self.show_bottom_toolbar = bool(show_bottom_toolbar) or c["main"].as_bool(
+            "show_bottom_toolbar"
+        )
 
         self.pgspecial.pset_pager(
             self.config["main"].as_bool("enable_pager") and "on" or "off"

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -160,6 +160,7 @@ class PGCli(object):
         prompt_dsn=None,
         auto_vertical_output=False,
         warn=None,
+        show_bottom_toolbar=False,
     ):
 
         self.force_passwd_prompt = force_passwd_prompt
@@ -211,6 +212,7 @@ class PGCli(object):
         self.decimal_format = c["data_formats"]["decimal"]
         self.float_format = c["data_formats"]["float"]
         self.initialize_keyring()
+        self.show_bottom_toolbar = bool(show_bottom_toolbar) or c["main"].as_bool("show_bottom_toolbar")
 
         self.pgspecial.pset_pager(
             self.config["main"].as_bool("enable_pager") and "on" or "off"
@@ -792,7 +794,7 @@ class PGCli(object):
                 reserve_space_for_menu=self.min_num_menu_lines,
                 message=get_message,
                 prompt_continuation=get_continuation,
-                bottom_toolbar=get_toolbar_tokens,
+                bottom_toolbar=get_toolbar_tokens if self.show_bottom_toolbar else None,
                 complete_style=complete_style,
                 input_processors=[
                     # Highlight matching brackets while editing.

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -214,9 +214,7 @@ class PGCli(object):
         self.decimal_format = c["data_formats"]["decimal"]
         self.float_format = c["data_formats"]["float"]
         self.initialize_keyring()
-        self.show_bottom_toolbar = bool(show_bottom_toolbar) or c["main"].as_bool(
-            "show_bottom_toolbar"
-        )
+        self.show_bottom_toolbar = c["main"].as_bool("show_bottom_toolbar")
 
         self.pgspecial.pset_pager(
             self.config["main"].as_bool("enable_pager") and "on" or "off"

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -87,7 +87,7 @@ search_path_filter = False
 timing = True
 
 # Show/hide the informational toolbar with function keymap at the footer.
-show_bottom_toolbar= False
+show_bottom_toolbar= True
 
 # Table format. Possible values: psql, plain, simple, grid, fancy_grid, pipe,
 # ascii, double, github, orgtbl, rst, mediawiki, html, latex, latex_booktabs,

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -87,7 +87,7 @@ search_path_filter = False
 timing = True
 
 # Show/hide the informational toolbar with function keymap at the footer.
-show_bottom_toolbar= True
+show_bottom_toolbar = True
 
 # Table format. Possible values: psql, plain, simple, grid, fancy_grid, pipe,
 # ascii, double, github, orgtbl, rst, mediawiki, html, latex, latex_booktabs,

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -87,7 +87,7 @@ search_path_filter = False
 timing = True
 
 # Show/hide the informational toolbar with function keymap at the footer.
-show_bottom_toolbar = True
+show_bottom_toolbar = False
 
 # Table format. Possible values: psql, plain, simple, grid, fancy_grid, pipe,
 # ascii, double, github, orgtbl, rst, mediawiki, html, latex, latex_booktabs,

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -87,7 +87,7 @@ search_path_filter = False
 timing = True
 
 # Show/hide the informational toolbar with function keymap at the footer.
-show_bottom_toolbar = False
+show_bottom_toolbar = True
 
 # Table format. Possible values: psql, plain, simple, grid, fancy_grid, pipe,
 # ascii, double, github, orgtbl, rst, mediawiki, html, latex, latex_booktabs,

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -86,6 +86,9 @@ search_path_filter = False
 # Timing of sql statments and table rendering.
 timing = True
 
+# Show/hide the informational toolbar with function keymap at the footer.
+show_bottom_toolbar= False
+
 # Table format. Possible values: psql, plain, simple, grid, fancy_grid, pipe,
 # ascii, double, github, orgtbl, rst, mediawiki, html, latex, latex_booktabs,
 # textile, moinmoin, jira, vertical, tsv, csv.
@@ -142,7 +145,7 @@ null_string = '<null>'
 # manage pager on startup
 enable_pager = True
 
-# Use keyring to automatically save and load password in a secure manner 
+# Use keyring to automatically save and load password in a secure manner
 keyring = True
 
 # Custom colors for the completion menu, toolbar, etc.


### PR DESCRIPTION
First open source commit! 🍻

## Description
This change introduces `show_bottom_toolbar` config option in pgclirc of True or False. Defaulting to True.

### If False the toolbar will be hidden.
<img width="640" alt="Screenshot 2020-04-17 at 23 34 34" src="https://user-images.githubusercontent.com/40718272/79619189-175c5200-8104-11ea-8eb9-284d84b9200c.png">

### If True the toolbar will be visible.
<img width="630" alt="Screenshot 2020-04-17 at 23 35 05" src="https://user-images.githubusercontent.com/40718272/79619199-1cb99c80-8104-11ea-8fd4-2ddfccf9eb5b.png">


This change was requested [here](https://github.com/dbcli/pgcli/issues/939#issuecomment-615469759).

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
