### PR TITLE
magic: use PGCli.connect_uri instead of connect

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -124,6 +124,7 @@ Contributors:
     * Kian-Meng Ang (kianmeng)
     * Liu Zhao (astroshot)
     * Rigo Neri (rigoneri)
+    * Anna Glasgall (annathyst)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -7,6 +7,7 @@ Features:
 * Changed the `destructive_warning` config to be a list of commands that are considered 
   destructive. This would allow you to be warned on `create`, `grant`, or `insert` queries.
 * Destructive warnings will now include the alias dsn connection string name if provided (-D option).
+* pgcli.magic will now work with connection URLs that use TLS client certificates for authentication
 
 3.5.0 (2022/09/15):
 ===================

--- a/pgcli/magic.py
+++ b/pgcli/magic.py
@@ -43,7 +43,7 @@ def pgcli_line_magic(line):
         u = conn.session.engine.url
         _logger.debug("New pgcli: %r", str(u))
 
-        pgcli.connect(u.database, u.host, u.username, u.port, u.password)
+        pgcli.connect_uri(str(u._replace(drivername="postgres")))
         conn._pgcli = pgcli
 
     # For convenience, print the connection alias


### PR DESCRIPTION
This makes %pgcli work even if you use non-password (e.g. TLS cert) authentication

## Description
<!--- Describe your changes in detail. -->
This change changes `pgcli.magic` to use `PGCli.connect_uri` instead of `PGCli.connect`, to make it work with PG connection urls that use TLS certs for authentication instead of username/password.

I looked into passing the underlying pg connection from sqlalchemy into pgcli instead (it's the `connection` method on `conn.session` to get a dbapi-connection-alike, or `conn.session.connection.dbapi_connection` to get the real underlying connection), but pgcli is using psycopg3 and sqlalchemy is still using psycopg2. So that won't be as easy without writing some sort of compatibility shim (sqlalchemy supports psycopg3 in 2.0, which is still in beta, so this problem will eventually go away)


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
