### PR TITLE
fix(tests): Fix Windows test failures related to click 8.2 encoding issues

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import pytest
 from utils import (
     POSTGRES_HOST,
@@ -11,6 +12,13 @@ from utils import (
 )
 import pgcli.main
 import pgcli.pgexecute
+
+
+# Fix Windows test failures related to click 8.2 encoding issues
+# Windows uses CP1252 encoding by default, which can't handle Unicode characters
+# Set PYTHONIOENCODING=utf-8 to ensure proper Unicode handling
+if platform.system() == "Windows":
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
 
 
 @pytest.fixture(scope="function")

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,9 @@ passenv = PGHOST
     PGPORT
     PGUSER
     PGPASSWORD
+    PYTHONIOENCODING
+setenv =
+    PYTHONIOENCODING = utf-8
 
 [testenv:style]
 skip_install = true
@@ -23,6 +26,10 @@ skip_install = true
 deps = uv
 commands = uv pip install -e .[dev]
         behave tests/features --no-capture
+passenv =
+    PYTHONIOENCODING
+setenv =
+    PYTHONIOENCODING = utf-8
 
 [testenv:rest]
 skip_install = true


### PR DESCRIPTION
## Description

This PR fixes Windows test failures related to click 8.2 encoding issues.

### Problem
Windows uses CP1252 encoding by default, which cannot handle Unicode characters output by `click.echo()`. This causes test failures on Windows when using click 8.2+ with error messages like:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\u2023' in position X: character maps to <undefined>
```

### Solution
Set `PYTHONIOENCODING=utf-8` environment variable to ensure proper Unicode handling:

1. **tests/conftest.py**: Set `PYTHONIOENCODING=utf-8` at module level for Windows platform during test collection
2. **tox.ini**: Set `PYTHONIOENCODING=utf-8` via `setenv` for all test environments

### Changes
- Added Windows encoding fix in `tests/conftest.py`
- Added `PYTHONIOENCODING=utf-8` to tox.ini testenv configurations

### Testing
- Verified tests pass locally
- Changes are minimal and focused on fixing Windows encoding issues

Fixes encoding issues that cause UnicodeEncodeError on Windows when tests output Unicode characters through click.echo().
