### PR TITLE
Add config option to always run with a single connection

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -13,6 +13,7 @@ Features:
 * Config option to not restart connection when cancelling a `destructive_warning` query. By default,
   it will now not restart.
 * Fix \ev not producing a correctly quoted "schema"."view"
+* Config option to always run with a single connection.
 
 3.5.0 (2022/09/15):
 ===================

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -264,6 +264,9 @@ class PGCli:
         # Initialize completer
         smart_completion = c["main"].as_bool("smart_completion")
         keyword_casing = c["main"]["keyword_casing"]
+        single_connection = single_connection or c["main"].as_bool(
+            "always_use_single_connection"
+        )
         self.settings = {
             "casing_file": get_casing_file(c),
             "generate_casing_file": c["main"].as_bool("generate_casing_file"),

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -9,6 +9,10 @@ smart_completion = True
 # visible.)
 wider_completion_menu = False
 
+# Do not create new connections for refreshing completions; Equivalent to
+# always running with the --single-connection flag.
+always_use_single_connection = False
+
 # Multi-line mode allows breaking up the sql statements into multiple lines. If
 # this is set to True, then the end of the statements must have a semi-colon.
 # If this is set to False then sql statements can't be split into multiple


### PR DESCRIPTION
## Description
Add a config option for always running with a single connection. This is equivalent to always running with the `--single-connection` flag.

This is a very minor change, but this flag seems like it's the type of thing that would be useful to have persist as a regular config setting; for people that use it, it can be annoying to always have to specify it.

Leaving it defaulting to False to have the same behavior as before this change (not specifying the flag will not run in single-connection mode). When the config setting is False, users can still enable it in a non-persistent way by running with the flag in the same way as before.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
