### PR TITLE
Update Dockerfile to use Python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.9
 
 COPY . /app
 RUN cd /app && pip install -e .


### PR DESCRIPTION
## Description
Small change to the Dockerfile to use Python 3.9 as required by pyproject.toml. Currently the docker build fails on "Package 'pgcli' requires a different Python: 3.8.20 not in '>=3.9'.
