### PR TITLE
Don't include '.0' on minutes and hours for durations when passed as large floats.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -141,6 +141,7 @@ Contributors:
     * Josh Lynch (josh-lynch)
     * Fabio (3ximus)
     * Doug Harris (dougharris)
+    * Jay Knight (jay-knight)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -17,6 +17,11 @@ Internal:
   * Update dev requirements and replace requirements-dev.txt with pyproject.toml
   * Use ruff instead of black
 
+Bug fixes:
+----------
+
+* Improve display of larger durations when passed as floats
+
 4.3.0 (2025-03-22)
 ==================
 

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1926,12 +1926,12 @@ def duration_in_words(duration_in_seconds: float) -> str:
     components = []
     hours, remainder = divmod(duration_in_seconds, 3600)
     if hours > 1:
-        components.append(f"{hours} hours")
+        components.append(f"{int(hours)} hours")
     elif hours == 1:
         components.append("1 hour")
     minutes, seconds = divmod(remainder, 60)
     if minutes > 1:
-        components.append(f"{minutes} minutes")
+        components.append(f"{int(minutes)} minutes")
     elif minutes == 1:
         components.append("1 minute")
     if seconds >= 2:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -565,9 +565,11 @@ def test_application_name_db_uri(tmpdir):
         (60, "1 minute"),
         (61, "1 minute 1 second"),
         (123, "2 minutes 3 seconds"),
+        (124.4, "2 minutes 4 seconds"),
         (3600, "1 hour"),
         (7235, "2 hours 35 seconds"),
         (9005, "2 hours 30 minutes 5 seconds"),
+        (9006.7, "2 hours 30 minutes 6 seconds"),
         (86401, "24 hours 1 second"),
     ],
 )


### PR DESCRIPTION
## Description
I was seeing duration values like `Time: 178.236s (2.0 minutes 58 seconds)`. This change just removes the ".0" off of the "2.0 minutes" by casting hours and minutes to ints.


## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits) 