### PR TITLE
Move from humanize to pendulum library for displaying query duration

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -111,6 +111,7 @@ Contributors:
     * Igor Kim (igorkim)
     * Anthony DeBarros (anthonydb)
     * Seungyong Kwak (GUIEEN)
+    * Tom Caruso (tomplex)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -15,6 +15,7 @@ Bug fixes:
 
 * Minor typo fixes in `pgclirc`. (Thanks: `anthonydb`_)
 * Fix for list index out of range when executing commands from a file (#1193). (Thanks: `Irina Truong`_)
+* Move from `humanize` to `pendulum` for displaying query durations (#1015)
 
 3.0.0
 =====

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -15,7 +15,7 @@ import logging
 import threading
 import shutil
 import functools
-import humanize
+import pendulum
 import datetime as dt
 import itertools
 import platform
@@ -692,9 +692,9 @@ class PGCli(object):
                         "Time: %0.03fs (%s), executed in: %0.03fs (%s)"
                         % (
                             query.total_time,
-                            humanize.time.naturaldelta(query.total_time),
+                            pendulum.Duration(seconds=query.total_time).in_words(),
                             query.execution_time,
-                            humanize.time.naturaldelta(query.execution_time),
+                            pendulum.Duration(seconds=query.execution_time).in_words(),
                         )
                     )
                 else:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requirements = [
     "psycopg2 >= 2.8",
     "sqlparse >=0.3.0,<0.4",
     "configobj >= 5.0.6",
-    "humanize >= 0.5.1",
+    "pendulum>=2.1.0",
     "cli_helpers[styles] >= 2.0.0",
 ]
 


### PR DESCRIPTION
## Description

As per #1015, this removes the `humanize` library in favor of `pendulum` for showing query duration. It does add `dateutil` and `pytzdata` as dependencies, which may not be desirable - just thought I'd throw it out there since it was such an easy change.


## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
