### PR TITLE
Esc + Enter should sumbit the query in safe multiline mode.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -7,6 +7,7 @@ Bug fixes:
 * Fix exception when retrieving password from keyring ([issue 1338](https://github.com/dbcli/pgcli/issues/1338)).
 * Fix using comments with special commands ([issue 1362](https://github.com/dbcli/pgcli/issues/1362)).
 * Small improvements to the Windows developer experience
+* Fix submitting queries in safe multiline mode ([1360](https://github.com/dbcli/pgcli/issues/1360)).
 
 Internal:
 ---------
@@ -21,7 +22,7 @@ Bug fixes:
 ----------
 
 * Fix the bug with Redshift not displaying word count in status ([related issue](https://github.com/dbcli/pgcli/issues/1320)).
-* Show the error status for CSV output format. 
+* Show the error status for CSV output format.
 
 
 3.4.0 (2022/02/21)

--- a/pgcli/key_bindings.py
+++ b/pgcli/key_bindings.py
@@ -9,7 +9,7 @@ from prompt_toolkit.filters import (
     vi_mode,
 )
 
-from .pgbuffer import buffer_should_be_handled
+from .pgbuffer import buffer_should_be_handled, safe_multi_line_mode
 
 _logger = logging.getLogger(__name__)
 
@@ -114,7 +114,7 @@ def pgcli_bindings(pgcli):
         _logger.debug("Detected enter key.")
         event.current_buffer.validate_and_handle()
 
-    @kb.add("escape", "enter", filter=~vi_mode)
+    @kb.add("escape", "enter", filter=~vi_mode & ~safe_multi_line_mode(pgcli))
     def _(event):
         """Introduces a line break regardless of multi-line mode or not."""
         _logger.debug("Detected alt-enter key.")

--- a/pgcli/pgbuffer.py
+++ b/pgcli/pgbuffer.py
@@ -25,8 +25,11 @@ mode, which by default will insert new lines on Enter.
 def safe_multi_line_mode(pgcli):
     @Condition
     def cond():
-        _logger.debug('Multi-line mode state: "%s" / "%s"', pgcli.multi_line, pgcli.multiline_mode)
+        _logger.debug(
+            'Multi-line mode state: "%s" / "%s"', pgcli.multi_line, pgcli.multiline_mode
+        )
         return pgcli.multi_line and (pgcli.multiline_mode == "safe")
+
     return cond
 
 

--- a/pgcli/pgbuffer.py
+++ b/pgcli/pgbuffer.py
@@ -22,6 +22,14 @@ mode, which by default will insert new lines on Enter.
 """
 
 
+def safe_multi_line_mode(pgcli):
+    @Condition
+    def cond():
+        _logger.debug('Multi-line mode state: "%s" / "%s"', pgcli.multi_line, pgcli.multiline_mode)
+        return pgcli.multi_line and (pgcli.multiline_mode == "safe")
+    return cond
+
+
 def buffer_should_be_handled(pgcli):
     @Condition
     def cond():


### PR DESCRIPTION
## Description

Fixes https://github.com/dbcli/pgcli/issues/1360. Safe multiline mode is not working as expected, there's no way to submit the query.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
