### PR TITLE
skip initial comment in pg_session file

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,7 @@ Features:
 
 * Consider `update` queries destructive and issue a warning. Change
   `destructive_warning` setting to `all|moderate|off`, vs `true|false`. (#1239)
+* Skip initial comment in .pg_session even if it doesn't start with '#'
 
 Bug fixes:
 ----------

--- a/pgcli/config.py
+++ b/pgcli/config.py
@@ -81,10 +81,10 @@ def skip_initial_comment(f_stream: TextIO) -> int:
     while True:
         line = f_stream.readline()
         if line == "":
-            return
+            break
         if re.match(section_regex, line) is not None:
             f_stream.seek(pos)
-            return
+            break
         else:
             pos += len(line)
             lines_skipped += 1

--- a/pgcli/config.py
+++ b/pgcli/config.py
@@ -3,6 +3,8 @@ import shutil
 import os
 import platform
 from os.path import expanduser, exists, dirname
+import re
+from typing import TextIO
 from configobj import ConfigObj
 
 
@@ -62,3 +64,28 @@ def get_casing_file(config):
     if casing_file == "default":
         casing_file = config_location() + "casing"
     return casing_file
+
+
+def skip_initial_comment(f_stream: TextIO) -> int:
+    """
+    Initial comment in ~/.pg_service.conf is not always marked with '#'
+    which crashes the parser. This function takes a file object and
+    "rewinds" it to the beginning of the first section,
+    from where on it can be parsed safely
+
+    :return: number of skipped lines
+    """
+    section_regex = r"\s*\["
+    pos = f_stream.tell()
+    lines_skipped = 0
+    while True:
+        line = f_stream.readline()
+        if line == "":
+            return
+        if re.match(section_regex, line) is not None:
+            f_stream.seek(pos)
+            return
+        else:
+            pos += len(line)
+            lines_skipped += 1
+    return lines_skipped

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,10 @@
+import io
 import os
 import stat
 
 import pytest
 
-from pgcli.config import ensure_dir_exists
+from pgcli.config import ensure_dir_exists, skip_initial_comment
 
 
 def test_ensure_file_parent(tmpdir):
@@ -28,3 +29,15 @@ def test_ensure_other_create_error(tmpdir):
 
     with pytest.raises(OSError):
         ensure_dir_exists(str(rcfile))
+
+
+@pytest.mark.parametrize(
+    "text, skipped_lines",
+    (
+        ("abc\n", 1),
+        ("#[section]\ndef\n[section]", 2),
+        ("[section]", 0),
+    ),
+)
+def test_skip_initial_comment(text, skipped_lines):
+    assert skip_initial_comment(io.StringIO(text)) == skipped_lines

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -288,7 +288,12 @@ def test_pg_service_file(tmpdir):
         cli = PGCli(pgclirc_file=str(tmpdir.join("rcfile")))
         with open(tmpdir.join(".pg_service.conf").strpath, "w") as service_conf:
             service_conf.write(
-                """[myservice]
+                """File begins with a comment
+            that is not a comment
+            # or maybe a comment after all
+            because psql is crazy
+
+            [myservice]
             host=a_host
             user=a_user
             port=5433


### PR DESCRIPTION
## Description
A [hackernews comment](https://news.ycombinator.com/item?id=26188757) brought up that psql skips the initial comment in `~/.pg_service.conf` even if it doesn't start with `#`, so basically all text before the first section. This PR tries to do the same. 



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
