### PR TITLE
fix: Fix row limit detection for multiline LIMIT clauses

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -147,6 +147,7 @@ Contributors:
     * Devadathan M B (devadathanmb)
     * Charalampos Stratakis
     * Laszlo Bimba (bimlas)
+    * Anjanna
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -16,6 +16,7 @@ Bug fixes:
 * Add `VERSION` to built-in function completion so `SELECT VERSION();` is suggested.
 * Hide timezone notice at startup when local and server timezones are the same.
 * Let `sqlparse` accept arbitrarily-large queries.
+* Respect user-specified `LIMIT` clauses when the limit value starts on a new line.
 
 4.4.0 (2025-12-24)
 ==================

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -27,6 +27,8 @@ from cli_helpers.tabular_output.preprocessors import (
 from cli_helpers.utils import strip_ansi
 from .explain_output_formatter import ExplainOutputFormatter
 import click
+import sqlparse
+from sqlparse import tokens as sqlparse_tokens
 import tzlocal
 
 try:
@@ -1114,7 +1116,7 @@ class PGCli:
     def _has_limit(self, sql):
         if not sql:
             return False
-        return "limit " in sql.lower()
+        return any(token.match(sqlparse_tokens.Keyword, "LIMIT") for statement in sqlparse.parse(sql) for token in statement.flatten())
 
     def _limit_output(self, cur):
         limit = min(self.row_limit, cur.rowcount)

--- a/tests/test_rowlimit.py
+++ b/tests/test_rowlimit.py
@@ -44,9 +44,18 @@ def low_count():
     return low_count_cursor
 
 
-def test_row_limit_with_LIMIT_clause(LIMIT, over_limit):
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        "SELECT * FROM students LIMIT 1000",
+        "SELECT * FROM students LIMIT\n    1000",
+        "SELECT * FROM students LIMIT\t1000",
+        "SELECT * FROM students limit 1000",
+        "SELECT * FROM students LiMiT 1000",
+    ],
+)
+def test_row_limit_with_LIMIT_clause(LIMIT, over_limit, stmt):
     cli = PGCli(row_limit=LIMIT)
-    stmt = "SELECT * FROM students LIMIT 1000"
 
     result = cli._should_limit_output(stmt, over_limit)
     assert result is False
@@ -54,6 +63,21 @@ def test_row_limit_with_LIMIT_clause(LIMIT, over_limit):
     cli = PGCli(row_limit=0)
     result = cli._should_limit_output(stmt, over_limit)
     assert result is False
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        "SELECT 'LIMIT 1000' FROM students",
+        "SELECT * FROM students -- LIMIT 1000",
+        "SELECT * FROM students /* LIMIT 1000 */",
+    ],
+)
+def test_row_limit_ignores_LIMIT_in_comments_or_strings(LIMIT, over_limit, stmt):
+    cli = PGCli(row_limit=LIMIT)
+
+    result = cli._should_limit_output(stmt, over_limit)
+    assert result is True
 
 
 def test_row_limit_without_LIMIT_clause(LIMIT, over_limit):


### PR DESCRIPTION
## Description
### Summary

Fixes #1592 

Fixes pgcli's row limit detection when a SQL query contains a `LIMIT` clause followed by a newline.

Previously, pgcli checked for `LIMIT` using a string search for `"limit "`, so queries like this were not recognized as already limited:

```sql
SELECT *
FROM foo
LIMIT
    10000;
```
As a result, pgcli could incorrectly apply its configured row limit and show the row-limit warning. This change uses parsed SQL tokens to detect real LIMIT keywords, including multiline and tab-separated formatting, while ignoring LIMIT inside strings or comments.

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected (this may include manually testing them in your local environment, or in other available environments). Cross this out if not relevant (for example, if you're making a documentation change).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
