### PR TITLE
Add rowcount to status returned from redshift.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,10 @@
 TBD
 ===
 
-* [List new changes here].
+Bug fixes:
+----------
+
+* Fix the bug with Redshift not displaying wor count in status ([related issue](https://github.com/dbcli/pgcli/issues/1320)).
 
 3.4.0 (2022/02/21)
 ==================

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1550,7 +1550,7 @@ def format_output(title, cur, headers, status, settings):
     def format_status(cur, status):
         # redshift does not return rowcount as part of status.
         # See https://github.com/dbcli/pgcli/issues/1320
-        if cur and hasattr(cur, 'rowcount') and cur.rowcount is not None:
+        if cur and hasattr(cur, "rowcount") and cur.rowcount is not None:
             if status and not status.endswith(str(cur.rowcount)):
                 status += " %s" % cur.rowcount
         return status

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1547,6 +1547,14 @@ def format_output(title, cur, headers, status, settings):
 
         return data, headers
 
+    def format_status(cur, status):
+        # redshift does not return rowcount as part of status.
+        # See https://github.com/dbcli/pgcli/issues/1320
+        if cur and hasattr(cur, 'rowcount') and cur.rowcount is not None:
+            if status and not status.endswith(str(cur.rowcount)):
+                status += " %s" % cur.rowcount
+        return status
+
     output_kwargs = {
         "sep_title": "RECORD {n}",
         "sep_character": "-",
@@ -1619,7 +1627,7 @@ def format_output(title, cur, headers, status, settings):
 
     # Only print the status if it's not None and we are not producing CSV
     if status and table_format != "csv":
-        output = itertools.chain(output, [status])
+        output = itertools.chain(output, [format_status(cur, status)])
 
     return output
 


### PR DESCRIPTION
## Description

Fix for https://github.com/dbcli/pgcli/issues/1320.

Normally, pgcli simply prints `cursor.statusmessage` that `psycopg2` returns. However, while with other databases `psycopg2` returns `SELECT X`, with Redshift this is just `SELECT`.

This adds missing rowcount in pgcli.

@dvarrazzo This PR does the job, but I wonder if it should be fixed in `psycopg2` instead. What do you think?

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
