### PR TITLE
Fix sql-insert format emits NULL as 'None'

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -23,6 +23,7 @@ Bug fixes:
 * Fix \ev not producing a correctly quoted "schema"."view"
 * Fix 'invalid connection option "dsn"' ([issue 1373](https://github.com/dbcli/pgcli/issues/1373)).
 * Fix explain mode when used with `expand`, `auto_expand`, or `--explain-vertical-output` ([issue 1393](https://github.com/dbcli/pgcli/issues/1393)).
+* Fix sql-insert format emits NULL as 'None' ([issue 1408](https://github.com/dbcli/pgcli/issues/1408)).
 
 3.5.0 (2022/09/15):
 ===================

--- a/pgcli/auth.py
+++ b/pgcli/auth.py
@@ -26,7 +26,9 @@ def keyring_initialize(keyring_enabled, *, logger):
 
         try:
             keyring = importlib.import_module("keyring")
-        except ModuleNotFoundError as e:
+        except (
+            ModuleNotFoundError
+        ) as e:  # ImportError for Python 2, ModuleNotFoundError for Python 3
             logger.warning("import keyring failed: %r.", e)
 
 

--- a/pgcli/packages/formatter/sqlformatter.py
+++ b/pgcli/packages/formatter/sqlformatter.py
@@ -14,12 +14,13 @@ preprocessors = ()
 
 
 def escape_for_sql_statement(value):
+    if value is None:
+        return "NULL"
+
     if isinstance(value, bytes):
         return f"X'{value.hex()}'"
-    elif value is None:
-        return "NULL"
-    else:
-        return "'{}'".format(value)
+
+    return "'{}'".format(value)
 
 
 def adapter(data, headers, table_format=None, **kwargs):

--- a/pgcli/packages/formatter/sqlformatter.py
+++ b/pgcli/packages/formatter/sqlformatter.py
@@ -16,6 +16,8 @@ preprocessors = ()
 def escape_for_sql_statement(value):
     if isinstance(value, bytes):
         return f"X'{value.hex()}'"
+    elif value is None:
+        return "NULL"
     else:
         return "'{}'".format(value)
 
@@ -29,7 +31,7 @@ def adapter(data, headers, table_format=None, **kwargs):
         else:
             table_name = table[1]
     else:
-        table_name = '"DUAL"'
+        table_name = "DUAL"
     if table_format == "sql-insert":
         h = '", "'.join(headers)
         yield 'INSERT INTO "{}" ("{}") VALUES'.format(table_name, h)

--- a/tests/formatter/test_sqlformatter.py
+++ b/tests/formatter/test_sqlformatter.py
@@ -34,7 +34,7 @@ def test_output_sql_insert():
             "Jackson",
             "jackson_test@gmail.com",
             "132454789",
-            "",
+            None,
             "2022-09-09 19:44:32.712343+08",
             "2022-09-09 19:44:32.712343+08",
         ]
@@ -58,7 +58,7 @@ def test_output_sql_insert():
     output_list = [l for l in output]
     expected = [
         'INSERT INTO "user" ("id", "name", "email", "phone", "description", "created_at", "updated_at") VALUES',
-        "  ('1', 'Jackson', 'jackson_test@gmail.com', '132454789', '', "
+        "  ('1', 'Jackson', 'jackson_test@gmail.com', '132454789', NULL, "
         + "'2022-09-09 19:44:32.712343+08', '2022-09-09 19:44:32.712343+08')",
         ";",
     ]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Fix sql-insert format emits NULL as 'None' ([issue 1408](https://github.com/dbcli/pgcli/issues/1408)).


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
