### PR TITLE
downgrade pendulum to released version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
 
             psql -h localhost -U postgres -p 6432 pgbouncer -c 'show help'
 
+      - name: Install beta version of pendulum
+        run: pip install pendulum==3.0.0b1
+        if: matrix.python-version == '3.12'
+
       - name: Install requirements
         run: |
           pip install -U pip setuptools

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,14 @@
 
 Features:
 ---------
+* Allow stable version of pendulum
+
+==================
+4.0.0 (2023-11-27)
+==================
+
+Features:
+---------
 
 * Ask for confirmation when quitting cli while a transaction is ongoing.
 * New `destructive_statements_require_transaction` config option to refuse to execute a

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requirements = [
     "psycopg >= 3.0.14",
     "sqlparse >=0.3.0,<0.5",
     "configobj >= 5.0.6",
-    "pendulum>=3.0.0b1",
+    "pendulum>=2.1.0",
     "cli_helpers[styles] >= 2.2.1",
 ]
 


### PR DESCRIPTION
## Description
"Unbump" pendulum to released version (3.0.0b1 is a beta version)

requiring 3.0.0b1 gives problems for packing pgcli for Fedora.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)