### PR TITLE
More explicit error message when DSN alias is not found

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -111,6 +111,7 @@ Contributors:
     * Igor Kim (igorkim)
     * Anthony DeBarros (anthonydb)
     * Seungyong Kwak (GUIEEN)
+    * Tom Caruso (tomplex)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -15,6 +15,7 @@ Bug fixes:
 
 * Minor typo fixes in `pgclirc`. (Thanks: `anthonydb`_)
 * Fix for list index out of range when executing commands from a file (#1193). (Thanks: `Irina Truong`_)
+* More explicit error message when connecting using DSN alias and it is not found.
 
 3.0.0
 =====

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1284,7 +1284,15 @@ def cli(
         try:
             cfg = load_config(pgclirc, config_full_path)
             dsn_config = cfg["alias_dsn"][dsn]
-        except:
+        except KeyError:
+            click.secho(
+                f"Could not find a DSN with alias {dsn}. "
+                'Please check the "[alias_dsn]" section in pgclirc.',
+                err=True,
+                fg="red",
+            )
+            exit(1)
+        except Exception:
             click.secho(
                 "Invalid DSNs found in the config file. "
                 'Please check the "[alias_dsn]" section in pgclirc.',


### PR DESCRIPTION
## Description

Today I made a typo in a DSN alias while connecting, and the "invalid DSN" error made me look at my pgcli config file, wondering how it changed, before I realized I just misspelled the alias. So I figured it might be nice to make the error for that case more explicit.

I'm happy to add a test or two but I couldn't find any other tests for the `cli` function / error cases to base it off of.


## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
