### PR TITLE
Fix issue where `syntax_style` config value would not have any effect

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -114,6 +114,7 @@ Contributors:
     * Tom Caruso (tomplex)
     * Jan Brun Rasmussen (janbrunrasmussen)
     * Kevin Marsh (kevinmarsh)
+    * Eero Ruohola (ruohola)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,11 @@
+TBD
+===
+
+Bug fixes:
+----------
+
+* Fix issue where `syntax_style` config value would not have any effect. (#1212)
+
 3.1.0
 =====
 

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -170,9 +170,12 @@ arg-toolbar = 'noinherit bold'
 arg-toolbar.text = 'nobold'
 bottom-toolbar.transaction.valid = 'bg:#222222 #00ff5f bold'
 bottom-toolbar.transaction.failed = 'bg:#222222 #ff005f bold'
-literal.string = '#ba2121'
-literal.number = '#666666'
-keyword = 'bold #008000'
+# These three values can be used to further refine the syntax highlighting.
+# They are commented out by default, since they have priority over the theme set
+# with the `syntax_style` setting and overriding its behavior can be confusing.
+# literal.string = '#ba2121'
+# literal.number = '#666666'
+# keyword = 'bold #008000'
 
 # style classes for colored table output
 output.header = "#00ff5f bold"


### PR DESCRIPTION
## Description

These config properties got introduced in 41dd24e8 as a means to have
more granular control over the syntax highlighting. The problem is that
these cannot be in the default config file since `get_config()` always
reads both the default config file and the user specified one, and there
is no way to unset these variables in the user specified config file to
restore their default behavior. Even if there would be a way, it
wouldn't be intuitive at all to be required to unset some random
settings under the `[colors]` section just to be able to use the well
documented `syntax_style` setting.

Note that one *can* still set these three lines in their user config
file if they want to utilize them.

Resolves #1212

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
