### PR TITLE
Hide timezone notice when local and server timezones are the same

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -11,6 +11,7 @@ Features:
 Bug fixes:
 ----------
 * Add `VERSION` to built-in function completion so `SELECT VERSION();` is suggested.
+* Hide timezone notice at startup when local and server timezones are the same.
 
 4.4.0 (2025-12-24)
 ==================

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1646,7 +1646,7 @@ def cli(
 
             if local_tz is None:
                 echo_error("No local time zone configuration found\n")
-            else:
+            elif local_tz != server_tz:
                 click.secho(
                     f"Using local time zone {local_tz} (server uses {server_tz})",
                     fg="green",


### PR DESCRIPTION
## Description

This takes space and is not very useful.

Now the notice is only printed when the local timezone is different from the server timezone, for example:

    Using local time zone Europe/Paris (server uses Etc/UTC)
    Use `set time zone <TZ>` to override, or set `use_local_timezone = False` in the config

Fixes #1579.

## Demo

When local and server timezones are different:

```
$ pgcli
Using local time zone Europe/Paris (server uses Etc/UTC)
Use `set time zone <TZ>` to override, or set `use_local_timezone = False` in the config
Server: PostgreSQL 17.5 (Debian 17.5-1.pgdg110+1)
[...]
```

When timezones are the same:

```
$ pgcli
Server: PostgreSQL 17.5 (Debian 17.5-1.pgdg110+1)
[...]
```

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected (this may include manually testing them in your local environment, or in other available environments). Cross this out if not relevant (for example, if you're making a documentation change).
- [ ] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
