### PR TITLE
Add bash completion for services defined in ~/.pg_service.conf

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -138,6 +138,7 @@ Contributors:
     * Mathieu Dupuy (deronnax)
     * Chris Novakovic
     * Josh Lynch (josh-lynch)
+    * Fabio (3ximus)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -5,6 +5,7 @@ Features
 --------
 * Add a `--ping` command line option; allows pgcli to replace `pg_isready`
 * Changed the packaging metadata from setup.py to pyproject.toml
+* Add bash completion for services defined in the service file `~/.pg_service.conf`
 
 Bug fixes:
 ----------


### PR DESCRIPTION
## Description
I've added bash completion to services defined in the service file.

It's only triggered after typing `service=`

I've also cleaned some formatting of the file itself to make it consistent


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
