### PR TITLE
fix: handle trailing SQL comments in multiline submit

### DIFF
--- a/pgcli/pgbuffer.py
+++ b/pgcli/pgbuffer.py
@@ -4,6 +4,7 @@ from prompt_toolkit.enums import DEFAULT_BUFFER
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.application import get_app
 from .packages.parseutils.utils import is_open_quote
+import sqlparse
 
 _logger = logging.getLogger(__name__)
 
@@ -12,7 +13,8 @@ def _is_complete(sql):
     # A complete command is an sql statement that ends with a semicolon, unless
     # there's an open quote surrounding it, as is common when writing a
     # CREATE FUNCTION command
-    return sql.endswith(";") and not is_open_quote(sql)
+    sql_for_check = sqlparse.format(sql, strip_comments=True)
+    return sql_for_check.endswith(";") and not is_open_quote(sql)
 
 
 """

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -361,7 +361,7 @@ class PGExecute:
         # run each sql query
         for sql in sqlarr:
             # Remove spaces, eol and semi-colons.
-            sql = sql.rstrip(";")
+            sql = sqlparse.format(sql, strip_comments=True).rstrip(";")
             sql = sqlparse.format(sql, strip_comments=False).strip()
             if not sql:
                 continue


### PR DESCRIPTION
Fixes two related bugs when a SQL comment follows the semicolon:

**Bug 1 — pgbuffer._is_complete():** sql.endswith(';') returned False when a trailing comment followed the semicolon. In multiline mode, pressing Enter never submitted the query.

**Bug 2 — pgexecute.run():** sql.rstrip(';') couldn't strip the semicolon because the string ended with comment text. The malformed SQL was sent to PostgreSQL via psycopg's extended query protocol.

Both locations now use sqlparse.format(sql, strip_comments=True) before checking for / removing the trailing semicolon.

Fixes dbcli/pgcli#1559