### PR TITLE
adding -c / --command parameter to pgcli w/tests

### DIFF
--- a/tests/features/command_option.feature
+++ b/tests/features/command_option.feature
@@ -1,0 +1,28 @@
+Feature: run the cli with -c/--command option,
+  execute a single command,
+  and exit
+
+  Scenario: run pgcli with -c and a SQL query
+     When we run pgcli with -c "SELECT 1 as test_column"
+      then we see the query result
+      and pgcli exits successfully
+
+  Scenario: run pgcli with --command and a SQL query
+     When we run pgcli with --command "SELECT 'hello' as greeting"
+      then we see the query result
+      and pgcli exits successfully
+
+  Scenario: run pgcli with -c and a special command
+     When we run pgcli with -c "\dt"
+      then we see the command output
+      and pgcli exits successfully
+
+  Scenario: run pgcli with -c and an invalid query
+     When we run pgcli with -c "SELECT invalid_column FROM nonexistent_table"
+      then we see an error message
+      and pgcli exits successfully
+
+  Scenario: run pgcli with -c and multiple statements
+     When we run pgcli with -c "SELECT 1; SELECT 2"
+      then we see both query results
+      and pgcli exits successfully

--- a/tests/features/steps/command_option.py
+++ b/tests/features/steps/command_option.py
@@ -1,0 +1,123 @@
+"""
+Steps for testing -c/--command option behavioral tests.
+"""
+
+import subprocess
+from behave import when, then
+
+
+@when('we run pgcli with -c "{command}"')
+def step_run_pgcli_with_c(context, command):
+    """Run pgcli with -c flag and a command."""
+    cmd = [
+        "pgcli",
+        "-h", context.conf["host"],
+        "-p", str(context.conf["port"]),
+        "-U", context.conf["user"],
+        "-d", context.conf["dbname"],
+        "-c", command
+    ]
+    try:
+        context.cmd_output = subprocess.check_output(
+            cmd,
+            cwd=context.package_root,
+            stderr=subprocess.STDOUT,
+            timeout=5
+        )
+        context.exit_code = 0
+    except subprocess.CalledProcessError as e:
+        context.cmd_output = e.output
+        context.exit_code = e.returncode
+    except subprocess.TimeoutExpired as e:
+        context.cmd_output = b"Command timed out"
+        context.exit_code = -1
+
+
+@when('we run pgcli with --command "{command}"')
+def step_run_pgcli_with_command(context, command):
+    """Run pgcli with --command flag and a command."""
+    cmd = [
+        "pgcli",
+        "-h", context.conf["host"],
+        "-p", str(context.conf["port"]),
+        "-U", context.conf["user"],
+        "-d", context.conf["dbname"],
+        "--command", command
+    ]
+    try:
+        context.cmd_output = subprocess.check_output(
+            cmd,
+            cwd=context.package_root,
+            stderr=subprocess.STDOUT,
+            timeout=5
+        )
+        context.exit_code = 0
+    except subprocess.CalledProcessError as e:
+        context.cmd_output = e.output
+        context.exit_code = e.returncode
+    except subprocess.TimeoutExpired as e:
+        context.cmd_output = b"Command timed out"
+        context.exit_code = -1
+
+
+@then("we see the query result")
+def step_see_query_result(context):
+    """Verify that the query result is in the output."""
+    output = context.cmd_output.decode('utf-8')
+    # Check for common query result indicators
+    assert any([
+        "SELECT" in output,
+        "test_column" in output,
+        "greeting" in output,
+        "hello" in output,
+        "+-" in output,  # table border
+        "|" in output,   # table column separator
+    ]), f"Expected query result in output, but got: {output}"
+
+
+@then("we see both query results")
+def step_see_both_query_results(context):
+    """Verify that both query results are in the output."""
+    output = context.cmd_output.decode('utf-8')
+    # Should contain output from both SELECT statements
+    assert "SELECT" in output, f"Expected SELECT in output, but got: {output}"
+    # The output should have multiple result sets
+    assert output.count("SELECT") >= 2, f"Expected at least 2 SELECT results, but got: {output}"
+
+
+@then("we see the command output")
+def step_see_command_output(context):
+    """Verify that the special command output is present."""
+    output = context.cmd_output.decode('utf-8')
+    # For \dt we should see table-related output
+    # It might be empty if no tables exist, but shouldn't error
+    assert context.exit_code == 0, f"Expected exit code 0, but got: {context.exit_code}"
+
+
+@then("we see an error message")
+def step_see_error_message(context):
+    """Verify that an error message is in the output."""
+    output = context.cmd_output.decode('utf-8')
+    assert any([
+        "does not exist" in output,
+        "error" in output.lower(),
+        "ERROR" in output,
+    ]), f"Expected error message in output, but got: {output}"
+
+
+@then("pgcli exits successfully")
+def step_pgcli_exits_successfully(context):
+    """Verify that pgcli exited with code 0."""
+    assert context.exit_code == 0, f"Expected exit code 0, but got: {context.exit_code}"
+    # Clean up
+    context.cmd_output = None
+    context.exit_code = None
+
+
+@then("pgcli exits with error")
+def step_pgcli_exits_with_error(context):
+    """Verify that pgcli exited with a non-zero code."""
+    assert context.exit_code != 0, f"Expected non-zero exit code, but got: {context.exit_code}"
+    # Clean up
+    context.cmd_output = None
+    context.exit_code = None


### PR DESCRIPTION
## Description
Like in psql command, where you can use -c/--command to run a single command (SQL or internal) and exit, I added the same behavior to pgcli.

Some screenshots:

<img width="1119" height="452" alt="image" src="https://github.com/user-attachments/assets/6369be00-df43-4a9c-960a-e4706e673925" />
<img width="700" height="700" alt="image" src="https://github.com/user-attachments/assets/5fbc8bb7-e843-441d-aee4-fc605254d25e" />


Tests:

```
(pgcli.dev) daf@d:tests$ ## particularmente este
/home/daf/scripts/pgcli/pgcli.dev/.venv/bin/behave features/command_option.feature
USING RUNNER: behave.runner:Runner
package root: /home/daf/scripts/pgcli/pgcli.dev
fixture dir: /home/daf/scripts/pgcli/pgcli.dev/tests/features/fixture_data
Created connection: {}.
Created connection: {}.
Pgbouncer is not available.
reading fixture data: /home/daf/scripts/pgcli/pgcli.dev/tests/features/fixture_data/
--- os.environ changed values: ---
BEHAVE_WARN="moderate"
COLUMNS="100"
COVERAGE_PROCESS_START="/home/daf/scripts/pgcli/pgcli.dev/.coveragerc"
EDITOR="ex"
LINES="100"
PGDATABASE="pgcli_behave_tests_3_10_17"
PGSERVICEFILE="/home/daf/scripts/pgcli/pgcli.dev/tests/features/fixture_data/mock_pg_service.conf"
PROMPT_TOOLKIT_NO_CPR="1"
VISUAL="ex"
XDG_CONFIG_HOME="/tmp/pgcli_home__5nyw4bu"
--------------------
Feature: run the cli with -c/--command option, # features/command_option.feature:1
  execute a single command,
  and exit
  Scenario: run pgcli with -c and a SQL query           # features/command_option.feature:5
    When we run pgcli with -c "SELECT 1 as test_column" # features/steps/command_option.py:9 0.355s
    Then we see the query result                        # features/steps/command_option.py:63 0.000s
    And pgcli exits successfully                        # features/steps/command_option.py:108 0.000s

  Scenario: run pgcli with --command and a SQL query              # features/command_option.feature:10
    When we run pgcli with --command "SELECT 'hello' as greeting" # features/steps/command_option.py:36 0.355s
    Then we see the query result                                  # features/steps/command_option.py:63 0.000s
    And pgcli exits successfully                                  # features/steps/command_option.py:108 0.000s

  Scenario: run pgcli with -c and a special command  # features/command_option.feature:15
    When we run pgcli with -c "\dt"                  # features/steps/command_option.py:9 0.372s
    Then we see the command output                   # features/steps/command_option.py:88 0.000s
    And pgcli exits successfully                     # features/steps/command_option.py:108 0.000s

  Scenario: run pgcli with -c and an invalid query                           # features/command_option.feature:20
    When we run pgcli with -c "SELECT invalid_column FROM nonexistent_table" # features/steps/command_option.py:9 0.363s
    Then we see an error message                                             # features/steps/command_option.py:97 0.000s
    And pgcli exits successfully                                             # features/steps/command_option.py:108 0.000s

  Scenario: run pgcli with -c and multiple statements  # features/command_option.feature:25
    When we run pgcli with -c "SELECT 1; SELECT 2"     # features/steps/command_option.py:9 0.364s
    Then we see both query results                     # features/steps/command_option.py:78 0.000s
    And pgcli exits successfully                       # features/steps/command_option.py:108 0.000s

  Scenario: run pgcli with multiple -c options  # features/command_option.feature:30
    When we run pgcli with multiple -c options  # features/steps/command_option.py:126 0.358s
    Then we see all command outputs             # features/steps/command_option.py:183 0.000s
    And pgcli exits successfully                # features/steps/command_option.py:108 0.000s

  Scenario: run pgcli with mixed -c and --command options  # features/command_option.feature:35
    When we run pgcli with mixed -c and --command          # features/steps/command_option.py:155 0.397s
    Then we see all command outputs                        # features/steps/command_option.py:183 0.000s
    And pgcli exits successfully                           # features/steps/command_option.py:108 0.000s

1 feature passed, 0 failed, 0 skipped
7 scenarios passed, 0 failed, 0 skipped
21 steps passed, 0 failed, 0 skipped
Took 0min 2.565s

pyTests: 2667 passed, 1 xfailed, 1 xpassed in 27.88s
```

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
