### PR TITLE
Dockerfile: Bump Python version to 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.14
 
 COPY . /app
 RUN cd /app && pip install -e .


### PR DESCRIPTION
## Description

Let's use the latest stable Python Docker image, and not a Docker image that uses a version of Python that reached its end of life 6 months ago.

See also #1583 that officializes support of Python 3.14.

## Demo

```
$ docker build .
[...]
 => => unpacking to moby-dangling@sha256:1de5179fa7e19a09ca82bee418862f2a2fab0f22a055d8c41e0f06e6d3a6cae3                                          0.3s

$ docker run --rm -it --net host 1de5179fa7e19a09ca82bee418862f2a2fab0f22a055d8c41e0f06e6d3a6cae3 pgcli -h localhost -p 5432 -d test_db -U postgres
Password for postgres: 
Using local time zone Etc/UTC (server uses UTC)
Use `set time zone <TZ>` to override, or set `use_local_timezone = False` in the config
Server: PostgreSQL 17.5 (Debian 17.5-1.pgdg110+1)
Version: 4.4.0
Home: http://pgcli.com
postgres@localhost:test_db>               
```

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected (this may include manually testing them in your local environment, or in other available environments). Cross this out if not relevant (for example, if you're making a documentation change).
- [ ] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
