### PR TITLE
Make auto-suggest optional

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -146,6 +146,7 @@ Contributors:
     * Charbel Jacquin (charbeljc)
     * Devadathan M B (devadathanmb)
     * Charalampos Stratakis
+    * Laszlo Bimba (bimlas)
 
 Creator:
 --------

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -267,6 +267,8 @@ class PGCli:
 
         self.query_history = []
 
+        self.auto_suggest = c["main"].as_bool("auto_suggest")
+
         # Initialize completer
         smart_completion = c["main"].as_bool("smart_completion")
         keyword_casing = c["main"]["keyword_casing"]
@@ -1070,7 +1072,7 @@ class PGCli:
                     # Render \t as 4 spaces instead of "^I"
                     TabsProcessor(char1=" ", char2=" "),
                 ],
-                auto_suggest=AutoSuggestFromHistory(),
+                auto_suggest=AutoSuggestFromHistory() if self.auto_suggest else None,
                 tempfile_suffix=".sql",
                 # N.b. pgcli's multi-line mode controls submit-on-Enter (which
                 # overrides the default behaviour of prompt_toolkit) and is

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -5,6 +5,9 @@
 # possible completions will be listed.
 smart_completion = True
 
+# Enable auto suggestions (like Fish shell).
+auto_suggest = True
+
 # Display the completions in several columns. (More completions will be
 # visible.)
 wider_completion_menu = False


### PR DESCRIPTION
Auto-suggest could distract the user. It can be disabled by setting `history_file = /dev/null`, but in this case, none of the historical queries are saved. Instead, add an option to disable auto-suggest while keeping the history.