### PR TITLE
For Python >= 3.11 directly use packaging to compare package versions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -127,6 +127,7 @@ Contributors:
     * Anna Glasgall (annathyst)
     * Andy Schoenberger (andyscho)
     * Damien Baty (dbaty)
+    * blag
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -24,6 +24,7 @@ Bug fixes:
 * Fix 'invalid connection option "dsn"' ([issue 1373](https://github.com/dbcli/pgcli/issues/1373)).
 * Fix explain mode when used with `expand`, `auto_expand`, or `--explain-vertical-output` ([issue 1393](https://github.com/dbcli/pgcli/issues/1393)).
 * Fix sql-insert format emits NULL as 'None' ([issue 1408](https://github.com/dbcli/pgcli/issues/1408)).
+* Fix parsing versions for Python 3.11+
 
 3.5.0 (2022/09/15):
 ===================

--- a/changelog.rst
+++ b/changelog.rst
@@ -24,7 +24,7 @@ Bug fixes:
 * Fix 'invalid connection option "dsn"' ([issue 1373](https://github.com/dbcli/pgcli/issues/1373)).
 * Fix explain mode when used with `expand`, `auto_expand`, or `--explain-vertical-output` ([issue 1393](https://github.com/dbcli/pgcli/issues/1393)).
 * Fix sql-insert format emits NULL as 'None' ([issue 1408](https://github.com/dbcli/pgcli/issues/1408)).
-* Fix parsing versions for Python 3.11+
+* Improve check for prompt-toolkit 3.0.6 ([issue 1416](https://github.com/dbcli/pgcli/issues/1416)).
 
 3.5.0 (2022/09/15):
 ===================

--- a/pgcli/pgtoolbar.py
+++ b/pgcli/pgtoolbar.py
@@ -1,9 +1,3 @@
-try:
-    from packaging.version import parse as parse_version
-except ImportError:
-    from pkg_resources.packaging.version import parse as parse_version
-
-import prompt_toolkit
 from prompt_toolkit.key_binding.vi_state import InputMode
 from prompt_toolkit.application import get_app
 
@@ -13,7 +7,8 @@ vi_modes = {
     InputMode.REPLACE: "R",
     InputMode.INSERT_MULTIPLE: "M",
 }
-if parse_version(prompt_toolkit.__version__) >= parse_version("3.0.6"):
+# REPLACE_SINGLE is available in prompt_toolkit >= 3.0.6
+if "REPLACE_SINGLE" in {e.name for e in InputMode}:
     vi_modes[InputMode.REPLACE_SINGLE] = "R"
 
 

--- a/pgcli/pgtoolbar.py
+++ b/pgcli/pgtoolbar.py
@@ -1,10 +1,11 @@
-from pkg_resources import packaging
+try:
+    from packaging.version import parse as parse_version
+except ImportError:
+    from pkg_resources.packaging.version import parse as parse_version
 
 import prompt_toolkit
 from prompt_toolkit.key_binding.vi_state import InputMode
 from prompt_toolkit.application import get_app
-
-parse_version = packaging.version.parse
 
 vi_modes = {
     InputMode.INSERT: "I",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ install_requirements = [
     "configobj >= 5.0.6",
     "pendulum>=2.1.0",
     "cli_helpers[styles] >= 2.2.1",
-    "packaging >= 23.1; python_version >= 3.11",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ install_requirements = [
     "configobj >= 5.0.6",
     "pendulum>=2.1.0",
     "cli_helpers[styles] >= 2.2.1",
+    "packaging >= 23.1; python_version >= 3.11",
 ]
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

On Python 3.11 and beyond, `pkg_resources` no longer bundles `packaging`:

```bash
$ python3.11
Python 3.11.4 (main, Jul 25 2023, 17:35:35)
```
```python
Type "help", "copyright", "credits" or "license" for more information.
>>> import pkg_resources
>>> pkg_resources.packaging
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'pkg_resources' has no attribute 'packaging'
>>>
```

That causes this issue in `pgcli`:

```python
Traceback (most recent call last):
  File ".../bin/pgcli", line 5, in <module>
    from pgcli.main import cli
  File ".../lib/python3.11/site-packages/pgcli/main.py", line 52, in <module>
    from .pgtoolbar import create_toolbar_tokens_func
  File ".../lib/python3.11/site-packages/pgcli/pgtoolbar.py", line 1, in <module>
    from pkg_resources import packaging
ImportError: cannot import name 'packaging' from 'pkg_resources' (unknown location)
```

So for Python 3.11+, we install the `packaging`...package, and use it directly:

```python
try:
    from packaging.version import parse as parse_version
except ImportError:
    from pkg_resources.packaging.version import parse as parse_version
```

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
