### PR TITLE
add python_requires constraint to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     long_description=open("README.rst").read(),
     install_requires=install_requirements,
     extras_require={"keyring": ["keyring >= 12.2.0"]},
+    python_requires=">=3.6",
     entry_points="""
         [console_scripts]
         pgcli=pgcli.main:cli


### PR DESCRIPTION
## Description
It has been brought to my attention that without this line pip may try to install packages on environments with python 2. At the moment it does not happen because prompt_toolkit has this constraint, but it's still better to have it explicit. 



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
