### PR TITLE
Fix integration with IPython

### DIFF
--- a/pgcli/magic.py
+++ b/pgcli/magic.py
@@ -40,7 +40,7 @@ def pgcli_line_magic(line):
         # from the sqlalchemy connection, so just grab the url and make a
         # new connection
         pgcli = PGCli()
-        u = conn.session.engine.url
+        u = conn.url
         _logger.debug("New pgcli: %r", str(u))
 
         pgcli.connect_uri(str(u._replace(drivername="postgres")))


### PR DESCRIPTION
## Description

(Context: pgcli provides integration with IPython, see https://www.pgcli.com/ipython.)

pgcli now requires psycopg3, whose `Connection` object does not have a `session` attribute. We can retrieve the URL directly from the `Connection` object. (Test is hard to write, because it requires a PostgreSQL server to connect to. We could mock a few functions here and there, but I am not interested in going this direction, see below.)

This fixes the bug reported in #1520: 

<details>
<summary>Click to toggle demo output</summary>

```
$ ipython
In [1] %load_ext pgcli.magic
In [2]: %pgcli postgresql+psycopg://postgres:password@0.0.0.0:5432/test_database
Password for postgres: 
Connected: postgres@test_database
Server: PostgreSQL 17.5 (Debian 17.5-1.pgdg110+1)
Version: 4.4.0
Home: http://pgcli.com
postgres@0.0.0.0:test_database>
Goodbye!
```
</details>

Note that I did **not** input any SQL query above. But the IPython integration is still half-broken **when one does input an SQL query**:

<details>
<summary>Click to toggle demo output</summary>

```
$ ipython
In [1] %load_ext pgcli.magic
In [2]: %pgcli postgresql+psycopg://postgres:password@0.0.0.0:5432/test_database
Password for postgres: 
Connected: postgres@test_database
Server: PostgreSQL 17.5 (Debian 17.5-1.pgdg110+1)
Version: 4.4.0
Home: http://pgcli.com
postgres@0.0.0.0:test_database> select 1;
+----------+
| ?column? |
|----------|
| 1        |
+----------+
SELECT 1
Time: 0.003s
postgres@0.0.0.0:test_database>                                                                                                                                  
Goodbye!
1 rows affected.
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[5], line 1
----> 1 get_ipython().run_line_magic('pgcli', 'postgresql+psycopg://postgres:password@0.0.0.0:5432/test_database')
File ~/dev/perso/pgcli/pgcli/magic.py:71, in pgcli_line_magic(line)
     68     return
     70 ipython = get_ipython()
---> 71 return ipython.run_cell_magic("sql", line, q.query)
File ~/env/pgcli/lib64/python3.14/site-packages/sql/magic.py:219, in SqlMagic.execute(self, line, cell, local_ns)
    216     return
    218 try:
--> 219     result = sql.run.run(conn, parsed["sql"], self, user_ns)
    221     if (
    222         result is not None
    223         and not isinstance(result, str)
   (...)    226         # Instead of returning values, set variables directly in the
    227         # user's namespace. Variable names given by column names
    229         if self.autopandas:
File ~/env/pgcli/lib64/python3.14/site-packages/sql/run.py:374, in run(conn, sql, config, user_namespace)
    372     if result and config.feedback:
    373         print(interpret_rowcount(result.rowcount))
--> 374 resultset = ResultSet(result, config)
    375 if config.autopandas:
    376     return resultset.DataFrame()
File ~/env/pgcli/lib64/python3.14/site-packages/sql/run.py:116, in ResultSet.__init__(self, sqlaproxy, config)
    114         list.__init__(self, sqlaproxy.fetchall())
    115     self.field_names = unduplicate_field_names(self.keys)
--> 116     self.pretty = PrettyTable(self.field_names, style=prettytable.__dict__[config.style.upper()])
    117 else:
    118     list.__init__(self, [])
KeyError: 'DEFAULT'
```
</details>

This is because of [a bug in ipython-sql](https://github.com/catherinedevlin/ipython-sql/issues/252). `ipython-sql` seems to be unmaintained, people suggest using a fork: `jupysql`. I tried, but it's not a drop-in replacement: I get an AttributeError on `sql.connection.Connection` in `pgcli.magic.pgcli_line_magic()`.

I do not use IPython, so I am not willing to go further. This pull request makes pgcli available from IPython, even though SQL results cannot be used back in IPython. This is not perfect (and certainly limited), but it's still better than the current situation.

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected (this may include manually testing them in your local environment, or in other available environments). Cross this out if not relevant (for example, if you're making a documentation change).
- [ ] ~Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)~