### PR TITLE
no need to strip_comments

### DIFF
--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -430,7 +430,7 @@ class PGExecute:
         for sql in sqlparse.split(statement):
             # Remove spaces, eol and semi-colons.
             sql = sql.rstrip(";")
-            sql = sqlparse.format(sql, strip_comments=True).strip()
+            sql = sqlparse.format(sql, strip_comments=False).strip()
             if not sql:
                 continue
             try:


### PR DESCRIPTION
## Description

just a  minor change to make sure SQL comments do not get lost before reaching the backend.
as discussed in https://github.com/dbcli/pgcli/issues/1286

I have run a comparison with psql on a query like

 /* TEST123 TAGGING */ select * from /*test 123 */ bizscheme.accounts limit 10;--jkjkjksdds fsdf sdf sd

and postgresql receives comments in the same way now