### PR TITLE
fix: add `VERSION` to builtin function completion

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,6 +8,10 @@ Features:
   reflects the current editing mode: beam in INSERT, block in NORMAL, underline in REPLACE.
   Uses prompt_toolkit's ``ModalCursorShapeConfig``.
 
+Bug fixes:
+----------
+* Add `VERSION` to builtin function completion so `SELECT VERSION();` is suggested.
+
 4.4.0 (2025-12-24)
 ==================
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -10,7 +10,7 @@ Features:
 
 Bug fixes:
 ----------
-* Add `VERSION` to builtin function completion so `SELECT VERSION();` is suggested.
+* Add `VERSION` to built-in function completion so `SELECT VERSION();` is suggested.
 
 4.4.0 (2025-12-24)
 ==================

--- a/pgcli/packages/pgliterals/pgliterals.json
+++ b/pgcli/packages/pgliterals/pgliterals.json
@@ -439,6 +439,7 @@
         "TRUNC",
         "UNNEST",
         "UPPER",
+        "VERSION",
         "WIDTH",
         "WIDTH_BUCKET",
         "XMLAGG"

--- a/tests/test_naive_completion.py
+++ b/tests/test_naive_completion.py
@@ -49,6 +49,13 @@ def test_function_name_completion(completer, complete_event):
     ])
 
 
+def test_version_function_name_completion(completer, complete_event):
+    text = "SELECT VE"
+    position = len(text)
+    result = completions_to_set(completer.get_completions(Document(text=text, cursor_position=position), complete_event))
+    assert result == completions_to_set([Completion(text="VERSION", start_position=-2)])
+
+
 def test_column_name_completion(completer, complete_event):
     text = "SELECT  FROM users"
     position = len("SELECT ")

--- a/tests/test_smart_completion_public_schema_only.py
+++ b/tests/test_smart_completion_public_schema_only.py
@@ -161,6 +161,12 @@ def test_builtin_function_name_completion(completer):
 
 
 @parametrize("completer", completers())
+def test_builtin_version_function_completion(completer):
+    result = get_result(completer, "SELECT VE")
+    assert completions_to_set(result) == completions_to_set([function("VERSION", -2)])
+
+
+@parametrize("completer", completers())
 def test_builtin_function_matches_only_at_start(completer):
     text = "SELECT IN"
 


### PR DESCRIPTION
## Description

Adds `VERSION` to pgcli's builtin function completion list so `SELECT VERSION();` is suggested during autocompletion.

Closes #1510

### Screenshots
#### Before:
*Notice that `VERSION()` is not suggested in the autocomplete list.*

<img width="545" height="153" alt="image" src="https://github.com/user-attachments/assets/c05e747b-4a91-48d6-9709-0f89cc6bd7e8" />


#### After:
*Notice that `VERSION()` is now correctly suggested in the autocomplete list.*

<img width="571" height="176" alt="image" src="https://github.com/user-attachments/assets/c8689688-87bc-4efc-b9ab-c88ac7a1ac03" />

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected (this may include manually testing them in your local environment, or in other available environments). Cross this out if not relevant (for example, if you're making a documentation change).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)