### PR TITLE
Fix short host (\h) display in prompt when using an IP address

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,12 @@
+Upcoming
+========
+
+Bug fixes:
+----------
+
+* Fix display of "short host" in prompt (with `\h`) for IPv4 addresses ([issue 964](https://github.com/dbcli/pgcli/issues/964)).
+
+
 ==================
 4.0.1 (2023-10-30)
 ==================

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -1,3 +1,4 @@
+import ipaddress
 import logging
 import traceback
 from collections import namedtuple
@@ -273,6 +274,11 @@ class PGExecute:
 
     @property
     def short_host(self):
+        try:
+            ipaddress.ip_address(self.host)
+            return self.host
+        except ValueError:
+            pass
         if "," in self.host:
             host, _, _ = self.host.partition(",")
         else:

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -721,6 +721,10 @@ def test_short_host(executor):
         executor, "host", "localhost1.example.org,localhost2.example.org"
     ):
         assert executor.short_host == "localhost1"
+    with patch.object(executor, "host", "ec2-11-222-333-444.compute-1.amazonaws.com"):
+        assert executor.short_host == "ec2-11-222-333-444"
+    with patch.object(executor, "host", "1.2.3.4"):
+        assert executor.short_host == "1.2.3.4"
 
 
 class VirtualCursor:


### PR DESCRIPTION
When connecting to an IPv4 address (`pgcli -h 127.0.0.1`), trying to
use the "short host" in the prompt (with `\h`) would only display the
first octet (127). Now it shows the full IP.

Fixes #964.