### PR TITLE
Add `--ping` as a CLI option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -134,6 +134,7 @@ Contributors:
     * Antonio Aguilar (crazybolillo)
     * Andrew M. MacFie (amacfie)
     * saucoide
+    * Chris Rose (offbyone/offby1)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,10 @@
+Dev
+===
+
+Features
+--------
+* Add a `--ping` command line option; allows pgcli to replace `pg_isready`
+
 4.1.0 (2024-03-09)
 ==================
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1643,7 +1643,7 @@ def cli(
             ...
 
         if results:
-            pgcli.echo("PONG")
+            click.echo("PONG")
             sys.exit(0)
         else:
             click.secho(

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1639,19 +1639,15 @@ def cli(
         try:
             results = list(pgcli.pgexecute.run("SELECT 1"))
         except Exception:
-            # yup, really, anything here
-            ...
-
-        if results:
-            click.echo("PONG")
-            sys.exit(0)
-        else:
             click.secho(
                 "Could not connect to the database. Please check that the database is running.",
                 err=True,
                 fg="red",
             )
             sys.exit(1)
+        else:
+            click.echo("PONG")
+            sys.exit(0)
 
     pgcli.logger.debug(
         "Launch Params: \n" "\tdatabase: %r" "\tuser: %r" "\thost: %r" "\tport: %r",

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1635,9 +1635,8 @@ def cli(
         sys.exit(0)
 
     if ping_database:
-        results = None
         try:
-            results = list(pgcli.pgexecute.run("SELECT 1"))
+            list(pgcli.pgexecute.run("SELECT 1"))
         except Exception:
             click.secho(
                 "Could not connect to the database. Please check that the database is running.",

--- a/tests/features/basic_commands.feature
+++ b/tests/features/basic_commands.feature
@@ -51,6 +51,10 @@ Feature: run the cli,
       When we list databases
       then we see list of databases
 
+  Scenario: ping databases
+      When we ping the database
+      then we get a pong response
+
   Scenario: run the cli with --username
     When we launch dbcli using --username
       and we send "\?" command

--- a/tests/features/steps/basic_commands.py
+++ b/tests/features/steps/basic_commands.py
@@ -26,6 +26,19 @@ def step_see_list_databases(context):
     context.cmd_output = None
 
 
+@when("we ping the database")
+def step_ping_database(context):
+    cmd = ["pgcli", "--ping"]
+    context.cmd_output = subprocess.check_output(cmd, cwd=context.package_root)
+
+
+@then("we get a pong response")
+def step_get_pong_response(context):
+    # exit code 0 is implied by the presence of cmd_output here, which
+    # is only set on a successful run.
+    assert context.cmd_output.strip() == b"PONG", f"Output was {context.cmd_output}"
+
+
 @when("we run dbcli")
 def step_run_cli(context):
     wrappers.run_cli(context)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

This builds in the functionality asked for in #1470; it allows pgcli to replace `pg_isready` from the postgresql command line toolchain

Fixes: #1470 

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
