### PR TITLE
separate formatted status lines from normal output and send to stderr

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -126,6 +126,7 @@ Contributors:
     * Rigo Neri (rigoneri)
     * Anna Glasgall (annathyst)
     * Andy Schoenberger (andyscho)
+    * teepark
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,7 @@ Features:
 * pgcli.magic will now work with connection URLs that use TLS client certificates for authentication
 * Have config option to retry queries on operational errors like connections being lost.
   Also prevents getting stuck in a retry loop.
+* Send trailing status and error lines to stderr to avoid breaking pagers expecting CSV or TSV.
 
 3.5.0 (2022/09/15):
 ===================

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -56,7 +56,7 @@ def test_obfuscate_process_password():
 
 def test_format_output():
     settings = OutputSettings(table_format="psql", dcmlfmt="d", floatfmt="g")
-    results = format_output(
+    results, errout = format_output(
         "Title", [("abc", "def")], ["head1", "head2"], "test status", settings
     )
     expected = [
@@ -66,16 +66,16 @@ def test_format_output():
         "|-------+-------|",
         "| abc   | def   |",
         "+-------+-------+",
-        "test status",
     ]
     assert list(results) == expected
+    assert list(errout) == ["test status"]
 
 
 def test_format_output_truncate_on():
     settings = OutputSettings(
         table_format="psql", dcmlfmt="d", floatfmt="g", max_field_width=10
     )
-    results = format_output(
+    results, _ = format_output(
         None,
         [("first field value", "second field value")],
         ["head1", "head2"],
@@ -97,7 +97,7 @@ def test_format_output_truncate_off():
         table_format="psql", dcmlfmt="d", floatfmt="g", max_field_width=None
     )
     long_field_value = ("first field " * 100).strip()
-    results = format_output(None, [(long_field_value,)], ["head1"], None, settings)
+    results, _ = format_output(None, [(long_field_value,)], ["head1"], None, settings)
     lines = list(results)
     assert lines[3] == f"| {long_field_value} |"
 
@@ -154,7 +154,7 @@ def test_format_output_auto_expand():
     settings = OutputSettings(
         table_format="psql", dcmlfmt="d", floatfmt="g", max_width=100
     )
-    table_results = format_output(
+    table_results, status_results = format_output(
         "Title", [("abc", "def")], ["head1", "head2"], "test status", settings
     )
     table = [
@@ -164,10 +164,10 @@ def test_format_output_auto_expand():
         "|-------+-------|",
         "| abc   | def   |",
         "+-------+-------+",
-        "test status",
     ]
     assert list(table_results) == table
-    expanded_results = format_output(
+    assert list(status_results) == ["test status"]
+    expanded_results, status_results = format_output(
         "Title",
         [("abc", "def")],
         ["head1", "head2"],
@@ -179,9 +179,9 @@ def test_format_output_auto_expand():
         "-[ RECORD 1 ]-------------------------",
         "head1 | abc",
         "head2 | def",
-        "test status",
     ]
     assert "\n".join(expanded_results) == "\n".join(expanded)
+    assert "\n".join(status_results) == "test status"
 
 
 termsize = namedtuple("termsize", ["rows", "columns"])


### PR DESCRIPTION
## Description
pgcli only makes use of standard out for output, including sending output to a pager. But there is no good way to mix formatted query output with trailing status lines ("SELECT N" &c) and error messages.

One choice is you can omit these status and error messages entirely with programmatic output (as was done before #1341) and take away users' ability to see these important messages (see #1326 - though the title is confusing because the author was under the impression stderr was already being used). Or you include them and confuse helpful pager programs like visidata that expect to only receive CSV:
![invalid CSV being handled by visidata](https://user-images.githubusercontent.com/37182/201416370-de591ad8-f520-4549-9d72-23271deb464f.png)

But this is why stderr exists, and it gives us the best of both worlds: users can still see this output on the terminal, but it won't be sent into the pager program.

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
