### PR TITLE
Always exit unsuccessfully with `sys.exit`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -135,6 +135,7 @@ Contributors:
     * Andrew M. MacFie (amacfie)
     * saucoide
     * Chris Rose (offbyone/offby1)
+    * Chris Novakovic
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,10 @@ Features
 --------
 * Add a `--ping` command line option; allows pgcli to replace `pg_isready`
 
+Bug fixes:
+----------
+* Avoid raising `NameError` when exiting unsuccessfully in some cases
+
 4.1.0 (2024-03-09)
 ==================
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -610,7 +610,7 @@ class PGCli:
             click.secho(
                 f"service '{service}' was not found in {file}", err=True, fg="red"
             )
-            exit(1)
+            sys.exit(1)
         self.connect(
             database=service_config.get("dbname"),
             host=service_config.get("host"),
@@ -710,7 +710,7 @@ class PGCli:
                 self.logger.handlers = logger_handlers
                 self.logger.error("traceback: %r", traceback.format_exc())
                 click.secho(str(e), err=True, fg="red")
-                exit(1)
+                sys.exit(1)
             self.logger.handlers = logger_handlers
 
             atexit.register(self.ssh_tunnel.stop)
@@ -763,7 +763,7 @@ class PGCli:
             self.logger.debug("Database connection failed: %r.", e)
             self.logger.error("traceback: %r", traceback.format_exc())
             click.secho(str(e), err=True, fg="red")
-            exit(1)
+            sys.exit(1)
 
         self.pgexecute = pgexecute
 
@@ -1551,7 +1551,7 @@ def cli(
                 err=True,
                 fg="red",
             )
-            exit(1)
+            sys.exit(1)
 
     if ssh_tunnel and not SSH_TUNNEL_SUPPORT:
         click.secho(
@@ -1560,7 +1560,7 @@ def cli(
             err=True,
             fg="red",
         )
-        exit(1)
+        sys.exit(1)
 
     pgcli = PGCli(
         prompt_passwd,
@@ -1604,7 +1604,7 @@ def cli(
                 err=True,
                 fg="red",
             )
-            exit(1)
+            sys.exit(1)
         except Exception:
             click.secho(
                 "Invalid DSNs found in the config file. "
@@ -1612,7 +1612,7 @@ def cli(
                 err=True,
                 fg="red",
             )
-            exit(1)
+            sys.exit(1)
         pgcli.connect_uri(dsn_config)
         pgcli.dsn_alias = dsn
     elif "://" in database:


### PR DESCRIPTION
## Description

`exit` isn't defined as a function or imported in `main.py`, so reaching any code path that attempts to execute `exit(1)` results in a `NameError` being raised:

```
Traceback (most recent call last):
    File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
    File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
    File "[...]/__main__.py", line 415, in <module>
    File "[...]/__main__.py", line 399, in run
    File "[...]/__main__.py", line 389, in main
    File "/usr/lib/python3.10/runpy.py", line 220, in run_module
    mod_name, mod_spec, code = _get_module_details(mod_name)
    File "/usr/lib/python3.10/runpy.py", line 157, in _get_module_details
    code = loader.get_code(mod_name)
    File "[...]/__main__.py", line 264, in get_code
    File "[...]/__main__.py", line 204, in load_module
    File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
    File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
    File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
    File "<frozen importlib._bootstrap_external>", line 883, in exec_module
    File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
    File "third_party/python3/__pgcli_main__.py", line 3, in <module>
    File "[...]/click/core.py", line 1157, in __call__
    File "[...]/click/core.py", line 1078, in main
    File "[...]/click/core.py", line 1434, in invoke
    File "[...]/click/core.py", line 783, in invoke
    File "[...]/pgcli/main.py", line 1617, in cli
    File "[...]/pgcli/main.py", line 766, in connect
NameError: name 'exit' is not defined. Did you mean: 'atexit'?
```

When exiting unsuccessfully, do so with `sys.exit(1)` - this is already used in several other places in `main.py`, and is always used (with exit code 0) when exiting successfully.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
