### PR TITLE
Bugfix alias_map_file not being used for table aliases

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -137,6 +137,7 @@ Contributors:
     * Chris Rose (offbyone/offby1)
     * Mathieu Dupuy (deronnax)
     * Chris Novakovic
+    * Josh Lynch (josh-lynch)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -9,6 +9,7 @@ Features
 Bug fixes:
 ----------
 * Avoid raising `NameError` when exiting unsuccessfully in some cases
+* Use configured `alias_map_file` to generate table aliases if available.
 
 Internal:
 ---------

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -528,7 +528,7 @@ class PGCompleter(Completer):
         scoped_cols = self.populate_scoped_cols(tables, suggestion.local_tables)
 
         def make_cand(name, ref):
-            synonyms = (name, generate_alias(self.case(name)))
+            synonyms = (name, generate_alias(self.case(name), alias_map=self.alias_map))
             return Candidate(qualify(name, ref), 0, "column", synonyms)
 
         def flat_cols():
@@ -601,7 +601,7 @@ class PGCompleter(Completer):
         tbl = self.case(tbl)
         tbls = {normalize_ref(t.ref) for t in tbls}
         if self.generate_aliases:
-            tbl = generate_alias(self.unescape_name(tbl))
+            tbl = generate_alias(self.unescape_name(tbl), alias_map=self.alias_map)
         if normalize_ref(tbl) not in tbls:
             return tbl
         elif tbl[0] == '"':
@@ -644,7 +644,7 @@ class PGCompleter(Completer):
                 join = "{0} ON {0}.{1} = {2}.{3}".format(
                     c(left.tbl), c(left.col), rtbl.ref, c(right.col)
                 )
-            alias = generate_alias(self.case(left.tbl))
+            alias = generate_alias(self.case(left.tbl), alias_map=self.alias_map)
             synonyms = [
                 join,
                 "{0} ON {0}.{1} = {2}.{3}".format(
@@ -845,7 +845,7 @@ class PGCompleter(Completer):
         cased_tbl = self.case(tbl.name)
         if do_alias:
             alias = self.alias(cased_tbl, suggestion.table_refs)
-        synonyms = (cased_tbl, generate_alias(cased_tbl))
+        synonyms = (cased_tbl, generate_alias(cased_tbl, alias_map=self.alias_map))
         maybe_alias = (" " + alias) if do_alias else ""
         maybe_schema = (self.case(tbl.schema) + ".") if tbl.schema else ""
         suffix = self._arg_list_cache[arg_mode][tbl.meta] if arg_mode else ""

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -63,10 +63,17 @@ normalize_ref = lambda ref: ref if ref[0] == '"' else '"' + ref.lower() + '"'
 
 
 def generate_alias(tbl, alias_map=None):
-    """Generate a table alias, consisting of all upper-case letters in
-    the table name, or, if there are no upper-case letters, the first letter +
-    all letters preceded by _
-    param tbl - unescaped name of the table to alias
+    """Generate a table alias.
+
+    Given a table name will return an alias for that table using the first of
+    the following options there's a match for.
+
+        1. The predefined alias for table defined in the alias_map.
+        2. All upper-case letters in the table name.
+        3. The first letter of the table name and all letters preceded by _
+
+    :param tbl: unescaped name of the table to alias
+    :param alias_map: optional mapping of predefined table aliases
     """
     if alias_map and tbl in alias_map:
         return alias_map[tbl]

--- a/tests/test_pgcompleter.py
+++ b/tests/test_pgcompleter.py
@@ -49,6 +49,9 @@ def test_generate_alias_uses_first_char_and_every_preceded_by_underscore(
     "table_name, alias_map, alias",
     [
         ("some_table", {"some_table": "my_alias"}, "my_alias"),
+        pytest.param(
+            "some_other_table", {"some_table": "my_alias"}, "sot", id="no_match_in_map"
+        ),
     ],
 )
 def test_generate_alias_can_use_alias_map(table_name, alias_map, alias):

--- a/tests/test_pgcompleter.py
+++ b/tests/test_pgcompleter.py
@@ -55,7 +55,6 @@ def test_generate_alias_can_use_alias_map(table_name, alias_map, alias):
     assert pgcompleter.generate_alias(table_name, alias_map) == alias
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "table_name, alias_map, alias",
     [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

PGCLI advertises the ability to configure a custom `alias_map_file`, enabling users to override table alias generation with predefined aliases of their choosing.

Prior to this change the use of the `alias_map_file` was bugged; the configured file was not used and users would continue to get the auto-generated table aliases.

This change plugs the configured `alias_map_file` into the alias generation process, enabling users to use/see their custom aliases.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`), and ran `black` on my code.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
