### PR TITLE
Drop support of Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     services:
       postgres:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     services:
       postgres:

--- a/README.rst
+++ b/README.rst
@@ -341,6 +341,7 @@ Pgcli dropped support for:
 
 * Python<3.8 as of 4.0.0.
 * Python<3.9 as of 4.2.0.
+* Python<10 as of 4.5.0.
 
 Thanks:
 -------

--- a/changelog.rst
+++ b/changelog.rst
@@ -8,6 +8,7 @@ Features:
   reflects the current editing mode: beam in INSERT, block in NORMAL, underline in REPLACE.
   Uses prompt_toolkit's ``ModalCursorShapeConfig``.
 * Add support of Python 3.14.
+* Drop support of Python 3.9.
 
 Bug fixes:
 ----------

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -17,7 +17,6 @@ import itertools
 import pathlib
 import platform
 from time import time, sleep
-from typing import Optional
 
 from cli_helpers.tabular_output import TabularOutputFormatter
 from cli_helpers.tabular_output.preprocessors import (
@@ -184,8 +183,8 @@ class PGCli:
         prompt_dsn=None,
         auto_vertical_output=False,
         warn=None,
-        ssh_tunnel_url: Optional[str] = None,
-        log_file: Optional[str] = None,
+        ssh_tunnel_url: str | None = None,
+        log_file: str | None = None,
     ):
         self.force_passwd_prompt = force_passwd_prompt
         self.never_passwd_prompt = never_passwd_prompt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -22,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 urls = { Homepage = "https://pgcli.com" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "pgspecial>=2.0.0",
     # Click 8.1.8 through 8.3.0 have broken pager invocation for multi-argument PAGER values, which causes behave test failures.


### PR DESCRIPTION
## Description

Python 3.9 has reached its end of life 6 months ago (2025-10-31).

See https://devguide.python.org/versions/

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected (this may include manually testing them in your local environment, or in other available environments). Cross this out if not relevant (for example, if you're making a documentation change).
- [ ] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
