### PR TITLE
Finer control over destructive warning.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,32 +62,32 @@ For more details:
     Usage: pgcli [OPTIONS] [DBNAME] [USERNAME]
 
     Options:
-      -h, --host TEXT         Host address of the postgres database.
-      -p, --port INTEGER      Port number at which the postgres instance is
-                              listening.
-      -U, --username TEXT     Username to connect to the postgres database.
-      -u, --user TEXT         Username to connect to the postgres database.
-      -W, --password          Force password prompt.
-      -w, --no-password       Never prompt for password.
-      --single-connection     Do not use a separate connection for completions.
-      -v, --version           Version of pgcli.
-      -d, --dbname TEXT       database name to connect to.
-      --pgclirc PATH          Location of pgclirc file.
-      -D, --dsn TEXT          Use DSN configured into the [alias_dsn] section of
-                              pgclirc file.
-      --list-dsn              list of DSN configured into the [alias_dsn] section
-                              of pgclirc file.
-      --row-limit INTEGER     Set threshold for row limit prompt. Use 0 to disable
-                              prompt.
-      --less-chatty           Skip intro on startup and goodbye on exit.
-      --prompt TEXT           Prompt format (Default: "\u@\h:\d> ").
-      --prompt-dsn TEXT       Prompt format for connections using DSN aliases
-                              (Default: "\u@\h:\d> ").
-      -l, --list              list available databases, then exit.
-      --auto-vertical-output  Automatically switch to vertical output mode if the
-                              result is wider than the terminal width.
-      --warn / --no-warn      Warn before running a destructive query.
-      --help                  Show this message and exit.
+      -h, --host TEXT            Host address of the postgres database.
+      -p, --port INTEGER         Port number at which the postgres instance is
+                                 listening.
+      -U, --username TEXT        Username to connect to the postgres database.
+      -u, --user TEXT            Username to connect to the postgres database.
+      -W, --password             Force password prompt.
+      -w, --no-password          Never prompt for password.
+      --single-connection        Do not use a separate connection for completions.
+      -v, --version              Version of pgcli.
+      -d, --dbname TEXT          database name to connect to.
+      --pgclirc FILE             Location of pgclirc file.
+      -D, --dsn TEXT             Use DSN configured into the [alias_dsn] section
+                                 of pgclirc file.
+      --list-dsn                 list of DSN configured into the [alias_dsn]
+                                 section of pgclirc file.
+      --row-limit INTEGER        Set threshold for row limit prompt. Use 0 to
+                                 disable prompt.
+      --less-chatty              Skip intro on startup and goodbye on exit.
+      --prompt TEXT              Prompt format (Default: "\u@\h:\d> ").
+      --prompt-dsn TEXT          Prompt format for connections using DSN aliases
+                                 (Default: "\u@\h:\d> ").
+      -l, --list                 list available databases, then exit.
+      --auto-vertical-output     Automatically switch to vertical output mode if
+                                 the result is wider than the terminal width.
+      --warn [all|moderate|off]  Warn before running a destructive query.
+      --help                     Show this message and exit.
 
 ``pgcli`` also supports many of the same `environment variables`_ as ``psql`` for login options (e.g. ``PGHOST``, ``PGPORT``, ``PGUSER``, ``PGPASSWORD``, ``PGDATABASE``).
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,12 @@
 TBD
 ===
 
+Features:
+---------
+
+* Consider `update` queries destructive and issue a warning. Change
+  `destructive_warning` setting to `all|moderate|off`, vs `true|false`. (#1239)
+
 Bug fixes:
 ----------
 

--- a/pgcli/packages/parseutils/__init__.py
+++ b/pgcli/packages/parseutils/__init__.py
@@ -14,7 +14,7 @@ def query_is_unconditional_update(formatted_sql):
 
 
 def query_is_simple_update(formatted_sql):
-    """Check if the query starts with UPDATE and contains no WHERE."""
+    """Check if the query starts with UPDATE."""
     tokens = formatted_sql.split()
     return bool(tokens) and tokens[0] == "update"
 
@@ -25,10 +25,10 @@ def is_destructive(queries, warning_level="all"):
     for query in sqlparse.split(queries):
         if query:
             formatted_sql = sqlparse.format(query.lower(), strip_comments=True).strip()
-            if query_starts_with(formatted_sql, keywords) is True:
+            if query_starts_with(formatted_sql, keywords):
                 return True
-            if query_is_unconditional_update(formatted_sql) is True:
+            if query_is_unconditional_update(formatted_sql):
                 return True
-            if warning_level == "all" and query_is_simple_update(formatted_sql) is True:
+            if warning_level == "all" and query_is_simple_update(formatted_sql):
                 return True
     return False

--- a/pgcli/packages/parseutils/__init__.py
+++ b/pgcli/packages/parseutils/__init__.py
@@ -1,22 +1,34 @@
 import sqlparse
 
 
-def query_starts_with(query, prefixes):
+def query_starts_with(formatted_sql, prefixes):
     """Check if the query starts with any item from *prefixes*."""
     prefixes = [prefix.lower() for prefix in prefixes]
-    formatted_sql = sqlparse.format(query.lower(), strip_comments=True).strip()
     return bool(formatted_sql) and formatted_sql.split()[0] in prefixes
 
 
-def queries_start_with(queries, prefixes):
-    """Check if any queries start with any item from *prefixes*."""
-    for query in sqlparse.split(queries):
-        if query and query_starts_with(query, prefixes) is True:
-            return True
-    return False
+def query_is_unconditional_update(formatted_sql):
+    """Check if the query starts with UPDATE and contains no WHERE."""
+    tokens = formatted_sql.split()
+    return bool(tokens) and tokens[0] == "update" and "where" not in tokens
 
 
-def is_destructive(queries):
+def query_is_simple_update(formatted_sql):
+    """Check if the query starts with UPDATE and contains no WHERE."""
+    tokens = formatted_sql.split()
+    return bool(tokens) and tokens[0] == "update"
+
+
+def is_destructive(queries, warning_level="all"):
     """Returns if any of the queries in *queries* is destructive."""
     keywords = ("drop", "shutdown", "delete", "truncate", "alter")
-    return queries_start_with(queries, keywords)
+    for query in sqlparse.split(queries):
+        if query:
+            formatted_sql = sqlparse.format(query.lower(), strip_comments=True).strip()
+            if query_starts_with(formatted_sql, keywords) is True:
+                return True
+            if query_is_unconditional_update(formatted_sql) is True:
+                return True
+            if warning_level == "all" and query_is_simple_update(formatted_sql) is True:
+                return True
+    return False

--- a/pgcli/packages/prompt_utils.py
+++ b/pgcli/packages/prompt_utils.py
@@ -3,7 +3,7 @@ import click
 from .parseutils import is_destructive
 
 
-def confirm_destructive_query(queries):
+def confirm_destructive_query(queries, warning_level):
     """Check if the query is destructive and prompts the user to confirm.
 
     Returns:
@@ -15,7 +15,7 @@ def confirm_destructive_query(queries):
     prompt_text = (
         "You're about to run a destructive command.\n" "Do you want to proceed? (y/n)"
     )
-    if is_destructive(queries) and sys.stdin.isatty():
+    if is_destructive(queries, warning_level) and sys.stdin.isatty():
         return prompt(prompt_text, type=bool)
 
 

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -28,7 +28,7 @@ multi_line_mode = psql
 # Possible values:
 # "all" - warn on data definition statements, server actions such as SHUTDOWN, DELETE or UPDATE
 # "moderate" - skip warning on UPDATE statements, except for unconditional updates
-# "off" - skip all warning
+# "off" - skip all warnings
 destructive_warning = all
 
 # Enables expand mode, which is similar to `\x` in psql.

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -23,9 +23,13 @@ multi_line = False
 multi_line_mode = psql
 
 # Destructive warning mode will alert you before executing a sql statement
-# that may cause harm to the database such as "drop table", "drop database"
-# or "shutdown".
-destructive_warning = True
+# that may cause harm to the database such as "drop table", "drop database",
+# "shutdown", "delete", or "update".
+# Possible values:
+# "all" - warn on data definition statements, server actions such as SHUTDOWN, DELETE or UPDATE
+# "moderate" - skip warning on UPDATE statements, except for unconditional updates
+# "off" - skip all warning
+destructive_warning = all
 
 # Enables expand mode, which is similar to `\x` in psql.
 expand = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from utils import (
 import pgcli.pgexecute
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def connection():
     create_db("_test_db")
     connection = db_connection("_test_db")

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -63,7 +63,7 @@ def before_all(context):
                         "import coverage",
                         "coverage.process_startup()",
                         "import pgcli.main",
-                        "pgcli.main.cli()",
+                        "pgcli.main.cli(auto_envvar_prefix='BEHAVE')",
                     ]
                 ),
             )
@@ -102,6 +102,7 @@ def before_all(context):
     else:
         if "PGPASSWORD" in os.environ:
             del os.environ["PGPASSWORD"]
+    os.environ['BEHAVE_WARN'] = 'moderate'
 
     context.cn = dbutils.create_db(
         context.conf["host"],

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -102,7 +102,7 @@ def before_all(context):
     else:
         if "PGPASSWORD" in os.environ:
             del os.environ["PGPASSWORD"]
-    os.environ['BEHAVE_WARN'] = 'moderate'
+    os.environ["BEHAVE_WARN"] = "moderate"
 
     context.cn = dbutils.create_db(
         context.conf["host"],

--- a/tests/parseutils/test_parseutils.py
+++ b/tests/parseutils/test_parseutils.py
@@ -1,4 +1,5 @@
 import pytest
+from pgcli.packages.parseutils import is_destructive
 from pgcli.packages.parseutils.tables import extract_tables
 from pgcli.packages.parseutils.utils import find_prev_keyword, is_open_quote
 
@@ -267,3 +268,21 @@ def test_is_open_quote__closed(sql):
 )
 def test_is_open_quote__open(sql):
     assert is_open_quote(sql)
+
+
+@pytest.mark.parametrize(
+    ("sql", "warning_level", "expected"),
+    [
+        ("update abc set x = 1", "all", True),
+        ("update abc set x = 1 where y = 2", "all", True),
+        ("update abc set x = 1", "moderate", True),
+        ("update abc set x = 1 where y = 2", "moderate", False),
+        ("select x, y, z from abc", "all", False),
+        ("drop abc", "all", True),
+        ("alter abc", "all", True),
+        ("delete abc", "all", True),
+        ("truncate abc", "all", True),
+    ],
+)
+def test_is_destructive(sql, warning_level, expected):
+    assert is_destructive(sql, warning_level=warning_level) == expected

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -7,4 +7,4 @@ def test_confirm_destructive_query_notty():
     stdin = click.get_text_stream("stdin")
     if not stdin.isatty():
         sql = "drop database foo;"
-        assert confirm_destructive_query(sql) is None
+        assert confirm_destructive_query(sql, "all") is None


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

This PR adds `UPDATE` queries to the list of queries that we consider "destructive". It also changes `destructive_warning` setting in `pgclirc` from simple boolean to 3 levels:

* all - warn on data-changing queries, including DELETE and UPDATE, schema modifications, or server state commands
* moderate - similar to the above, but only warn on UNCONDITIONAL updates
* off - no warnings

Related to issue https://github.com/dbcli/pgcli/issues/1239.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
