### PR TITLE
Add some comments about porting from psycopg 2 to 3

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -119,6 +119,7 @@ Contributors:
     * Eric R Young (ERYoung11)
     * Paweł Sacawa (psacawa)
     * Bruno Inec (sweenu)
+    * Daniele Varrazzo
 
 Creator:
 --------

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -80,6 +80,8 @@ except ImportError:
 
 from getpass import getuser
 from psycopg2 import OperationalError, InterfaceError
+
+# pg3: https://www.psycopg.org/psycopg3/docs/api/conninfo.html
 from psycopg2.extensions import make_dsn, parse_dsn
 import psycopg2
 
@@ -1580,12 +1582,15 @@ def format_output(title, cur, headers, status, settings):
         if hasattr(cur, "description"):
             column_types = []
             for d in cur.description:
+                # pg3: type_name = cur.adapters.types[d.type_code].name
                 if (
+                    # pg3: type_name in ("numeric", "float4", "float8")
                     d[1] in psycopg2.extensions.DECIMAL.values
                     or d[1] in psycopg2.extensions.FLOAT.values
                 ):
                     column_types.append(float)
                 if (
+                    # pg3: type_name in ("int2", "int4", "int8")
                     d[1] == psycopg2.extensions.INTEGER.values
                     or d[1] in psycopg2.extensions.LONGINTEGER.values
                 ):


### PR DESCRIPTION
## Description

Added hints about how to port some psycopg2 idioms to psycopg 3. No code was changed.

Feel free to merge this as it is, or you might use it as a base for a psycopg 3 porting branch.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`.  -- not meaningful yet as no code was changed
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
