### PR TITLE
Add --log-file & \log-file option to always capture output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -133,6 +133,7 @@ Contributors:
     * Hollis Wu (holi0317)
     * Antonio Aguilar (crazybolillo)
     * Andrew M. MacFie (amacfie)
+    * saucoide
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -8,6 +8,8 @@ Features:
   displaying of all Postgres error fields received.
 * Show Postgres notifications.
 * Support sqlparse 0.5.x
+* Add `--log-file [filename]` cli argument and `\log-file [filename]` special commands to
+  log to an external file in addition to the normal output
 
 Bug fixes:
 ----------

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -313,7 +313,8 @@ class PGCli:
         self.ssh_tunnel = None
 
         if log_file:
-            open(log_file, "a+").close()  # ensure writeable
+            with open(log_file, "a+"):
+                pass  # ensure writeable
         self.log_file = log_file
 
         # formatter setup

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -880,7 +880,7 @@ class PGCli:
                 ):
                     try:
                         with open(self.log_file, "a", encoding="utf-8") as f:
-                            click.echo(dt.datetime.now(), file=f)  # timestamp log
+                            click.echo(dt.datetime.now().isoformat(), file=f)  # timestamp log
                             click.echo(text, file=f)
                             click.echo("\n".join(output), file=f)
                             click.echo("", file=f)  # extra newline

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -880,7 +880,9 @@ class PGCli:
                 ):
                     try:
                         with open(self.log_file, "a", encoding="utf-8") as f:
-                            click.echo(dt.datetime.now().isoformat(), file=f)  # timestamp log
+                            click.echo(
+                                dt.datetime.now().isoformat(), file=f
+                            )  # timestamp log
                             click.echo(text, file=f)
                             click.echo("\n".join(output), file=f)
                             click.echo("", file=f)  # extra newline

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -13,6 +13,7 @@ import shutil
 import functools
 import datetime as dt
 import itertools
+import pathlib
 import platform
 from time import time, sleep
 from typing import Optional
@@ -182,6 +183,7 @@ class PGCli:
         auto_vertical_output=False,
         warn=None,
         ssh_tunnel_url: Optional[str] = None,
+        log_file: Optional[str] = None,
     ):
         self.force_passwd_prompt = force_passwd_prompt
         self.never_passwd_prompt = never_passwd_prompt
@@ -310,6 +312,10 @@ class PGCli:
         self.ssh_tunnel_url = ssh_tunnel_url
         self.ssh_tunnel = None
 
+        if log_file:
+            open(log_file, "a+").close()  # ensure writeable
+        self.log_file = log_file
+
         # formatter setup
         self.formatter = TabularOutputFormatter(format_name=c["main"]["table_format"])
         register_new_formatter(self.formatter)
@@ -368,6 +374,12 @@ class PGCli:
             "\\o",
             "\\o [filename]",
             "Send all query results to file.",
+        )
+        self.pgspecial.register(
+            self.write_to_logfile,
+            "\\log-file",
+            "\\log-file [filename]",
+            "Log all query results to a logfile, in addition to the normal output destination.",
         )
         self.pgspecial.register(
             self.info_connection, "\\conninfo", "\\conninfo", "Get connection details"
@@ -507,6 +519,25 @@ class PGCli:
             on_error_resume=on_error_resume,
             explain_mode=self.explain_mode,
         )
+
+    def write_to_logfile(self, pattern, **_):
+        if not pattern:
+            self.log_file = None
+            message = "Logfile capture disabled"
+            return [(None, None, None, message, "", True, True)]
+
+        log_file = pathlib.Path(pattern).expanduser().absolute()
+
+        try:
+            open(log_file, "a+").close()  # ensure writeable
+        except OSError as e:
+            self.log_file = None
+            message = str(e) + "\nLogfile capture disabled"
+            return [(None, None, None, message, "", False, True)]
+
+        self.log_file = str(log_file)
+        message = 'Writing to file "%s"' % self.log_file
+        return [(None, None, None, message, "", True, True)]
 
     def write_to_file(self, pattern, **_):
         if not pattern:
@@ -826,7 +857,7 @@ class PGCli:
         else:
             try:
                 if self.output_file and not text.startswith(
-                    ("\\o ", "\\? ", "\\echo ")
+                    ("\\o ", "\\log-file", "\\? ", "\\echo ")
                 ):
                     try:
                         with open(self.output_file, "a", encoding="utf-8") as f:
@@ -838,6 +869,21 @@ class PGCli:
                 else:
                     if output:
                         self.echo_via_pager("\n".join(output))
+
+                # Log to file in addition to normal output
+                if (
+                    self.log_file
+                    and not text.startswith(("\\o ", "\\log-file", "\\? ", "\\echo "))
+                    and not text.strip() == ""
+                ):
+                    try:
+                        with open(self.log_file, "a", encoding="utf-8") as f:
+                            click.echo(dt.datetime.now(), file=f)  # timestamp log
+                            click.echo(text, file=f)
+                            click.echo("\n".join(output), file=f)
+                            click.echo("", file=f)  # extra newline
+                    except OSError as e:
+                        click.secho(str(e), err=True, fg="red")
             except KeyboardInterrupt:
                 pass
 
@@ -1428,6 +1474,11 @@ class PGCli:
     default=None,
     help="Open an SSH tunnel to the given address and connect to the database from it.",
 )
+@click.option(
+    "--log-file",
+    default=None,
+    help="Write all queries & output into a file, in addition to the normal output destination.",
+)
 @click.argument("dbname", default=lambda: None, envvar="PGDATABASE", nargs=1)
 @click.argument("username", default=lambda: None, envvar="PGUSER", nargs=1)
 def cli(
@@ -1453,6 +1504,7 @@ def cli(
     list_dsn,
     warn,
     ssh_tunnel: str,
+    log_file: str,
 ):
     if version:
         print("Version:", __version__)
@@ -1511,6 +1563,7 @@ def cli(
         auto_vertical_output=auto_vertical_output,
         warn=warn,
         ssh_tunnel_url=ssh_tunnel,
+        log_file=log_file,
     )
 
     # Choose which ever one has a valid value.

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -530,7 +530,8 @@ class PGCli:
         log_file = pathlib.Path(pattern).expanduser().absolute()
 
         try:
-            open(log_file, "a+").close()  # ensure writeable
+            with open(log_file, "a+"):
+                pass  # ensure writeable
         except OSError as e:
             self.log_file = None
             message = str(e) + "\nLogfile capture disabled"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -354,7 +354,9 @@ def test_logfile_unwriteable_file(executor):
     cli = PGCli(pgexecute=executor)
     statement = r"\log-file forbidden.log"
     with mock.patch("builtins.open") as mock_open:
-        mock_open.side_effect = PermissionError("[Errno 13] Permission denied: 'forbidden.log'")
+        mock_open.side_effect = PermissionError(
+            "[Errno 13] Permission denied: 'forbidden.log'"
+        )
         result = run(executor, statement, pgspecial=cli.pgspecial)
     assert result == [
         "[Errno 13] Permission denied: 'forbidden.log'\nLogfile capture disabled"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -352,10 +352,12 @@ def test_logfile_works(executor):
 @dbtest
 def test_logfile_unwriteable_file(executor):
     cli = PGCli(pgexecute=executor)
-    statement = r"\log-file /etc/forbidden.log"
-    result = run(executor, statement, pgspecial=cli.pgspecial)
+    statement = r"\log-file forbidden.log"
+    with mock.patch("builtins.open") as mock_open:
+        mock_open.side_effect = PermissionError("[Errno 13] Permission denied: 'forbidden.log'")
+        result = run(executor, statement, pgspecial=cli.pgspecial)
     assert result == [
-        "[Errno 13] Permission denied: '/etc/forbidden.log'\nLogfile capture disabled"
+        "[Errno 13] Permission denied: 'forbidden.log'\nLogfile capture disabled"
     ]
 
 


### PR DESCRIPTION
## Description

Currently outputting to a file via \o disables the console output, however i often find
myself wanting to both log the results & see them in the terminal too #1424

This patch would add a cli arg `--log-file`, behaving as the same option in `psql`* + a
\log-file special command to enable/disable it from the console

\* https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-OPTION-LOG-FILE

Maybe this is just useful for me and not worth adding but thought i'd submit it anyway,
i'll update changelog, etc later if you decide it's ok to merge


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
