### PR TITLE
Fix explain output when running with auto-vertical-output or max_width

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -19,6 +19,7 @@ Bug fixes:
 
 * Fix \ev not producing a correctly quoted "schema"."view"
 * Fix 'invalid connection option "dsn"' ([issue 1373](https://github.com/dbcli/pgcli/issues/1373)).
+* Fix explain mode when used with `expand`, `auto_expand`, or `--explain-vertical-output` ([issue 1393](https://github.com/dbcli/pgcli/issues/1393)).
 
 3.5.0 (2022/09/15):
 ===================

--- a/pgcli/explain_output_formatter.py
+++ b/pgcli/explain_output_formatter.py
@@ -10,7 +10,8 @@ class ExplainOutputFormatter:
         self.max_width = max_width
 
     def format_output(self, cur, headers, **output_kwargs):
-        (data,) = cur.fetchone()
+        # explain query results should always contain 1 row each
+        [(data,)] = list(cur)
         explain_list = json.loads(data)
         visualizer = Visualizer(self.max_width)
         for explain in explain_list:

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1602,7 +1602,8 @@ def format_output(title, cur, headers, status, settings, explain_mode=False):
         first_line = next(formatted)
         formatted = itertools.chain([first_line], formatted)
         if (
-            not expanded
+            not explain_mode
+            and not expanded
             and max_width
             and len(strip_ansi(first_line)) > max_width
             and headers


### PR DESCRIPTION
## Description
This PR fixes #1393.

In some circumstance `cur` in the `ExplainOutputFormatter.format_output()` method will already have its results fetched and be a `list`.  This PR makes sure all results are loaded by always converting `cur` to be a `list`. This PR won't be meaningfully worse for memory since it's always just a single explain query result.

Also added an `explain_mode` check on a later code path since explain mode query results are already formatted with a `max_width` automatically and we don't need to attempt to convert them to vertical output if they're wider than `max_width`.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
