### PR TITLE
Add comment to pgclirc pager section on default LESS

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -13,6 +13,7 @@ Features:
 * Config option to not restart connection when cancelling a `destructive_warning` query. By default,
   it will now not restart.
 * Config option to always run with a single connection.
+* Add comment explaining default LESS environment variable behavior and change example pager setting.
 
 Bug fixes:
 ----------

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -95,9 +95,10 @@ qualify_columns = if_more_than_one_table
 # When no schema is entered, only suggest objects in search_path
 search_path_filter = False
 
-# Default pager.
-# By default 'PAGER' environment variable is used
-# pager = less -SRXF
+# Default pager. See https://www.pgcli.com/pager for more information on settings.
+# By default 'PAGER' environment variable is used. If the pager is less, and the 'LESS'
+# environment variable is not set, then LESS='-SRXF' will be automatically set.
+# pager = less
 
 # Timing of sql statements and table rendering.
 timing = True


### PR DESCRIPTION
## Description
Add brief comment detailing the behavior in [pgcli/main.py](https://github.com/dbcli/pgcli/blob/141873f86d299a7c8469392367b820960d01707a/pgcli/main.py#L160).

I also changed the example `pager` setting since it seemed misleading that the `less` options in the `pager` setting would be able to be used as if the `LESS` environment variable is not being set automatically.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
