### PR TITLE
dependencies: add support for sqlparse 0.5.x

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -7,6 +7,7 @@ Features:
 * Add `verbose_errors` config and `\v` special command which enable the
   displaying of all Postgres error fields received.
 * Show Postgres notifications.
+* Support sqlparse 0.5.x
 
 Bug fixes:
 ----------

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requirements = [
     "prompt_toolkit>=2.0.6,<4.0.0",
     "psycopg >= 3.0.14; sys_platform != 'win32'",
     "psycopg-binary >= 3.0.14; sys_platform == 'win32'",
-    "sqlparse >=0.3.0,<0.5",
+    "sqlparse >=0.3.0,<0.6",
     "configobj >= 5.0.6",
     "cli_helpers[styles] >= 2.2.1",
 ]


### PR DESCRIPTION
## Description

`sqlparse` 0.5.0 was released on 2024-04-13 and contains a security fix for a potential denial of service attack: https://sqlparse.readthedocs.io/en/latest/changes.html#release-0-5-0-apr-13-2024

Other changes mentioned `sqlparse`'s release notes shouldn't break pgcli :crossed_fingers: I've run `pytest` locally (but not `behave`) so will rely on the GH actions to catch any breaking changes.

_[EDIT:] pytest/behave/etc are passing in the GH actions, but seems like there's an unrelated issue with docutils (think maybe `rst2html.py` was renamed to `rst2html`?) but running `rst2html --halt=warning changelog.rst >/dev/null` works locally._


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
