### PR TITLE
Add alternate_editor config option to specify an editor.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -122,6 +122,7 @@ Contributors:
     * Daniele Varrazzo
     * Daniel Kukula (dkuku)
     * Kian-Meng Ang (kianmeng)
+    * Max Steinbach (bossstein)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,7 @@ Internal:
 
 * Port to psycopg3 (https://github.com/psycopg/psycopg). Needs a major version bump.
 * Fix typos
+* add config option 'alternate_editor' so user can specify editor other than $VISUAL or $EDITOR
 
 3.4.1 (2022/03/19)
 ==================

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,11 @@
 Upcoming:
 =========
 
+Bug fixes:
+----------
+
+* Fix exception when retrieving password from keyring ([issue 1338](https://github.com/dbcli/pgcli/issues/1338)).
+
 Internal:
 ---------
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -11,7 +11,7 @@ Internal:
 
 * Port to psycopg3 (https://github.com/psycopg/psycopg). Needs a major version bump.
 * Fix typos
-* add config option 'alternate_editor' so user can specify editor other than $VISUAL or $EDITOR
+* Add config option `alternate_editor` so user can specify editor other than `$VISUAL` or `$EDITOR`.
 
 3.4.1 (2022/03/19)
 ==================

--- a/pgcli/auth.py
+++ b/pgcli/auth.py
@@ -1,0 +1,58 @@
+import click
+from textwrap import dedent
+
+
+keyring = None  # keyring will be loaded later
+
+
+keyring_error_message = dedent(
+    """\
+    {}
+    {}
+    To remove this message do one of the following:
+    - prepare keyring as described at: https://keyring.readthedocs.io/en/stable/
+    - uninstall keyring: pip uninstall keyring
+    - disable keyring in our configuration: add keyring = False to [main]"""
+)
+
+
+def keyring_initialize(keyring_enabled, *, logger):
+    """Initialize keyring only if explicitly enabled"""
+    global keyring
+
+    if keyring_enabled:
+        # Try best to load keyring (issue #1041).
+        import importlib
+
+        try:
+            keyring = importlib.import_module("keyring")
+        except Exception as e:  # ImportError for Python 2, ModuleNotFoundError for Python 3
+            logger.warning("import keyring failed: %r.", e)
+
+
+def keyring_get_password(key):
+    """Attempt to get password from keyring"""
+    # Find password from store
+    passwd = ""
+    try:
+        passwd = keyring.get_password("pgcli", key) or ""
+    except Exception as e:
+        click.secho(
+            keyring_error_message.format(
+                "Load your password from keyring returned:", str(e)
+            ),
+            err=True,
+            fg="red",
+        )
+    return passwd
+
+
+def keyring_set_password(key, passwd):
+    try:
+        keyring.set_password("pgcli", key, passwd)
+    except Exception as e:
+        click.secho(
+            keyring_error_message.format("Set password in keyring returned:", str(e)),
+            err=True,
+            fg="red",
+        )

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -673,7 +673,9 @@ class PGCli:
                     query = self.pgexecute.view_definition(spec)
                 elif editor_command == "\\ef":
                     query = self.pgexecute.function_definition(spec)
-            sql, message = special.open_external_editor(filename, sql=query, editor=self.alternate_editor)
+            sql, message = special.open_external_editor(
+                filename, sql=query, editor=self.alternate_editor
+            )
             if message:
                 # Something went wrong. Raise an exception and bail.
                 raise RuntimeError(message)

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -202,6 +202,11 @@ class PGCli:
         self.multi_line = c["main"].as_bool("multi_line")
         self.multiline_mode = c["main"].get("multi_line_mode", "psql")
         self.vi_mode = c["main"].as_bool("vi")
+        alternate_editor_text = c["main"]["alternate_editor"]
+        if alternate_editor_text == "default":
+            self.alternate_editor = None
+        else:
+            self.alternate_editor = alternate_editor_text
         self.auto_expand = auto_vertical_output or c["main"].as_bool("auto_expand")
         self.expanded_output = c["main"].as_bool("expand")
         self.pgspecial.timing_enabled = c["main"].as_bool("timing")
@@ -695,7 +700,7 @@ class PGCli:
         by a '\e'. The reason for a while loop is because a user
         might edit a query multiple times.
         For eg:
-        "select * from \e"<enter> to edit it in vim, then come
+        "select * from \e"<enter> to edit it in an editor, then come
         back to the prompt with the edited query "select * from
         blah where q = 'abc'\e" to edit it again.
         :param text: Document
@@ -713,7 +718,7 @@ class PGCli:
                     query = self.pgexecute.view_definition(spec)
                 elif editor_command == "\\ef":
                     query = self.pgexecute.function_definition(spec)
-            sql, message = special.open_external_editor(filename, sql=query)
+            sql, message = special.open_external_editor(filename, sql=query, editor=self.alternate_editor)
             if message:
                 # Something went wrong. Raise an exception and bail.
                 raise RuntimeError(message)

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -110,6 +110,12 @@ syntax_style = default
 # for end are available in the REPL.
 vi = False
 
+# Alternate Editor
+# When set to a non default value, the chosen editor will be used when opening an
+# editor with \e. Otherwise, if default is selected, the enviroment variable VISUAL
+# is used. If VISUAL is blank then enviroment variable EDITOR is used.
+alternate_editor = default
+
 # Error handling
 # When one of multiple SQL statements causes an error, choose to either
 # continue executing the remaining statements, or stopping

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pgcli import __version__
 description = "CLI for Postgres Database. With auto-completion and syntax highlighting."
 
 install_requirements = [
-    "pgspecial>=2.0.0",
+    "pgspecial>=2.0.1",
     "click >= 4.1",
     "Pygments>=2.0",  # Pygments has to be Capitalcased. WTF?
     # We still need to use pt-2 unless pt-3 released on Fedora32

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,40 @@
+import pytest
+from unittest import mock
+from pgcli import auth
+
+
+@pytest.mark.parametrize("enabled,call_count", [(True, 1), (False, 0)])
+def test_keyring_initialize(enabled, call_count):
+    logger = mock.MagicMock()
+
+    with mock.patch("importlib.import_module", return_value=True) as import_method:
+        auth.keyring_initialize(enabled, logger=logger)
+        assert import_method.call_count == call_count
+
+
+def test_keyring_get_password_ok():
+    with mock.patch("pgcli.auth.keyring", return_value=mock.MagicMock()):
+        with mock.patch("pgcli.auth.keyring.get_password", return_value="abc123"):
+            assert auth.keyring_get_password("test") == "abc123"
+
+
+def test_keyring_get_password_exception():
+    with mock.patch("pgcli.auth.keyring", return_value=mock.MagicMock()):
+        with mock.patch(
+            "pgcli.auth.keyring.get_password", side_effect=Exception("Boom!")
+        ):
+            assert auth.keyring_get_password("test") == ""
+
+
+def test_keyring_set_password_ok():
+    with mock.patch("pgcli.auth.keyring", return_value=mock.MagicMock()):
+        with mock.patch("pgcli.auth.keyring.set_password"):
+            auth.keyring_set_password("test", "abc123")
+
+
+def test_keyring_set_password_exception():
+    with mock.patch("pgcli.auth.keyring", return_value=mock.MagicMock()):
+        with mock.patch(
+            "pgcli.auth.keyring.set_password", side_effect=Exception("Boom!")
+        ):
+            auth.keyring_set_password("test", "abc123")


### PR DESCRIPTION
## Description
Solution to issue #1342 . This change adds an `alternate_editor` config option. Previous functionality was to check the $VISUAL environment variable and use this and then if this is blank it would use $EDITOR. These environment variables are used by other software and as such a user may not want to change them, however they may want to not use a visual editor in pgcli or they may want to use a different editor to the default. By adding this alternate editor option a user can choose a different editor and even specify arguments if they want to use different editor behaviour while in pgcli.

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
