### PR TITLE
Support PGAPPNAME

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -131,6 +131,7 @@ Contributors:
     * Rob Berry (rob-b)
     * Sharon Yogev (sharonyogev)
     * Hollis Wu (holi0317)
+    * Antonio Aguilar (crazybolillo)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,10 @@
 Upcoming
 ========
 
+Features:
+---------
+* Support `PGAPPNAME` as an environment variable and `--application-name` as a command line argument.
+
 Bug fixes:
 ----------
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -165,6 +165,7 @@ class PGCli:
         pgexecute=None,
         pgclirc_file=None,
         row_limit=None,
+        application_name="pgcli",
         single_connection=False,
         less_chatty=None,
         prompt=None,
@@ -209,6 +210,8 @@ class PGCli:
             self.row_limit = row_limit
         else:
             self.row_limit = c["main"].as_int("row_limit")
+
+        self.application_name = application_name
 
         # if not specified, set to DEFAULT_MAX_FIELD_WIDTH
         # if specified but empty, set to None to disable truncation
@@ -568,7 +571,7 @@ class PGCli:
         if not database:
             database = user
 
-        kwargs.setdefault("application_name", "pgcli")
+        kwargs.setdefault("application_name", self.application_name)
 
         # If password prompt is not forced but no password is provided, try
         # getting it from environment variable.
@@ -1338,6 +1341,12 @@ class PGCli:
     help="Set threshold for row limit prompt. Use 0 to disable prompt.",
 )
 @click.option(
+    "--application-name",
+    default="pgcli",
+    envvar="PGAPPNAME",
+    help="Application name for the connection.",
+)
+@click.option(
     "--less-chatty",
     "less_chatty",
     is_flag=True,
@@ -1387,6 +1396,7 @@ def cli(
     pgclirc,
     dsn,
     row_limit,
+    application_name,
     less_chatty,
     prompt,
     prompt_dsn,
@@ -1445,6 +1455,7 @@ def cli(
         never_prompt,
         pgclirc_file=pgclirc,
         row_limit=row_limit,
+        application_name=application_name,
         single_connection=single_connection,
         less_chatty=less_chatty,
         prompt=prompt,

--- a/tests/test_application_name.py
+++ b/tests/test_application_name.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from pgcli.main import cli
+from pgcli.pgexecute import PGExecute
+
+
+def test_application_name_in_env():
+    runner = CliRunner()
+    app_name = "wonderful_app"
+    with patch.object(PGExecute, "__init__") as mock_pgxecute:
+        runner.invoke(
+            cli, ["127.0.0.1:5432/hello", "user"], env={"PGAPPNAME": app_name}
+        )
+        kwargs = mock_pgxecute.call_args.kwargs
+        assert kwargs.get("application_name") == app_name


### PR DESCRIPTION
The application_name to be used when connecting to a database can now be specified as a command line argument (--application-name) or be taken directly from environment variables (PGAPPNAME). It still defaults to 'pgcli' when not specified.

Closes #1421.

## Description
I added a new click option to support `PGAPPNAME` and created a new class member for `PGCli` which stores the set value. This value is then used during the `connect` method unless a different value was stated in `**kwargs`.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
