### PR TITLE
Add support for \clip command

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -16,6 +16,7 @@ Bug fixes:
 * Fix comments being lost in config when saving a named query. (#1240)
 * Fix IPython magic for ipython-sql >= 0.4.0
 * Fix pager not being used when output format is set to csv. (#1238)
+* Add \clip command to copy to clipboard
 
 3.1.0
 =====

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -385,6 +385,26 @@ class PGExecute:
                             self.reset_expanded = True
                         sql = sql[:-2].strip()
 
+                    #  stub implementation
+                    #  copying the output is useful for profiling queries with EXPLAIN
+                    if sql.startswith(r"\clip"):
+                        sql = sql.strip(r"\clip")
+                        cur = self.conn.cursor()
+                        cur.execute(sql)
+                        out_lines = cur.fetchall()
+                        output = "\n".join([tup[0] for tup in out_lines])
+
+                        #  cross-platform clipboard copy
+                        _logger.debug("copying to clipboard")
+                        import pyperclip
+
+                        pyperclip.copy(output)
+
+                        #  still print output
+                        #  since it is likely a explain analyze query, we may like to use an
+                        #  existing Pygments lexer for Postgres explain output
+                        print(output)
+
                     # First try to run each query as special
                     _logger.debug("Trying a pgspecial command. sql: %r", sql)
                     try:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

When profiling Postgres queries with `EXPLAIN ANALYZE`, it is often necessary to copy the query to the system clipboard in order to feed the output to a visualisation tool like (depesz)[explain.depesz.com]. `psql` has no facilities for this, so I usually need to do something like 
```
psql -qAt --no-psqlrc -f cmd.sql | xsel -ib
```
This is annoying, so I see the advantage of a `\clip` command that copies the DB output to the clipboard, which lets you do
```
\clip explain analyze select * from tab;
```

It is different from the native DB commands, so I don't see how to implement it cleanly. It doesn't belong in `pgspecial`. The present implementation is a bit ad hoc. It uses the package `pyperclip`, which implements a cross-platform clipboard client.

I am submitting this PR to solicit comments, with the hope to work toward a good solution. **Please allow me to run workflows**

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
