### PR TITLE
Adding behave.ini to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 .pytest_cache
+tests/behave.ini
 
 # Translations
 *.mo


### PR DESCRIPTION
## Description
Adding `tests/behave.ini` to `.gitignore` to lessen the likelihood that somebody commits real db credentials (and also reduces the noise from `git status`)



## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [ ] I've added this contribution to the `changelog.rst`. _I'd argue this isn't worth including in changelog_
- [ ] I've added my name to the `AUTHORS` file (or it's already there). _(added in separate PR)_
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
