### PR TITLE
Fix: ANSI escape codes in first line make the cli choose expanded output incorrectly...

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -117,6 +117,7 @@ Contributors:
     * Eero Ruohola (ruohola)
     * Miroslav Šedivý (eumiro)
     * Eric R Young (ERYoung11) 
+    * Paweł Sacawa (psacawa)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -16,6 +16,7 @@ Bug fixes:
 * Fix comments being lost in config when saving a named query. (#1240)
 * Fix IPython magic for ipython-sql >= 0.4.0
 * Fix pager not being used when output format is set to csv. (#1238)
+* Fix ANSI escape codes in first line make the cli choose expanded output incorrectly
 
 3.1.0
 =====

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -26,6 +26,7 @@ keyring = None  # keyring will be loaded later
 
 from cli_helpers.tabular_output import TabularOutputFormatter
 from cli_helpers.tabular_output.preprocessors import align_decimals, format_numbers
+from cli_helpers.utils import strip_ansi
 import click
 
 try:
@@ -1487,7 +1488,7 @@ def format_output(title, cur, headers, status, settings):
             formatted = iter(formatted.splitlines())
         first_line = next(formatted)
         formatted = itertools.chain([first_line], formatted)
-        if not expanded and max_width and len(first_line) > max_width and headers:
+        if not expanded and max_width and len(strip_ansi(first_line)) > max_width and headers:
             formatted = formatter.format_output(
                 cur, headers, format_name="vertical", column_types=None, **output_kwargs
             )


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

The `format_output` procedure chooses to output as a table or in the expanded    format on the basis of the length of the first line of the table formatter. However, this first line contains a lot of ANSI    escape codes, so this comparison is wrong, and the expanded mode   is used either way. This patch strips these escape codes before the    comparison.

To reproduce the bug, set `expand_auto = True` in a narrow terminal (number of rows < 100) and try `select 1`. The output is narrow enough to fit in the terminal, but because of the ANSI escape codes, `len(first_line)` exceeds `max_width` in `format_output`, so we get expanded output.

Screencast of the bug fixed: https://asciinema.org/a/vjoWc9OeHxlXvg0joNDLT40rv

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
