### PR TITLE
convert to dual outputs: pager and stdout

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -126,6 +126,7 @@ Contributors:
     * Rigo Neri (rigoneri)
     * Anna Glasgall (annathyst)
     * Andy Schoenberger (andyscho)
+    * Travis Parker (teepark)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -19,6 +19,7 @@ Bug fixes:
 
 * Fix \ev not producing a correctly quoted "schema"."view"
 * Fix 'invalid connection option "dsn"' ([issue 1373](https://github.com/dbcli/pgcli/issues/1373)).
+* Bypass the pager for status output to clean up use with programmatic pagers.
 
 3.5.0 (2022/09/15):
 ===================

--- a/pgcli/output.py
+++ b/pgcli/output.py
@@ -4,25 +4,16 @@ import click
 #   def emit(self, cmd: str, output: str) -> None
 
 
-class Pager:
+class OutputHandler:
     """
-    An output target which emits to the pager via the PGCli object.
-    """
-
-    def __init__(self, cli):
-        self._cli = cli
-
-    def emit(self, cmd, output):
-        self._cli.echo_via_pager(output)
-
-
-class Stdout:
-    """
-    An output which emits to stdout via `click.echo()`.
+    An output which ignores the cmd and sends output through a provided handler function.
     """
 
-    def emit(self, cmd, output):
-        click.echo(output)
+    def __init__(self, handler):
+        self._handler = handler
+
+    def emit(self, _, output):
+        self._handler(output)
 
 
 class Log:
@@ -30,21 +21,24 @@ class Log:
     An output wrapper which optionally emits to a log file instead.
     """
 
-    def __init__(self, cli, parent):
-        self._cli = cli
-        self._parent = parent
+    def __init__(self, logpath, parent):
+        self._logpath = logpath
+        self.parent = parent
+
+    def update(self, logpath):
+        self._logpath = logpath
 
     def _emit(self, cmd, output):
-        if self._cli.output_file and not cmd.startswith(("\\o ", "\\? ")):
+        if self._logpath and not cmd.startswith(("\\o ", "\\? ")):
             try:
-                with open(self._cli.output_file, "a", encoding="utf-8") as f:
+                with open(self._logpath, "a", encoding="utf-8") as f:
                     click.echo(cmd, file=f)
                     click.echo(output, file=f)
                     click.echo("", file=f)  # extra newline
             except OSError as e:
                 click.secho(str(e), err=True, fg="red")
         elif output:
-            self._parent.emit(cmd, output)
+            self.parent.emit(cmd, output)
 
     def emit(self, cmd, output):
         try:

--- a/pgcli/output.py
+++ b/pgcli/output.py
@@ -1,0 +1,53 @@
+import click
+
+# output interface:
+#   def emit(self, cmd: str, output: str) -> None
+
+
+class Pager:
+    """
+    An output target which emits to the pager via the PGCli object.
+    """
+
+    def __init__(self, cli):
+        self._cli = cli
+
+    def emit(self, cmd, output):
+        self._cli.echo_via_pager(output)
+
+
+class Stdout:
+    """
+    An output which emits to stdout via `click.echo()`.
+    """
+
+    def emit(self, cmd, output):
+        click.echo(output)
+
+
+class Log:
+    """
+    An output wrapper which optionally emits to a log file instead.
+    """
+
+    def __init__(self, cli, parent):
+        self._cli = cli
+        self._parent = parent
+
+    def _emit(self, cmd, output):
+        if self._cli.output_file and not cmd.startswith(("\\o ", "\\? ")):
+            try:
+                with open(self._cli.output_file, "a", encoding="utf-8") as f:
+                    click.echo(cmd, file=f)
+                    click.echo(output, file=f)
+                    click.echo("", file=f)  # extra newline
+            except OSError as e:
+                click.secho(str(e), err=True, fg="red")
+        elif output:
+            self._parent.emit(cmd, output)
+
+    def emit(self, cmd, output):
+        try:
+            self._emit(cmd, output)
+        except KeyboardInterrupt:
+            pass

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,7 +27,17 @@ def format_output(title, cur, headers, status, settings, explain_mode=False):
     output = []
     cli.pager_output.emit.side_effect = lambda _, t: output.extend(t.split("\n"))
     cli.stdout_output.emit.side_effect = lambda _, t: output.extend(t.split("\n"))
-    emit_output(cli, "", title, cur, headers, status, settings, explain_mode)
+    emit_output(
+        cli.stdout_output,
+        cli.pager_output,
+        "",
+        title,
+        cur,
+        headers,
+        status,
+        settings,
+        explain_mode,
+    )
     return output
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,7 +11,7 @@ except ImportError:
 
 from pgcli.main import (
     obfuscate_process_password,
-    format_output,
+    emit_output,
     PGCli,
     OutputSettings,
     COLOR_CODE_REGEX,
@@ -20,6 +20,15 @@ from pgcli.pgexecute import PGExecute
 from pgspecial.main import PAGER_OFF, PAGER_LONG_OUTPUT, PAGER_ALWAYS
 from utils import dbtest, run
 from collections import namedtuple
+
+
+def format_output(title, cur, headers, status, settings, explain_mode=False):
+    cli = mock.Mock()
+    output = []
+    cli.pager_output.emit.side_effect = lambda _, t: output.extend(t.split("\n"))
+    cli.stdout_output.emit.side_effect = lambda _, t: output.extend(t.split("\n"))
+    emit_output(cli, "", title, cur, headers, status, settings, explain_mode)
+    return output
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Not applicable in windows")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,8 @@
 import pytest
 import psycopg
-from pgcli.main import format_output, OutputSettings
+from pgcli.main import emit_output, OutputSettings
 from os import getenv
+from unittest.mock import Mock
 
 POSTGRES_USER = getenv("PGUSER", "postgres")
 POSTGRES_HOST = getenv("PGHOST", "localhost")
@@ -77,8 +78,15 @@ def run(
     settings = OutputSettings(
         table_format="psql", dcmlfmt="d", floatfmt="g", expanded=expanded
     )
+    cli = Mock()
     for title, rows, headers, status, sql, success, is_special in results:
-        formatted.extend(format_output(title, rows, headers, status, settings))
+        emit_output(cli, "", title, rows, headers, status, settings)
+
+    if cli.pager_output.emit.called:
+        formatted.extend([c.args[1] for c in cli.pager_output.emit.call_args_list])
+    if cli.stdout_output.emit.called:
+        formatted.extend([c.args[1] for c in cli.stdout_output.emit.call_args_list])
+
     if join:
         formatted = "\n".join(formatted)
 


### PR DESCRIPTION
regular output (mainly query results) goes to the pager. status output goes directly to stdout.
both implement a consistent interface for easy mocking in tests.

## Description
Picking up where #1383 left off.

We agreed on the need to separate normal query result output from status output. The previous PR used stdout and stderr, but we decided instead to use _the pager's stdin_ and _pgcli's stdout_ as the two streams.

Further, because there's a need to maintain order in the output lines even across the two streams, this PR inverts control and takes a DI approach, pushing "output emitters" down into the PGCli object. The previously pure "format_output" function is now "emit_output" which takes the injected emitters. For tests, we mock out the emitters with an implementation that collects the output lines in order for later assertions.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `changelog.rst`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [X] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
