### PR TITLE
Add verbose_errors config and special command

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -132,6 +132,7 @@ Contributors:
     * Sharon Yogev (sharonyogev)
     * Hollis Wu (holi0317)
     * Antonio Aguilar (crazybolillo)
+    * Andrew M. MacFie (amacfie)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,8 @@ Upcoming
 Features:
 ---------
 * Support `PGAPPNAME` as an environment variable and `--application-name` as a command line argument.
+* Add `verbose_errors` config which enables the displaying of all Postgres
+  error fields received.
 
 Bug fixes:
 ----------

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -384,6 +384,26 @@ class PGCli:
             "Echo a string to the query output channel.",
         )
 
+        self.pgspecial.register(
+            self.toggle_verbose_errors,
+            "\\v",
+            "\\v [on|off]",
+            "Toggle verbose errors.",
+        )
+
+    def toggle_verbose_errors(self, pattern, **_):
+        flag = pattern.strip()
+
+        if flag == "on":
+            self.verbose_errors = True
+        elif flag == "off":
+            self.verbose_errors = False
+        else:
+            self.verbose_errors = not self.verbose_errors
+
+        message = "Verbose errors " + "on." if self.verbose_errors else "off."
+        return [(None, None, None, message)]
+
     def echo(self, pattern, **_):
         return [(None, None, None, pattern)]
 

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -156,8 +156,9 @@ max_field_width = 500
 # Skip intro on startup and goodbye on exit
 less_chatty = False
 
-# Show all Postgres error fields (as in
-# https://www.postgresql.org/docs/current/protocol-error-fields.html)
+# Show all Postgres error fields (as listed in
+# https://www.postgresql.org/docs/current/protocol-error-fields.html).
+# Can be toggled with \v.
 verbose_errors = False
 
 # Postgres prompt

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -156,6 +156,10 @@ max_field_width = 500
 # Skip intro on startup and goodbye on exit
 less_chatty = False
 
+# Show all Postgres error fields (as in
+# https://www.postgresql.org/docs/current/protocol-error-fields.html)
+verbose_errors = False
+
 # Postgres prompt
 # \t - Current date and time
 # \u - Username

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -298,6 +298,24 @@ def test_i_works(tmpdir, executor):
 
 
 @dbtest
+def test_toggle_verbose_errors(executor):
+    cli = PGCli(pgexecute=executor)
+
+    cli._evaluate_command("\\v on")
+    assert cli.verbose_errors
+    output, _ = cli._evaluate_command("SELECT 1/0")
+    assert "SQLSTATE" in output[0]
+
+    cli._evaluate_command("\\v off")
+    assert not cli.verbose_errors
+    output, _ = cli._evaluate_command("SELECT 1/0")
+    assert "SQLSTATE" not in output[0]
+
+    cli._evaluate_command("\\v")
+    assert cli.verbose_errors
+
+
+@dbtest
 def test_echo_works(executor):
     cli = PGCli(pgexecute=executor)
     statement = r"\echo asdf"

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -220,8 +220,10 @@ def test_database_list(executor):
 
 @dbtest
 def test_invalid_syntax(executor, exception_formatter):
-    result = run(executor, "invalid syntax!", exception_formatter=exception_formatter)
+    result = run(executor, "invalid syntax!", exception_formatter=lambda x:
+                 main_exception_formatter(x, verbose_errors=False))
     assert 'syntax error at or near "invalid"' in result[0]
+    assert 'SQLSTATE' not in result[0]
 
 
 @dbtest

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -1,3 +1,4 @@
+import re
 from textwrap import dedent
 
 import psycopg
@@ -6,7 +7,7 @@ from unittest.mock import patch, MagicMock
 from pgspecial.main import PGSpecial, NO_QUERY
 from utils import run, dbtest, requires_json, requires_jsonb
 
-from pgcli.main import PGCli
+from pgcli.main import PGCli, exception_formatter as main_exception_formatter
 from pgcli.packages.parseutils.meta import FunctionMetadata
 
 
@@ -221,6 +222,26 @@ def test_database_list(executor):
 def test_invalid_syntax(executor, exception_formatter):
     result = run(executor, "invalid syntax!", exception_formatter=exception_formatter)
     assert 'syntax error at or near "invalid"' in result[0]
+
+
+@dbtest
+def test_invalid_syntax_verbose(executor):
+    result = run(
+        executor,
+        "invalid syntax!",
+        exception_formatter=lambda x: main_exception_formatter(x, verbose_errors=True),
+    )
+    fields = r"""
+Severity: ERROR
+Severity \(non-localized\): ERROR
+SQLSTATE code: 42601
+Message: syntax error at or near "invalid"
+Position: 1
+File: scan\.l
+Line: \d+
+Routine: scanner_yyerror
+    """.strip()
+    assert re.search(fields, result[0])
 
 
 @dbtest

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -220,10 +220,13 @@ def test_database_list(executor):
 
 @dbtest
 def test_invalid_syntax(executor, exception_formatter):
-    result = run(executor, "invalid syntax!", exception_formatter=lambda x:
-                 main_exception_formatter(x, verbose_errors=False))
+    result = run(
+        executor,
+        "invalid syntax!",
+        exception_formatter=lambda x: main_exception_formatter(x, verbose_errors=False),
+    )
     assert 'syntax error at or near "invalid"' in result[0]
-    assert 'SQLSTATE' not in result[0]
+    assert "SQLSTATE" not in result[0]
 
 
 @dbtest


### PR DESCRIPTION
## Description
To address https://github.com/dbcli/pgcli/discussions/1407, this adds a boolean parameter to the config file called `verbose_errors`. If set, the values of any postgres error fields present (see https://www.postgresql.org/docs/current/protocol-error-fields.html) are appended to the error message.

~(The code that extracts the error fields should be good but I'm not sure if a config parameter is the best place to control this, or whether this PR does everything necessary to introduce a new config parameter.)~ ETA: I've also added the `\v` special command which toggles verbose errors.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
