### PR TITLE
Add custom color

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -110,6 +110,7 @@ Contributors:
     * Panos Mavrogiorgos (pmav99)
     * Igor Kim (igorkim)
     * Anthony DeBarros (anthonydb)
+    * Seungyong Kwak (GUIEEN)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -7,7 +7,7 @@ Features:
 * Make the output more compact by removing the empty newline. (Thanks: `laixintao`_)
 * Add support for using [pspg](https://github.com/okbob/pspg) as a pager (#1102)
 * Update python version in Dockerfile
-* Support setting color for null value
+* Support setting color for null, string, number, keyword value
 
 Bug fixes:
 ----------

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -170,6 +170,9 @@ arg-toolbar = 'noinherit bold'
 arg-toolbar.text = 'nobold'
 bottom-toolbar.transaction.valid = 'bg:#222222 #00ff5f bold'
 bottom-toolbar.transaction.failed = 'bg:#222222 #ff005f bold'
+literal.string = '#ba2121'
+literal.number = '#666666'
+keyword = 'bold #008000'
 
 # style classes for colored table output
 output.header = "#00ff5f bold"

--- a/pgcli/pgstyle.py
+++ b/pgcli/pgstyle.py
@@ -35,6 +35,9 @@ TOKEN_TO_PROMPT_STYLE = {
     Token.Output.OddRow: "output.odd-row",
     Token.Output.EvenRow: "output.even-row",
     Token.Output.Null: "output.null",
+    Token.Literal.String: "literal.string",
+    Token.Literal.Number: "literal.number",
+    Token.Keyword: "keyword",
 }
 
 # reverse dict for cli_helpers, because they still expect Pygments tokens.


### PR DESCRIPTION
## Description

Since the only way to customize the string, number, keyword color is by changing through `syntax_style = <given_style>`,
I added some custom color types which will overwrite prompt_toolkit's style color via `merge_styles` func.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
