### PR TITLE
skipping initial comments in pgconfig file did not work on Windows.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -116,6 +116,7 @@ Contributors:
     * Kevin Marsh (kevinmarsh)
     * Eero Ruohola (ruohola)
     * Miroslav Šedivý (eumiro)
+    * Eric R Young (ERYoung11) 
 
 Creator:
 --------

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -21,7 +21,6 @@ import datetime as dt
 import itertools
 import platform
 from time import time, sleep
-from codecs import open
 
 keyring = None  # keyring will be loaded later
 
@@ -1517,7 +1516,7 @@ def parse_service_info(service):
     if not service or not os.path.exists(service_file):
         # nothing to do
         return None, service_file
-    with open(service_file) as f:
+    with open(service_file, newline="") as f:
         skipped_lines = skip_initial_comment(f)
         try:
             service_file_config = ConfigObj(f)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
See Issue #1257.

To fix this issue, we needed to have skip_initial_comment consume EOL in the same way no matter the OS.

codecs.open does not provide an option to consider EOLs for each platform in the same way.

[codecs.open is not favored for python 3. ](https://stackoverflow.com/questions/5250744/difference-between-open-and-codecs-open-in-python)

The built-in open does provide for a way to consider EOLs for each platform in the same way.

Therefore, I removed the import of codecs.open and used the standard open feature.

All tests now run on Windows and Linux and the pgcli command appears to work correctly.



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`. (the initial commit is already there so I'm not adding my fix)
- [X] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [X] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
