### PR TITLE
use https for domains that support it

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,9 +28,9 @@ A REPL for Postgres
 
 This is a postgres client that does auto-completion and syntax highlighting.
 
-Home Page: http://pgcli.com
+Home Page: https://pgcli.com
 
-MySQL Equivalent: http://mycli.net
+MySQL Equivalent: https://mycli.net
 
 .. image:: screenshots/pgcli.gif
 .. image:: screenshots/image01.png
@@ -159,8 +159,8 @@ https://github.com/dbcli/pgcli/blob/main/CONTRIBUTING.rst
 
 Please feel free to reach out to us if you need help.
 
-* Amjith, pgcli author: amjith.r@gmail.com, Twitter: `@amjithr <http://twitter.com/amjithr>`_
-* Irina, pgcli maintainer: i.chernyavska@gmail.com, Twitter: `@irinatruong <http://twitter.com/irinatruong>`_
+* Amjith, pgcli author: amjith.r@gmail.com, Twitter: `@amjithr <https://twitter.com/amjithr>`_
+* Irina, pgcli maintainer: i.chernyavska@gmail.com, Twitter: `@irinatruong <https://twitter.com/irinatruong>`_
 
 Detailed Installation Instructions:
 -----------------------------------
@@ -346,12 +346,12 @@ Thanks:
 -------
 
 A special thanks to `Jonathan Slenders <https://twitter.com/jonathan_s>`_ for
-creating `Python Prompt Toolkit <http://github.com/jonathanslenders/python-prompt-toolkit>`_,
+creating `Python Prompt Toolkit <https://github.com/jonathanslenders/python-prompt-toolkit>`_,
 which is quite literally the backbone library, that made this app possible.
 Jonathan has also provided valuable feedback and support during the development
 of this app.
 
-`Click <http://click.pocoo.org/>`_ is used for command line option parsing
+`Click <https://click.pocoo.org/>`_ is used for command line option parsing
 and printing error messages.
 
 Thanks to `psycopg <https://www.psycopg.org/>`_ for providing a rock solid

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -959,7 +959,7 @@ class PGCli:
         if not self.less_chatty:
             print("Server: PostgreSQL", self.pgexecute.server_version)
             print("Version:", __version__)
-            print("Home: http://pgcli.com")
+            print("Home: https://pgcli.com")
 
         try:
             while True:


### PR DESCRIPTION
## Description
Use https for domains that support it

## Checklist
This is probably too small a change to merit any of the usual stuff.
