### PR TITLE
fix(docker): update base image to python:3.9 to match pyproject.toml requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.9
 
 COPY . /app
 RUN cd /app && pip install -e .


### PR DESCRIPTION
The Dockerfile used an outdated Python 3.8 base image, but pyproject.toml requires Python >=3.9. This mismatch caused Docker builds to fail with the error "Package 'pgcli' requires a different Python: 3.8.20 not in '>=3.9'".

Updated the base image from python:3.8 to python:3.9.

Fixes #1528