### PR TITLE
Small developer improvements for Windows-based devs.

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -48,6 +48,10 @@ Create a virtualenv (let's call it pgcli-dev). Activate it:
 
     source ./pgcli-dev/bin/activate
 
+    or
+
+    .\pgcli-dev\scripts\activate (for Windows)
+
 Once the virtualenv is activated, `cd` into the local clone of pgcli folder
 and install pgcli using pip as follows:
 
@@ -72,6 +76,37 @@ Adding PostgreSQL Special (Meta) Commands
 If you want to work on adding new meta-commands (such as `\dp`, `\ds`, `dy`),
 you need to contribute to `pgspecial <https://github.com/dbcli/pgspecial/>`_
 project.
+
+Visual Studio Code Debugging
+-----------------------------
+To set up Visual Studio Code to debug pgcli requires a launch.json file.
+
+Within the project, create a file: .vscode\\launch.json like below.
+
+::
+
+    {
+        // Use IntelliSense to learn about possible attributes.
+        // Hover to view descriptions of existing attributes.
+        // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "Python: Module",
+                "type": "python",
+                "request": "launch",
+                "module": "pgcli.main",
+                "justMyCode": false,
+                "console": "externalTerminal",
+                "env": {
+                    "PGUSER": "postgres",
+                    "PGPASS": "password",
+                    "PGHOST": "localhost",
+                    "PGPORT": "5432"
+                }
+            }
+        ]
+    }
 
 Building RPM and DEB packages
 -----------------------------
@@ -145,6 +180,7 @@ service for the changes to take effect.
     $ sudo service postgresql restart
 
 After that, tests in the ``/pgcli/tests`` directory can be run with:
+(Note that these ``behave`` tests do not currently work when developing on Windows due to pexpect incompatibility.)
 
 ::
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,7 @@ Bug fixes:
 
 * Fix exception when retrieving password from keyring ([issue 1338](https://github.com/dbcli/pgcli/issues/1338)).
 * Fix using comments with special commands ([issue 1362](https://github.com/dbcli/pgcli/issues/1362)).
+* Small improvements to the Windows developer experience
 
 Internal:
 ---------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ pytest>=2.7.0
 tox>=1.9.2
 behave>=1.2.4
 black>=22.3.0
-pexpect==3.3
+pexpect==3.3; platform_system != "Windows"
 pre-commit>=1.16.0
 coverage>=5.0.4
 codecov>=1.5.1
@@ -10,3 +10,4 @@ docutils>=0.13.1
 autopep8>=1.3.3
 twine>=1.11.0
 wheel>=0.33.6
+sshtunnel>=0.4.0

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,11 @@ install_requirements = [
 # so we'll only install it if we're not in Windows.
 if platform.system() != "Windows" and not platform.system().startswith("CYGWIN"):
     install_requirements.append("setproctitle >= 1.1.9")
+        
+# Windows will require the binary psycopg to run pgcli
+if platform.system() == "Windows":
+    install_requirements.append("psycopg-binary >= 3.0.14")
+
 
 setup(
     name="pgcli",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requirements = [
 # so we'll only install it if we're not in Windows.
 if platform.system() != "Windows" and not platform.system().startswith("CYGWIN"):
     install_requirements.append("setproctitle >= 1.1.9")
-        
+
 # Windows will require the binary psycopg to run pgcli
 if platform.system() == "Windows":
     install_requirements.append("psycopg-binary >= 3.0.14")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Some small improvements to make the development cycle better on Windows.
- requirements-dev.txt - ```pexpect``` doesn't work on Windows so I just put in a conditional to skip it on Windows.  Also added ```sshtunnel``` since tests require it.
- setup.py - downloading ```psycopg-binary >= 3.0.14``` on Windows only because Windows won't work without the binary version
- Some additions to DEVELOP.rst to give hints on how to do things on Windows and with VSCode debugging.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
