### PR TITLE
fix: preserve hash character in pg_service.conf passwords

### DIFF
--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1974,7 +1974,7 @@ def parse_service_info(service):
     with open(service_file, newline="") as f:
         skipped_lines = skip_initial_comment(f)
         try:
-            service_file_config = ConfigObj(f)
+            service_file_config = ConfigObj(f, comment_tokens=[])
         except ParseError as err:
             err.line_number += skipped_lines
             raise err


### PR DESCRIPTION
## Fixes #1575

The `#` character is treated as a comment delimiter by ConfigObj, which truncates passwords like `abc#123` to `abc`.

This fix adds `comment_tokens=[]` to the `ConfigObj()` call in `parse_service_info()` to disable comment parsing, allowing `#` characters within password values.

### Before
```python
service_file_config = ConfigObj(f)
```

### After
```python
service_file_config = ConfigObj(f, comment_tokens=[])
```