### PR TITLE
Fix completion crash when tables are created during refresh

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -148,6 +148,7 @@ Contributors:
     * Charalampos Stratakis
     * Laszlo Bimba (bimlas)
     * Anjanna
+    * Shayan Golshani (shgol)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -20,6 +20,7 @@ Bug fixes:
 * Fix trailing SQL comments preventing query submission and execution.
     * ``SELECT 1; -- note`` now submits correctly in multiline mode
     * ``rstrip(";")`` in ``pgexecute.py`` now handles comments after the semicolon
+* Fix completion crash when tables are created during refresh.
 
 4.4.0 (2025-12-24)
 ==================

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -229,6 +229,8 @@ class PGCompleter(Completer):
                 has_default=has_default,
                 default=default,
             )
+            metadata.setdefault(schema, {})
+            metadata[schema].setdefault(relname, OrderedDict())
             metadata[schema][relname][colname] = column
             self.all_completions.add(colname)
 


### PR DESCRIPTION
## Description
Fixes race in `completer_refresh` thread when a table is created in between `extend_relations` and `extend_columns`, which causes a `KeyError` on accessing the `relname` key.

closes #1590 

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected (this may include manually testing them in your local environment, or in other available environments). Cross this out if not relevant (for example, if you're making a documentation change).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
