### PR TITLE
fix psycopg.sql.Identifier in \ev handling

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,7 @@ Features:
   Also prevents getting stuck in a retry loop.
 * Config option to not restart connection when cancelling a `destructive_warning` query. By default,
   it will now not restart.
+* Fix \ev not producing a correctly quoted "schema"."view"
 
 3.5.0 (2022/09/15):
 ===================

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -470,7 +470,7 @@ class PGExecute:
             return (
                 psycopg.sql.SQL(template)
                 .format(
-                    name=psycopg.sql.Identifier(f"{result.nspname}.{result.relname}"),
+                    name=psycopg.sql.Identifier(result.nspname, result.relname),
                     stmt=psycopg.sql.SQL(result.viewdef),
                 )
                 .as_string(self.conn)

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -558,6 +558,7 @@ def test_view_definition(executor):
     run(executor, "create view vw1 AS SELECT * FROM tbl1")
     run(executor, "create materialized view mvw1 AS SELECT * FROM tbl1")
     result = executor.view_definition("vw1")
+    assert 'VIEW "public"."vw1" AS' in result
     assert "FROM tbl1" in result
     # import pytest; pytest.set_trace()
     result = executor.view_definition("mvw1")


### PR DESCRIPTION
## Description
This fixes the issue outlined in #1372 by changing the [psycopg.sql.Identifier](https://www.psycopg.org/psycopg3/docs/api/sql.html#psycopg.sql.Identifier). I would guess this problem originally entered the codebase relatively recently during the port to psycopg3.

Before this PR, `CREATE OR REPLACE VIEW` will not replace the view, and will instead create a new view with the name `<schema>.<view>`, leaving the original view unchanged.

Adds extremely small test assertion to make sure the view is quoted correctly.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
