### PR TITLE
feature: Add config option to require a transaction for destructive statements

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -126,6 +126,7 @@ Contributors:
     * Rigo Neri (rigoneri)
     * Anna Glasgall (annathyst)
     * Andy Schoenberger (andyscho)
+    * Damien Baty (dbaty)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,8 @@ Upcoming
 Features:
 ---------
 
+* New `destructive_statements_require_transaction` config option to refuse to execute a
+  destructive SQL statement if outside a transaction. This option is off by default.
 * Changed the `destructive_warning` config to be a list of commands that are considered
   destructive. This would allow you to be warned on `create`, `grant`, or `insert` queries.
 * Destructive warnings will now include the alias dsn connection string name if provided (-D option).

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -71,9 +71,9 @@ from .__init__ import __version__
 click.disable_unicode_literals_warning = True
 
 try:
-    from urlparse import urlparse, unquote, parse_qs
+    from urlparse import urlparse
 except ImportError:
-    from urllib.parse import urlparse, unquote, parse_qs
+    from urllib.parse import urlparse
 
 from getpass import getuser
 
@@ -724,7 +724,7 @@ class PGCli:
                         "Destructive statements must be run within a transaction."
                     )
                     raise KeyboardInterrupt
-                destroy = confirm = confirm_destructive_query(
+                destroy = confirm_destructive_query(
                     text, self.destructive_warning, self.dsn_alias
                 )
                 if destroy is False:
@@ -753,7 +753,7 @@ class PGCli:
             click.secho(str(e), err=True, fg="red")
             if handle_closed_connection:
                 self._handle_server_closed_connection(text)
-        except (PgCliQuitError, EOFError) as e:
+        except (PgCliQuitError, EOFError):
             raise
         except Exception as e:
             logger.error("sql: %r, error: %r", text, e)

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -28,16 +28,20 @@ multi_line_mode = psql
 
 # Destructive warning will alert you before executing a sql statement
 # that may cause harm to the database such as "drop table", "drop database",
-# "shutdown", "delete", or "update". 
+# "shutdown", "delete", or "update".
 # You can pass a list of destructive commands or leave it empty if you want to skip all warnings.
 # "unconditional_update" will warn you of update statements that don't have a where clause
 destructive_warning = drop, shutdown, delete, truncate, alter, update, unconditional_update
 
 # Destructive warning can restart the connection if this is enabled and the
 # user declines. This means that any current uncommitted transaction can be
-# aborted if the user doesn't want to proceed with a destructive_warning 
+# aborted if the user doesn't want to proceed with a destructive_warning
 # statement.
 destructive_warning_restarts_connection = False
+
+# When this option is on (and if `destructive_warning` is not empty),
+# destructive statements are not executed when outside of a transaction.
+destructive_statements_require_transaction = False
 
 # Enables expand mode, which is similar to `\x` in psql.
 expand = False


### PR DESCRIPTION
When this option is on, any statement that is deemed destructive (through the use of the existing `destructive_warning` config option) will not be executed unless a transaction has been started. The default value is off (thus not changing the current behaviour).

Demo: [![asciicast](https://asciinema.org/a/564064.svg)](https://asciinema.org/a/564064)

Rationale: I think it's a good practice to execute "destructing" queries within a transaction (even more so when executing multiple queries, obviously!). It provides a last chance to rollback if things go wrong. Especially when it (unfortunately) becomes a reflex to just type "yes, I do want to execute this _destructive_ query, duh!". ;)

Notes:
- tests: I don't know what/which tests to add. I could not see appropriate unit tests to add or adapt, nor any related behaviour test. I'll gladly write tests if anyone can point me in the right direction.
- docs: If merged, [this page](https://github.com/dbcli/pgcli.com/blob/main/content/pages/config.md) will need to be updated to include the new config option.


## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [ ] ~Please squash merge this pull request.~ There is a "lint" commit that could be merged separately from the "feature" commit.
