### PR TITLE
Move log and history files to $XDG_STATE_HOME

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -146,6 +146,7 @@ Contributors:
     * Charbel Jacquin (charbeljc)
     * Devadathan M B (devadathanmb)
     * Charalampos Stratakis
+    * Justin Raymond (jrraymond)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -3,6 +3,7 @@ Upcoming (TBD)
 
 Features:
 ---------
+* Move log and history files to ``$XDG_STATE_HOME`` (default ``~/.local/state/pgcli/``) per the XDG Base Directory Specification. Existing files at the old location (``~/.config/pgcli/``) are automatically migrated on first launch.
 * Add support for `\\T` prompt escape sequence to display transaction status (similar to psql's `%x`).
 * Add cursor shape support for vi mode. When ``vi = True``, the terminal cursor now
   reflects the current editing mode: beam in INSERT, block in NORMAL, underline in REPLACE.

--- a/pgcli/config.py
+++ b/pgcli/config.py
@@ -1,3 +1,4 @@
+import logging
 import shutil
 import os
 import platform
@@ -5,6 +6,8 @@ from os.path import expanduser, exists, dirname
 import re
 from typing import TextIO
 from configobj import ConfigObj
+
+logger = logging.getLogger(__name__)
 
 
 def config_location():
@@ -14,6 +17,16 @@ def config_location():
         return os.getenv("USERPROFILE") + "\\AppData\\Local\\dbcli\\pgcli\\"
     else:
         return expanduser("~/.config/pgcli/")
+
+
+def state_location():
+    if "XDG_STATE_HOME" in os.environ:
+        return "%s/pgcli/" % expanduser(os.environ["XDG_STATE_HOME"])
+    elif platform.system() == "Windows":
+        # No XDG equivalent on Windows; use the same directory as config.
+        return config_location()
+    else:
+        return expanduser("~/.local/state/pgcli/")
 
 
 def load_config(usr_cfg, def_cfg=None):
@@ -27,6 +40,24 @@ def load_config(usr_cfg, def_cfg=None):
         cfg = ConfigObj(expanduser(usr_cfg), interpolation=False, encoding="utf-8")
     cfg.filename = expanduser(usr_cfg)
     return cfg
+
+
+def migrate_file(old_path, new_path):
+    """Move old_path to new_path if old exists and new does not.
+
+    Silently does nothing if old_path does not exist or new_path already exists.
+    Logs an error if the move fails.
+    """
+    old_path = expanduser(old_path)
+    new_path = expanduser(new_path)
+    if not os.path.exists(old_path) or os.path.exists(new_path):
+        return
+    try:
+        ensure_dir_exists(new_path)
+        shutil.move(old_path, new_path)
+        logger.debug("Migrated %r to %r.", old_path, new_path)
+    except OSError as e:
+        logger.error("Failed to migrate %r to %r: %s", old_path, new_path, e)
 
 
 def ensure_dir_exists(path):

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -64,6 +64,8 @@ from .config import (
     get_casing_file,
     load_config,
     config_location,
+    state_location,
+    migrate_file,
     ensure_dir_exists,
     get_config,
     get_config_filename,
@@ -560,7 +562,8 @@ class PGCli:
     def initialize_logging(self):
         log_file = self.config["main"]["log_file"]
         if log_file == "default":
-            log_file = config_location() + "log"
+            log_file = state_location() + "log"
+            migrate_file(config_location() + "log", log_file)
         ensure_dir_exists(log_file)
         log_level = self.config["main"]["log_level"]
 
@@ -950,7 +953,8 @@ class PGCli:
 
         history_file = self.config["main"]["history_file"]
         if history_file == "default":
-            history_file = config_location() + "history"
+            history_file = state_location() + "history"
+            migrate_file(config_location() + "history", history_file)
         history = FileHistory(os.path.expanduser(history_file))
         self.refresh_completions(history=history, persist_priorities="none")
 

--- a/pgcli/pgclirc
+++ b/pgcli/pgclirc
@@ -66,7 +66,7 @@ generate_aliases = False
 alias_map_file =
 
 # log_file location.
-# In Unix/Linux: ~/.config/pgcli/log
+# In Unix/Linux: ~/.local/state/pgcli/log (respects $XDG_STATE_HOME if set)
 # In Windows: %USERPROFILE%\AppData\Local\dbcli\pgcli\log
 # %USERPROFILE% is typically C:\Users\{username}
 log_file = default
@@ -88,7 +88,7 @@ generate_casing_file = False
 case_column_headers = True
 
 # history_file location.
-# In Unix/Linux: ~/.config/pgcli/history
+# In Unix/Linux: ~/.local/state/pgcli/history (respects $XDG_STATE_HOME if set)
 # In Windows: %USERPROFILE%\AppData\Local\dbcli\pgcli\history
 # %USERPROFILE% is typically C:\Users\{username}
 history_file = default

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ import stat
 
 import pytest
 
-from pgcli.config import ensure_dir_exists, skip_initial_comment
+from pgcli.config import ensure_dir_exists, migrate_file, skip_initial_comment, state_location
 
 
 def test_ensure_file_parent(tmpdir):
@@ -29,6 +29,74 @@ def test_ensure_other_create_error(tmpdir):
 
     with pytest.raises(OSError):
         ensure_dir_exists(str(rcfile))
+
+
+def test_state_location_default(monkeypatch):
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    loc = state_location()
+    assert loc == os.path.expanduser("~/.local/state/pgcli/")
+
+
+def test_state_location_xdg(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    loc = state_location()
+    assert loc == str(tmp_path) + "/pgcli/"
+
+
+def test_migrate_file_old_only(tmp_path):
+    old = tmp_path / "old" / "history"
+    old.parent.mkdir()
+    old.write_text("cmd1\ncmd2\n")
+    new = tmp_path / "new" / "history"
+
+    migrate_file(str(old), str(new))
+
+    assert not old.exists()
+    assert new.read_text() == "cmd1\ncmd2\n"
+
+
+def test_migrate_file_both_exist(tmp_path):
+    old = tmp_path / "old" / "history"
+    old.parent.mkdir()
+    old.write_text("old content\n")
+    new = tmp_path / "new" / "history"
+    new.parent.mkdir()
+    new.write_text("new content\n")
+
+    migrate_file(str(old), str(new))
+
+    # neither file should be touched
+    assert old.read_text() == "old content\n"
+    assert new.read_text() == "new content\n"
+
+
+def test_migrate_file_old_missing(tmp_path):
+    old = tmp_path / "old" / "history"
+    new = tmp_path / "new" / "history"
+
+    migrate_file(str(old), str(new))
+
+    assert not new.exists()
+
+
+def test_migrate_file_error_is_logged(tmp_path, caplog):
+    import logging
+
+    old = tmp_path / "old" / "history"
+    old.parent.mkdir()
+    old.write_text("cmd1\n")
+    # make the destination parent directory read-only so the move fails
+    new_dir = tmp_path / "new"
+    new_dir.mkdir()
+    os.chmod(str(new_dir), stat.S_IREAD | stat.S_IEXEC)
+
+    new = new_dir / "subdir" / "history"
+
+    with caplog.at_level(logging.ERROR, logger="pgcli.config"):
+        migrate_file(str(old), str(new))
+
+    assert any("Failed to migrate" in r.message for r in caplog.records)
+    assert old.exists()  # original untouched since move failed
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1497.

## Summary

Per the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/), `$XDG_STATE_HOME` (default `~/.local/state`) is the correct location for state data that persists across restarts but is not user-configuration. Log and history fit this definition; config and casing remain in `$XDG_CONFIG_HOME`.

- Add `state_location()` to `config.py`, mirroring `config_location()` but using `$XDG_STATE_HOME` (defaults to `~/.local/state/pgcli/`). On Windows, returns the same path as `config_location()` since there is no XDG equivalent.
- Add `migrate_file(old, new)` helper that silently moves a file from the old location to the new one on first launch after upgrade. Errors are logged rather than raised.
- `initialize_logging()` and `run_cli()` now use `state_location()` for the default log and history paths, and call `migrate_file()` to handle the one-time upgrade migration.
- Update default path comments in `pgclirc`.
- Add tests for `state_location()` and all migration cases (old only, both exist, old missing, error logged on failure).

## Testing

```
> pgcli
Server: PostgreSQL 18.3 (Homebrew)
Version: 4.4.0
Home: http://pgcli.com
justinraymond> select * from foo;
Goodbye!

# logs/history resepect XDG_STATE_HOME
> cat ~/.local/state/pgcli/history

# 2026-04-03 11:57:59.545613
+select * from foo;

> cat ~/.local/state/pgcli/log
2026-04-03 11:51:19,816 (77436/MainThread) pgcli.main INFO - No default pager found in environment. Using os default pager
...

# move history/logs to old location to test migration
> mv ~/.local/state/pgcli/* ~/.config/pgcli/
> rm -r ~/.local/state/pgcli/

> pgcli
Server: PostgreSQL 18.3 (Homebrew)
Version: 4.4.0
Home: http://pgcli.com
justinraymond> select * from bar;
Goodbye!

> cat ~/.local/state/pgcli/history

# 2026-04-03 11:57:59.545613
+select * from foo;

# 2026-04-03 11:59:40.069136
+select * from bar;

> cat ~/.local/state/pgcli/log
2026-04-03 11:51:19,816 (77436/MainThread) pgcli.main INFO - No default pager found in environment. Using os default pager
...

# old location empty
> tree ~/.config/pgcli/
/Users/justinraymond/.config/pgcli/
└── config

1 directory, 1 file
```

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected.
- [x] Please squash merge this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)