### PR TITLE
Autocommit

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -122,6 +122,7 @@ Contributors:
     * Daniele Varrazzo
     * Daniel Kukula (dkuku)
     * Kian-Meng Ang (kianmeng)
+    * Frank van Viegen (vanviegen)
 
 Creator:
 --------

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -42,20 +42,22 @@ It is highly recommended to use virtualenv for development. If you don't know
 what a virtualenv is, `this guide <http://docs.python-guide.org/en/latest/dev/virtualenvs/#virtual-environments>`_
 will help you get started.
 
-Create a virtualenv (let's call it pgcli-dev). Activate it:
+Create a virtualenv (let's call it pgcli-dev) and activate it:
 
 ::
 
-    source ./pgcli-dev/bin/activate
+    $ virtualenv pgcli-dev
+    $ source pgcli-dev/bin/activate
 
-Once the virtualenv is activated, `cd` into the local clone of pgcli folder
-and install pgcli using pip as follows:
+Once the virtualenv is activated, you may first need to update a few of its
+packages to their latest versions:
 
 ::
+    $ pip install --upgrade pip setuptools wheel
 
-    $ pip install --editable .
+Next, `cd` into your local clone of pgcli and run:
 
-    or
+::
 
     $ pip install -e .
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,12 @@
 Upcoming:
 =========
 
+Features:
+---------
+
+* Toggle autocommit mode using F6 or a config setting.
+* When in a transaction, rollback erring queries without aborting the transaction. ('On error rollback'.)
+
 Bug fixes:
 ----------
 

--- a/pgcli/key_bindings.py
+++ b/pgcli/key_bindings.py
@@ -45,6 +45,12 @@ def pgcli_bindings(pgcli):
         _logger.debug("Detected F5 key.")
         pgcli.explain_mode = not pgcli.explain_mode
 
+    @kb.add("f6")
+    def _(event):
+        """Toggle autocommit mode."""
+        _logger.debug("Detected F6 key.")
+        pgcli.autocommit = not pgcli.autocommit
+
     @kb.add("tab")
     def _(event):
         """Force autocompletion at cursor on non-empty lines."""

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -199,6 +199,7 @@ class PGCli:
         self.multi_line = c["main"].as_bool("multi_line")
         self.multiline_mode = c["main"].get("multi_line_mode", "psql")
         self.vi_mode = c["main"].as_bool("vi")
+        self.autocommit = c["main"].as_bool("autocommit")
         self.auto_expand = auto_vertical_output or c["main"].as_bool("auto_expand")
         self.expanded_output = c["main"].as_bool("expand")
         self.pgspecial.timing_enabled = c["main"].as_bool("timing")
@@ -431,6 +432,7 @@ class PGCli:
             self.pgspecial,
             on_error_resume=on_error_resume,
             explain_mode=self.explain_mode,
+            autocommit=self.autocommit,
         )
 
     def write_to_file(self, pattern, **_):
@@ -958,6 +960,7 @@ class PGCli:
             exception_formatter,
             on_error_resume,
             explain_mode=self.explain_mode,
+            autocommit=self.autocommit,
         )
 
         is_special = None

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -110,6 +110,10 @@ syntax_style = default
 # for end are available in the REPL.
 vi = False
 
+# Enable automatic commits after each query. When disabled, queries outside of a
+# transaction will start a new transaction, but the user will need to COMMIT manually.
+autocommit = True
+
 # Error handling
 # When one of multiple SQL statements causes an error, choose to either
 # continue executing the remaining statements, or stopping

--- a/pgcli/pgtoolbar.py
+++ b/pgcli/pgtoolbar.py
@@ -53,9 +53,14 @@ def create_toolbar_tokens_func(pgcli):
             result.append(("class:bottom-toolbar", "[F4] Emacs-mode  "))
 
         if pgcli.explain_mode:
-            result.append(("class:bottom-toolbar", "[F5] Explain: ON "))
+            result.append(("class:bottom-toolbar", "[F5] Explain: ON  "))
         else:
-            result.append(("class:bottom-toolbar", "[F5] Explain: OFF "))
+            result.append(("class:bottom-toolbar", "[F5] Explain: OFF  "))
+
+        if pgcli.autocommit:
+            result.append(("class:bottom-toolbar", "[F6] Autocommit: ON "))
+        else:
+            result.append(("class:bottom-toolbar", "[F6] Autocommit: OFF "))
 
         if pgcli.pgexecute.failed_transaction():
             result.append(


### PR DESCRIPTION
## Description

- Toggle autocommit mode using F6 or a config setting.
- When in a transaction, rollback erring queries without aborting the transaction. ('On error rollback'.)

Closes #410. This work is loosely based on PR #917 by Matthieu Guilbert, but attempts to keep things simpler. I'm no PostgreSQL expert, so reviewers are encouraged to look for edge cases that make this simpler approach fall apart.

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
      --> I'm getting `(no files to check) Skipped`.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
