### PR TITLE
Remove leftovers of Python 2 support

### DIFF
--- a/pgcli/auth.py
+++ b/pgcli/auth.py
@@ -26,7 +26,7 @@ def keyring_initialize(keyring_enabled, *, logger):
 
         try:
             keyring = importlib.import_module("keyring")
-        except Exception as e:  # ImportError for Python 2, ModuleNotFoundError for Python 3
+        except ModuleNotFoundError as e:
             logger.warning("import keyring failed: %r.", e)
 
 

--- a/pgcli/completion_refresher.py
+++ b/pgcli/completion_refresher.py
@@ -6,7 +6,6 @@ from .pgcompleter import PGCompleter
 
 
 class CompletionRefresher:
-
     refreshers = OrderedDict()
 
     def __init__(self):

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -302,7 +302,6 @@ class PGCli:
         raise PgCliQuitError
 
     def register_special_commands(self):
-
         self.pgspecial.register(
             self.change_db,
             "\\c",
@@ -474,7 +473,6 @@ class PGCli:
         return [(None, None, None, message, "", True, True)]
 
     def initialize_logging(self):
-
         log_file = self.config["main"]["log_file"]
         if log_file == "default":
             log_file = config_location() + "log"

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -70,10 +70,7 @@ from .__init__ import __version__
 
 click.disable_unicode_literals_warning = True
 
-try:
-    from urlparse import urlparse
-except ImportError:
-    from urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from getpass import getuser
 

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -290,7 +290,6 @@ def suggest_special(text):
 
 
 def suggest_based_on_last_token(token, stmt):
-
     if isinstance(token, str):
         token_v = token.lower()
     elif isinstance(token, Comparison):
@@ -399,7 +398,6 @@ def suggest_based_on_last_token(token, stmt):
     elif (token_v.endswith("join") and token.is_keyword) or (
         token_v in ("copy", "from", "update", "into", "describe", "truncate")
     ):
-
         schema = stmt.get_identifier_schema()
         tables = extract_tables(stmt.text_before_cursor)
         is_join = token_v.endswith("join") and token.is_keyword
@@ -436,7 +434,6 @@ def suggest_based_on_last_token(token, stmt):
         try:
             prev = stmt.get_previous_token(token).value.lower()
             if prev in ("drop", "alter", "create", "create or replace"):
-
                 # Suggest functions from either the currently-selected schema or the
                 # public schema if no schema has been specified
                 suggest = []

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -157,7 +157,6 @@ class PGCompleter(Completer):
         self.all_completions.update(additional_keywords)
 
     def extend_schemata(self, schemata):
-
         # schemata is a list of schema names
         schemata = self.escaped_names(schemata)
         metadata = self.dbmetadata["tables"]
@@ -226,7 +225,6 @@ class PGCompleter(Completer):
             self.all_completions.add(colname)
 
     def extend_functions(self, func_data):
-
         # func_data is a list of function metadata namedtuples
 
         # dbmetadata['schema_name']['functions']['function_name'] should return
@@ -260,7 +258,6 @@ class PGCompleter(Completer):
         }
 
     def extend_foreignkeys(self, fk_data):
-
         # fk_data is a list of ForeignKey namedtuples, with fields
         # parentschema, childschema, parenttable, childtable,
         # parentcolumns, childcolumns
@@ -283,7 +280,6 @@ class PGCompleter(Completer):
             parcolmeta.foreignkeys.append(fk)
 
     def extend_datatypes(self, type_data):
-
         # dbmetadata['datatypes'][schema_name][type_name] should store type
         # metadata, such as composite type field names. Currently, we're not
         # storing any metadata beyond typename, so just store None
@@ -697,7 +693,6 @@ class PGCompleter(Completer):
         return self.find_matches(word_before_cursor, conds, meta="join")
 
     def get_function_matches(self, suggestion, word_before_cursor, alias=False):
-
         if suggestion.usage == "from":
             # Only suggest functions allowed in FROM clause
 

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -76,7 +76,6 @@ class ProtocolSafeCursor(psycopg.Cursor):
 
 
 class PGExecute:
-
     # The boolean argument to the current_schemas function indicates whether
     # implicit schemas, e.g. pg_catalog
     search_path_query = """
@@ -180,7 +179,6 @@ class PGExecute:
         dsn=None,
         **kwargs,
     ):
-
         conn_params = self._conn_params.copy()
 
         new_params = {

--- a/tests/features/steps/wrappers.py
+++ b/tests/features/steps/wrappers.py
@@ -3,10 +3,7 @@ import pexpect
 from pgcli.main import COLOR_CODE_REGEX
 import textwrap
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 
 
 def expect_exact(context, expected, timeout):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -216,7 +216,6 @@ def pset_pager_mocks():
     with mock.patch("pgcli.main.click.echo") as mock_echo, mock.patch(
         "pgcli.main.click.echo_via_pager"
     ) as mock_echo_via_pager, mock.patch.object(cli, "prompt_app") as mock_app:
-
         yield cli, mock_echo, mock_echo_via_pager, mock_app
 
 
@@ -371,7 +370,6 @@ def test_quoted_db_uri(tmpdir):
 
 
 def test_pg_service_file(tmpdir):
-
     with mock.patch.object(PGCli, "connect") as mock_connect:
         cli = PGCli(pgclirc_file=str(tmpdir.join("rcfile")))
         with open(tmpdir.join(".pg_service.conf").strpath, "w") as service_conf:


### PR DESCRIPTION
## Description

This short pull request removes a few leftovers of Python 2 support. This was prompted by @amjith who detected one such leftover in https://github.com/dbcli/pgcli/pull/1397#discussion_r1140893187.  

## Checklist
- [ ] ~I've added this contribution to the `changelog.rst`.~ Not necessary, I guess?
- [ ] ~I've added my name to the `AUTHORS` file (or it's already there)~ My name is already in this file.
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
