### PR TITLE
Add a configuration option to execute commands on startup.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -122,6 +122,7 @@ Contributors:
     * Daniele Varrazzo
     * Daniel Kukula (dkuku)
     * Kian-Meng Ang (kianmeng)
+    * Mathieu Gascon-Lefebvre (mlefebvre)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,10 @@
 Upcoming:
 =========
 
+Features:
+---------
+* Add a configuration option to execute commands on startup ([related issue](https://github.com/dbcli/pgcli/issues/247)).
+
 Bug fixes:
 ----------
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -241,6 +241,7 @@ class PGCli:
         self.float_format = c["data_formats"]["float"]
         auth.keyring_initialize(c["main"].as_bool("keyring"), logger=self.logger)
         self.show_bottom_toolbar = c["main"].as_bool("show_bottom_toolbar")
+        self.startup_command = c["main"]["startup_command"]
 
         self.pgspecial.pset_pager(
             self.config["main"].as_bool("enable_pager") and "on" or "off"
@@ -778,6 +779,10 @@ class PGCli:
             print("Home: http://pgcli.com")
 
         try:
+            if self.startup_command:
+                print(f"Executing startup command: {self.startup_command}")
+                self.handle_watch_command(self.startup_command)
+
             while True:
                 try:
                     text = self.prompt_app.prompt()

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -158,6 +158,9 @@ enable_pager = True
 # Use keyring to automatically save and load password in a secure manner
 keyring = True
 
+# Command to run at startup. Multiple commands can be specified if separated by a semicolon.
+startup_command = ''
+
 # Custom colors for the completion menu, toolbar, etc.
 [colors]
 completion-menu.completion.current = 'bg:#ffffff #000000'


### PR DESCRIPTION
## Description
Related issue: #247 

I needed a way to execute commands on startup (like `SET default_transaction_read_only = on` when connecting on a production server), so I added a new startup_command configuration option.

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
