### PR TITLE
Adding `column_date_formats` config option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -139,6 +139,7 @@ Contributors:
     * Chris Novakovic
     * Josh Lynch (josh-lynch)
     * Fabio (3ximus)
+    * Doug Harris (dougharris)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,7 @@ Features
 * Add a `--ping` command line option; allows pgcli to replace `pg_isready`
 * Changed the packaging metadata from setup.py to pyproject.toml
 * Add bash completion for services defined in the service file `~/.pg_service.conf`
+* Added support for per-column date/time formatting using `column_date_formats` in config
 
 Bug fixes:
 ----------

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -240,3 +240,8 @@ output.null = "#808080"
 [data_formats]
 decimal = ""
 float = ""
+
+# Per column formats for date/timestamp columns
+[column_date_formats]
+# use strftime format, e.g.
+# created = "%Y-%m-%d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "psycopg-binary >= 3.0.14; sys_platform == 'win32'",
     "sqlparse >=0.3.0,<0.6",
     "configobj >= 5.0.6",
-    "cli_helpers[styles] >= 2.2.1",
+    "cli_helpers[styles] >= 2.4.0",
     # setproctitle is used to mask the password when running `ps` in command line.
     # But this is not necessary in Windows since the password is never shown in the
     # task manager. Also setproctitle is a hard dependency to install in Windows,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -76,6 +76,57 @@ def test_format_output():
     assert list(results) == expected
 
 
+def test_column_date_formats():
+    settings = OutputSettings(
+        table_format="psql",
+        column_date_formats={
+            "date_col": "%Y-%m-%d",
+            "datetime_col": "%I:%M:%S %m/%d/%y",
+        },
+    )
+    data = [
+        ("name1", "2024-12-13T18:32:22", "2024-12-13T19:32:22", "2024-12-13T20:32:22"),
+        ("name2", "2025-02-13T02:32:22", "2025-02-13T02:32:22", "2025-02-13T02:32:22"),
+    ]
+    headers = ["name", "date_col", "datetime_col", "unchanged_col"]
+
+    results = format_output("Title", data, headers, "test status", settings)
+    expected = [
+        "Title",
+        "+-------+------------+-------------------+---------------------+",
+        "| name  | date_col   | datetime_col      | unchanged_col       |",
+        "|-------+------------+-------------------+---------------------|",
+        "| name1 | 2024-12-13 | 07:32:22 12/13/24 | 2024-12-13T20:32:22 |",
+        "| name2 | 2025-02-13 | 02:32:22 02/13/25 | 2025-02-13T02:32:22 |",
+        "+-------+------------+-------------------+---------------------+",
+        "test status",
+    ]
+    assert list(results) == expected
+
+
+def test_no_column_date_formats():
+    """Test that not setting any column date formats returns unaltered datetime columns"""
+    settings = OutputSettings(table_format="psql")
+    data = [
+        ("name1", "2024-12-13T18:32:22", "2024-12-13T19:32:22", "2024-12-13T20:32:22"),
+        ("name2", "2025-02-13T02:32:22", "2025-02-13T02:32:22", "2025-02-13T02:32:22"),
+    ]
+    headers = ["name", "date_col", "datetime_col", "unchanged_col"]
+
+    results = format_output("Title", data, headers, "test status", settings)
+    expected = [
+        "Title",
+        "+-------+---------------------+---------------------+---------------------+",
+        "| name  | date_col            | datetime_col        | unchanged_col       |",
+        "|-------+---------------------+---------------------+---------------------|",
+        "| name1 | 2024-12-13T18:32:22 | 2024-12-13T19:32:22 | 2024-12-13T20:32:22 |",
+        "| name2 | 2025-02-13T02:32:22 | 2025-02-13T02:32:22 | 2025-02-13T02:32:22 |",
+        "+-------+---------------------+---------------------+---------------------+",
+        "test status",
+    ]
+    assert list(results) == expected
+
+
 def test_format_output_truncate_on():
     settings = OutputSettings(
         table_format="psql", dcmlfmt="d", floatfmt="g", max_field_width=10


### PR DESCRIPTION
## Description
Allows per-column formatting for date, time, datetime like columns.

Add a column_date_formats section to your config file with separate lines for each column that you'd like to specify a format using name=format. Use standard Python strftime formatting strings.

More details in https://github.com/dbcli/pgcli/issues/1402


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
