### PR TITLE
Fix connecting with dsn.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           pip install keyrings.alt>=3.1
 
       - name: Run unit tests
-        run: coverage run --source pgcli -m py.test
+        run: coverage run --source pgcli -m pytest
 
       - name: Run integration tests
         env:

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,7 +4,7 @@ Upcoming
 Features:
 ---------
 
-* Changed the `destructive_warning` config to be a list of commands that are considered 
+* Changed the `destructive_warning` config to be a list of commands that are considered
   destructive. This would allow you to be warned on `create`, `grant`, or `insert` queries.
 * Destructive warnings will now include the alias dsn connection string name if provided (-D option).
 * pgcli.magic will now work with connection URLs that use TLS client certificates for authentication
@@ -12,7 +12,12 @@ Features:
   Also prevents getting stuck in a retry loop.
 * Config option to not restart connection when cancelling a `destructive_warning` query. By default,
   it will now not restart.
+
+Bug fixes:
+----------
+
 * Fix \ev not producing a correctly quoted "schema"."view"
+* Fix 'invalid connection option "dsn"' ([issue 1373](https://github.com/dbcli/pgcli/issues/1373)).
 
 3.5.0 (2022/09/15):
 ===================

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -203,7 +203,11 @@ class PGExecute:
 
         conn_params.update({k: v for k, v in new_params.items() if v})
 
-        conn_info = make_conninfo(**conn_params)
+        if "dsn" in conn_params:
+            other_params = {k: v for k, v in conn_params.items() if k != "dsn"}
+            conn_info = make_conninfo(conn_params["dsn"], **other_params)
+        else:
+            conn_info = make_conninfo(**conn_params)
         conn = psycopg.connect(conn_info)
         conn.cursor_factory = ProtocolSafeCursor
 


### PR DESCRIPTION
## Description

Fix for https://github.com/dbcli/pgcli/issues/1373.

I'm not sure how long this has been broken, possibly since the [port to psycopg 3](https://github.com/dbcli/pgcli/pull/1324). We started using the call to `make_conninfo` vs the old `make_dsn`, but it looks like `make_conninfo` does not expect `dsn=xxx` as part of the parameters.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
