### PR TITLE
fixed unknown symbol REPLACE_SINGLE in prompt_toolkit < 3.0.6

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,7 @@ Bug fixes:
 ----------
 
 * Fix issue where `syntax_style` config value would not have any effect. (#1212)
+* Fix crash because of not found `InputMode.REPLACE_SINGLE` with prompt-toolkit < 3.0.6
 
 3.1.0
 =====

--- a/pgcli/pgtoolbar.py
+++ b/pgcli/pgtoolbar.py
@@ -1,15 +1,20 @@
+from packaging.version import parse as parse_version
+
+import prompt_toolkit
 from prompt_toolkit.key_binding.vi_state import InputMode
 from prompt_toolkit.application import get_app
 
 
 def _get_vi_mode():
-    return {
+    modes = {
         InputMode.INSERT: "I",
         InputMode.NAVIGATION: "N",
         InputMode.REPLACE: "R",
-        InputMode.REPLACE_SINGLE: "R",
         InputMode.INSERT_MULTIPLE: "M",
-    }[get_app().vi_state.input_mode]
+    }
+    if parse_version(prompt_toolkit.__version__) >= parse_version("3.0.6"):
+        modes[InputMode.REPLACE_SINGLE] = "R"
+    return modes[get_app().vi_state.input_mode]
 
 
 def create_toolbar_tokens_func(pgcli):


### PR DESCRIPTION
## Description
After #1208 we stopped crashing for prompt-toolkit versions >= 3.0.6, but started crashing for lower versions. Since we apparently still need version 2, the only workaround I can think of is a runtime check. 



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
