### PR TITLE
dependencies: add support for sqlparse 0.4.x

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -113,6 +113,7 @@ Contributors:
     * Seungyong Kwak (GUIEEN)
     * Tom Caruso (tomplex)
     * Jan Brun Rasmussen (janbrunrasmussen)
+    * Kevin Marsh (kevinmarsh)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -9,6 +9,7 @@ Features:
 * Update python version in Dockerfile
 * Support setting color for null, string, number, keyword value
 * Support Prompt Toolkit 2
+* Support sqlparse 0.4.x
 * Update functions, datatypes literals for auto-suggestion field
 * Add suggestion for schema in function auto-complete
 

--- a/pgcli/packages/parseutils/ctes.py
+++ b/pgcli/packages/parseutils/ctes.py
@@ -16,7 +16,7 @@ TableExpression = namedtuple("TableExpression", "name columns start stop")
 def isolate_query_ctes(full_text, text_before_cursor):
     """Simplify a query by converting CTEs into table metadata objects"""
 
-    if not full_text:
+    if not full_text or not full_text.strip():
         return full_text, text_before_cursor, tuple()
 
     ctes, remainder = extract_ctes(full_text)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requirements = [
     # see: https://github.com/dbcli/pgcli/pull/1197
     "prompt_toolkit>=2.0.6,<4.0.0",
     "psycopg2 >= 2.8",
-    "sqlparse >=0.3.0,<0.4",
+    "sqlparse >=0.3.0,<0.5",
     "configobj >= 5.0.6",
     "pendulum>=2.1.0",
     "cli_helpers[styles] >= 2.0.0",

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -816,7 +816,7 @@ def test_create_db_with_template():
     assert set(suggestions) == set((Database(),))
 
 
-@pytest.mark.parametrize("initial_text", ("", "    ", "\t \t"))
+@pytest.mark.parametrize("initial_text", ("", "    ", "\t \t", "\n"))
 def test_specials_included_for_initial_completion(initial_text):
     suggestions = suggest_type(initial_text, initial_text)
 


### PR DESCRIPTION
## Description
`sqlparse` `0.4.0` has a breaking change which means that SQL strings which are [only whitespace are no longer parsed as statements any more](https://github.com/andialbrecht/sqlparse/blob/63885dd5f1be3fe519fceb0a21f1f87fdc6aa973/CHANGELOG#L28-L32).

I've run `behave` and `py.test` with Python 3.8.5 on both `sqlparse==0.3.1` and the latest `sqlparse==0.4.1`

Closes #1218 

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
