### PR TITLE
Do not automatically restart connection on destructive warning

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,8 @@ Features:
 * pgcli.magic will now work with connection URLs that use TLS client certificates for authentication
 * Have config option to retry queries on operational errors like connections being lost.
   Also prevents getting stuck in a retry loop.
+* Config option to not restart connection when cancelling a `destructive_warning` query. By default,
+  it will now not restart.
 
 3.5.0 (2022/09/15):
 ===================

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -29,6 +29,12 @@ multi_line_mode = psql
 # "unconditional_update" will warn you of update statements that don't have a where clause
 destructive_warning = drop, shutdown, delete, truncate, alter, update, unconditional_update
 
+# Destructive warning can restart the connection if this is enabled and the
+# user declines. This means that any current uncommitted transaction can be
+# aborted if the user doesn't want to proceed with a destructive_warning 
+# statement.
+destructive_warning_restarts_connection = False
+
 # Enables expand mode, which is similar to `\x` in psql.
 expand = False
 

--- a/tests/features/basic_commands.feature
+++ b/tests/features/basic_commands.feature
@@ -23,6 +23,13 @@ Feature: run the cli,
      When we send "ctrl + d"
       then dbcli exits
 
+  Scenario: interrupt current query via "ctrl + c"
+     When we send sleep query
+      and we send "ctrl + c"
+      then we see cancelled query warning
+      when we check for any non-idle sleep queries
+      then we don't see any non-idle sleep queries
+
   Scenario: list databases
       When we list databases
       then we see list of databases

--- a/tests/features/crud_database.feature
+++ b/tests/features/crud_database.feature
@@ -5,7 +5,7 @@ Feature: manipulate databases:
      When we create database
       then we see database created
       when we drop database
-      then we confirm the destructive warning
+      then we respond to the destructive warning: y
       then we see database dropped
       when we connect to dbserver
       then we see database connected

--- a/tests/features/crud_table.feature
+++ b/tests/features/crud_table.feature
@@ -8,15 +8,38 @@ Feature: manipulate tables:
       then we see table created
       when we insert into table
       then we see record inserted
+      when we select from table
+      then we see data selected: initial
       when we update table
       then we see record updated
       when we select from table
-      then we see data selected
+      then we see data selected: updated
       when we delete from table
-      then we confirm the destructive warning
+      then we respond to the destructive warning: y
       then we see record deleted
       when we drop table
-      then we confirm the destructive warning
+      then we respond to the destructive warning: y
       then we see table dropped
       when we connect to dbserver
       then we see database connected
+
+  Scenario: transaction handling, with cancelling on a destructive warning.
+    When we connect to test database
+      then we see database connected
+      when we create table
+      then we see table created
+      when we begin transaction
+      then we see transaction began
+      when we insert into table
+      then we see record inserted
+      when we delete from table
+      then we respond to the destructive warning: n
+      when we select from table
+      then we see data selected: initial
+      when we rollback transaction
+      then we see transaction rolled back
+      when we select from table
+      then we see select output without data
+      when we drop table
+      then we respond to the destructive warning: y
+      then we see table dropped

--- a/tests/features/expanded.feature
+++ b/tests/features/expanded.feature
@@ -7,7 +7,7 @@ Feature: expanded mode:
       and we select from table
       then we see expanded data selected
       when we drop table
-      then we confirm the destructive warning
+      then we respond to the destructive warning: y
       then we see table dropped
 
   Scenario: expanded off
@@ -16,7 +16,7 @@ Feature: expanded mode:
       and we select from table
       then we see nonexpanded data selected
       when we drop table
-      then we confirm the destructive warning
+      then we respond to the destructive warning: y
       then we see table dropped
 
   Scenario: expanded auto
@@ -25,5 +25,5 @@ Feature: expanded mode:
       and we select from table
       then we see auto data selected
       when we drop table
-      then we confirm the destructive warning
+      then we respond to the destructive warning: y
       then we see table dropped

--- a/tests/features/steps/crud_table.py
+++ b/tests/features/steps/crud_table.py
@@ -9,6 +9,10 @@ from textwrap import dedent
 import wrappers
 
 
+INITIAL_DATA = "xxx"
+UPDATED_DATA = "yyy"
+
+
 @when("we create table")
 def step_create_table(context):
     """
@@ -22,7 +26,7 @@ def step_insert_into_table(context):
     """
     Send insert into table.
     """
-    context.cli.sendline("""insert into a(x) values('xxx');""")
+    context.cli.sendline(f"""insert into a(x) values('{INITIAL_DATA}');""")
 
 
 @when("we update table")
@@ -30,7 +34,9 @@ def step_update_table(context):
     """
     Send insert into table.
     """
-    context.cli.sendline("""update a set x = 'yyy' where x = 'xxx';""")
+    context.cli.sendline(
+        f"""update a set x = '{UPDATED_DATA}' where x = '{INITIAL_DATA}';"""
+    )
 
 
 @when("we select from table")
@@ -46,7 +52,7 @@ def step_delete_from_table(context):
     """
     Send deete from table.
     """
-    context.cli.sendline("""delete from a where x = 'yyy';""")
+    context.cli.sendline(f"""delete from a where x = '{UPDATED_DATA}';""")
 
 
 @when("we drop table")
@@ -55,6 +61,30 @@ def step_drop_table(context):
     Send drop table.
     """
     context.cli.sendline("drop table a;")
+
+
+@when("we alter the table")
+def step_alter_table(context):
+    """
+    Alter the table by adding a column.
+    """
+    context.cli.sendline("""alter table a add column y varchar;""")
+
+
+@when("we begin transaction")
+def step_begin_transaction(context):
+    """
+    Begin transaction
+    """
+    context.cli.sendline("begin;")
+
+
+@when("we rollback transaction")
+def step_rollback_transaction(context):
+    """
+    Rollback transaction
+    """
+    context.cli.sendline("rollback;")
 
 
 @then("we see table created")
@@ -81,21 +111,42 @@ def step_see_record_updated(context):
     wrappers.expect_pager(context, "UPDATE 1\r\n", timeout=2)
 
 
-@then("we see data selected")
-def step_see_data_selected(context):
+@then("we see data selected: {data}")
+def step_see_data_selected(context, data):
     """
-    Wait to see select output.
+    Wait to see select output with initial or updated data.
+    """
+    x = UPDATED_DATA if data == "updated" else INITIAL_DATA
+    wrappers.expect_pager(
+        context,
+        dedent(
+            f"""\
+            +-----+\r
+            | x   |\r
+            |-----|\r
+            | {x} |\r
+            +-----+\r
+            SELECT 1\r
+        """
+        ),
+        timeout=1,
+    )
+
+
+@then("we see select output without data")
+def step_see_no_data_selected(context):
+    """
+    Wait to see select output without data.
     """
     wrappers.expect_pager(
         context,
         dedent(
             """\
-            +-----+\r
-            | x   |\r
-            |-----|\r
-            | yyy |\r
-            +-----+\r
-            SELECT 1\r
+            +---+\r
+            | x |\r
+            |---|\r
+            +---+\r
+            SELECT 0\r
         """
         ),
         timeout=1,
@@ -116,3 +167,19 @@ def step_see_table_dropped(context):
     Wait to see drop output.
     """
     wrappers.expect_pager(context, "DROP TABLE\r\n", timeout=2)
+
+
+@then("we see transaction began")
+def step_see_transaction_began(context):
+    """
+    Wait to see transaction began.
+    """
+    wrappers.expect_pager(context, "BEGIN\r\n", timeout=2)
+
+
+@then("we see transaction rolled back")
+def step_see_transaction_rolled_back(context):
+    """
+    Wait to see transaction rollback.
+    """
+    wrappers.expect_pager(context, "ROLLBACK\r\n", timeout=2)


### PR DESCRIPTION
## Description
Before this change, cancelling a query with a destructive warning would automatically restart the connection. This can be unintuitive behavior for users that might expect only their destructive warning statement to be cancelled. For instance, a user in the middle of a transaction could have their entire transaction aborted because they cancelled a destructive warning statement, leading to previous non-destructive inserts being lost. 

With the new default for this config option (not automatically restarting the whole connection), the past statements within the transaction will not be lost, and the user may continue executing more statements within the same transaction.

This change adds a config option for whether or not a destructive warning will restart the connection, and defaults it to False. It only affects statements issued directly in the cli, and not destructive warnings from sql statements files.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
