### PR TITLE
Support history_file configuration per dsn, and --history option.

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1194,6 +1194,9 @@ class PGCli(object):
 @click.option(
     "--warn/--no-warn", default=None, help="Warn before running a destructive query."
 )
+@click.option(
+    "--history", default=None, help="Specify history file location."
+)
 @click.argument("dbname", default=lambda: None, envvar="PGDATABASE", nargs=1)
 @click.argument("username", default=lambda: None, envvar="PGUSER", nargs=1)
 def cli(
@@ -1217,6 +1220,7 @@ def cli(
     auto_vertical_output,
     list_dsn,
     warn,
+    history,
 ):
     if version:
         print("Version:", __version__)

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -165,7 +165,7 @@ class PGCli(object):
         auto_vertical_output=False,
         warn=None,
         histfile=None,
-        alias_dsn=None
+        alias_dsn=None,
     ):
 
         self.force_passwd_prompt = force_passwd_prompt
@@ -1203,9 +1203,7 @@ class PGCli(object):
 @click.option(
     "--warn/--no-warn", default=None, help="Warn before running a destructive query."
 )
-@click.option(
-    "--histfile", default=None, help="Specify history file location."
-)
+@click.option("--histfile", default=None, help="Specify history file location.")
 @click.argument("dbname", default=lambda: None, envvar="PGDATABASE", nargs=1)
 @click.argument("username", default=lambda: None, envvar="PGUSER", nargs=1)
 def cli(

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -58,7 +58,8 @@ generate_casing_file = False
 # Casing of column headers based on the casing_file described above
 case_column_headers = True
 
-# history_file location.
+# default history_file location. You can also set history file location for
+# specific database. see [dsn_history_file] section.
 # In Unix/Linux: ~/.config/pgcli/history
 # In Windows: %USERPROFILE%\AppData\Local\dbcli\pgcli\history
 # %USERPROFILE% is typically C:\Users\{username}
@@ -186,6 +187,11 @@ output.null = "#808080"
 # DSN to call by -D option
 [alias_dsn]
 # example_dsn = postgresql://[user[:password]@][netloc][:port][/dbname]
+
+# Specify sperate history file for alias_dsn.
+# If not set, will use history_file settings.
+[dsn_history_file]
+# example_dsn = ~/.config/pgcli/example_dsn.history
 
 # Format for number representation
 # for decimal "d" - 12345678, ",d" - 12,345,678


### PR DESCRIPTION
## Description

This feature enables the user to config history file location for specific dsn.

close: #535 

## TODOs

- [ ] `--hisfile` support
- [ ] history file per database
  - [ ] switch history file when switch database
- [ ] alias dsn histfile


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
