### PR TITLE
fix IPython magic

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Bug fixes:
 * Fix issue where `syntax_style` config value would not have any effect. (#1212)
 * Fix crash because of not found `InputMode.REPLACE_SINGLE` with prompt-toolkit < 3.0.6
 * Fix comments being lost in config when saving a named query. (#1240)
+* Fix IPython magic for ipython-sql >= 0.4.0
 
 3.1.0
 =====

--- a/pgcli/magic.py
+++ b/pgcli/magic.py
@@ -25,7 +25,11 @@ def pgcli_line_magic(line):
     if hasattr(sql.connection.Connection, "get"):
         conn = sql.connection.Connection.get(parsed["connection"])
     else:
-        conn = sql.connection.Connection.set(parsed["connection"])
+        try:
+            conn = sql.connection.Connection.set(parsed["connection"])
+        # a new positional argument was added to Connection.set in version 0.4.0 of ipython-sql
+        except TypeError:
+            conn = sql.connection.Connection.set(parsed["connection"], False)
 
     try:
         # A corresponding pgcli object already exists


### PR DESCRIPTION
## Description
IPython magic doesn't work with [ipython-sql](https://github.com/catherinedevlin/ipython-sql) >= 0.4.0, because they broke the API a little.



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
