### PR TITLE
bugfix: don't echo a newline when output is empty.

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -660,7 +660,8 @@ class PGCli(object):
                     except IOError as e:
                         click.secho(str(e), err=True, fg="red")
                 else:
-                    self.echo_via_pager("\n".join(output))
+                    if output:
+                        self.echo_via_pager("\n".join(output))
             except KeyboardInterrupt:
                 pass
 


### PR DESCRIPTION
## Description
fix https://github.com/dbcli/pgcli/issues/1169



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
