### PR TITLE
Add config option to not automatically retry connections with operational errors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -125,6 +125,7 @@ Contributors:
     * Liu Zhao (astroshot)
     * Rigo Neri (rigoneri)
     * Anna Glasgall (annathyst)
+    * Andy Schoenberger (andyscho)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -8,6 +8,8 @@ Features:
   destructive. This would allow you to be warned on `create`, `grant`, or `insert` queries.
 * Destructive warnings will now include the alias dsn connection string name if provided (-D option).
 * pgcli.magic will now work with connection URLs that use TLS client certificates for authentication
+* Have config option to retry queries on operational errors like connections being lost.
+  Also prevents getting stuck in a retry loop.
 
 3.5.0 (2022/09/15):
 ===================

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -35,6 +35,10 @@ expand = False
 # Enables auto expand mode, which is similar to `\x auto` in psql.
 auto_expand = False
 
+# Auto-retry queries on connection failures and other operational errors. If
+# False, will prompt to rerun the failed query instead of auto-retrying.
+auto_retry_closed_connection = True
+
 # If set to True, table suggestions will include a table alias
 generate_aliases = False
 


### PR DESCRIPTION
## Description
This change:
1. Adds a config option (defaulting to auto-retrying) for whether or not to retry a query after it has failed with an OperationalError.
2. Will only retry at most once on a connection that failed with an OperationalError. This will still be pretty usable and non-invasive in scenarios where we should gracefully reconnect and run a query, as in the scenario outlined in the PR introducing auto-retrying (#1009).

It is not necessarily good to always reconnect and retry queries that fail with an OperationalError. For instance, it might be desirable for a database admin to be able to kill a long-running resource-hogging query that a user left running unattended. Before this change, if the misbehaving query was killed with pg_terminate_backend, it would just be automatically restarted. Even worse, before this change, the query could find itself in a reconnect-and-retry loop since every time it's killed with pg_terminate_backend, it will just start up again automatically. Since the database admin might not necessarily even be aware of this as a possibility, it might be difficult to debug.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
