### PR TITLE
Refuse to quit cli if a transaction is ongoing.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,7 @@ Upcoming
 Features:
 ---------
 
+* Ask for confirmation when quitting cli while a transaction is ongoing.
 * New `destructive_statements_require_transaction` config option to refuse to execute a
   destructive SQL statement if outside a transaction. This option is off by default.
 * Changed the `destructive_warning` config to be a list of commands that are considered

--- a/tests/features/basic_commands.feature
+++ b/tests/features/basic_commands.feature
@@ -23,6 +23,23 @@ Feature: run the cli,
      When we send "ctrl + d"
       then dbcli exits
 
+  Scenario: confirm exit when a transaction is ongoing
+     When we begin transaction
+      and we try to send "ctrl + d"
+      then we see ongoing transaction message
+      when we send "c"
+      then dbcli exits
+
+  Scenario: cancel exit when a transaction is ongoing
+     When we begin transaction
+      and we try to send "ctrl + d"
+      then we see ongoing transaction message
+      when we send "a"
+      then we see dbcli prompt
+      when we rollback transaction
+      when we send "ctrl + d"
+      then dbcli exits
+
   Scenario: interrupt current query via "ctrl + c"
      When we send sleep query
       and we send "ctrl + c"

--- a/tests/features/steps/basic_commands.py
+++ b/tests/features/steps/basic_commands.py
@@ -64,13 +64,22 @@ def step_ctrl_d(context):
     """
     Send Ctrl + D to hopefully exit.
     """
+    step_try_to_ctrl_d(context)
+    context.cli.expect(pexpect.EOF, timeout=5)
+    context.exit_sent = True
+
+
+@when('we try to send "ctrl + d"')
+def step_try_to_ctrl_d(context):
+    """
+    Send Ctrl + D, perhaps exiting, perhaps not (if a transaction is
+    ongoing).
+    """
     # turn off pager before exiting
     context.cli.sendcontrol("c")
     context.cli.sendline(r"\pset pager off")
     wrappers.wait_prompt(context)
     context.cli.sendcontrol("d")
-    context.cli.expect(pexpect.EOF, timeout=5)
-    context.exit_sent = True
 
 
 @when('we send "ctrl + c"')
@@ -85,6 +94,14 @@ def step_see_cancelled_query_warning(context):
     Make sure we receive the warning that the current query was cancelled.
     """
     wrappers.expect_exact(context, "cancelled query", timeout=2)
+
+
+@then("we see ongoing transaction message")
+def step_see_ongoing_transaction_error(context):
+    """
+    Make sure we receive the warning that a transaction is ongoing.
+    """
+    context.cli.expect("A transaction is ongoing.", timeout=2)
 
 
 @when("we send sleep query")
@@ -199,3 +216,16 @@ def step_resppond_to_destructive_command(context, response):
 def step_send_password(context):
     wrappers.expect_exact(context, "Password for", timeout=5)
     context.cli.sendline(context.conf["pass"] or "DOES NOT MATTER")
+
+
+@when('we send "{text}"')
+def step_send_text(context, text):
+    context.cli.sendline(text)
+    # Try to detect whether we are exiting. If so, set `exit_sent`
+    # so that `after_scenario` correctly cleans up.
+    try:
+        context.cli.expect(pexpect.EOF, timeout=0.2)
+    except pexpect.TIMEOUT:
+        pass
+    else:
+        context.exit_sent = True


### PR DESCRIPTION
## Description

If a transaction is ongoing, quitting the cli (with "ctrl-d" or "quit") is not possible anymore. An error message is displayed. The user is forced to commit or rollback the transaction before quitting.

Fixes #1071.

## Notes

1. I did not add a new configuration option. **This commit thus changes the current behaviour of pgcli** (for good, I believe). This is debatable, I could add a configuration option (off by default) if preferable.
2. I added a "behave" test. This is my first one, feel free to comment if it's not the right way to do it.
3. Demo: [![asciicast](https://asciinema.org/a/571678.svg)](https://asciinema.org/a/571678)



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- ~[ ] I've added my name to the `AUTHORS` file (or it's already there).~ (I am already in this file.)
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
