### PR TITLE
fix: respect DSN password over PGPASSWORD env var

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -632,7 +632,13 @@ class PGCli:
         # If password prompt is not forced but no password is provided, try
         # getting it from environment variable.
         if not self.force_passwd_prompt and not passwd:
-            passwd = os.environ.get("PGPASSWORD", "")
+            if dsn:
+                # Check if DSN contains a password - if so, don't use PGPASSWORD
+                parsed_dsn = conninfo_to_dict(dsn)
+                if "password" not in parsed_dsn:
+                    passwd = os.environ.get("PGPASSWORD", "")
+            else:
+                passwd = os.environ.get("PGPASSWORD", "")
 
         # Prompt for a password immediately if requested via the -W flag. This
         # avoids wasting time trying to connect to the database and catching a


### PR DESCRIPTION
When connecting via DSN URI containing a password (e.g., `postgresql://user:pass@host/db`), pgcli incorrectly prioritized the PGPASSWORD environment variable over the password embedded in the DSN. This caused authentication failures when PGPASSWORD was set to a different value.

Changed the connection logic to check if the DSN contains a password before falling back to PGPASSWORD. If a password is present in the DSN, it takes precedence.

Fixes #1555