### PR TITLE
Let `sqlparse` accept arbitrarily-large queries

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,7 @@ Bug fixes:
 ----------
 * Add `VERSION` to built-in function completion so `SELECT VERSION();` is suggested.
 * Hide timezone notice at startup when local and server timezones are the same.
+* Let `sqlparse` accept arbitrarily-large queries.
 
 4.4.0 (2025-12-24)
 ==================

--- a/pgcli/packages/parseutils/__init__.py
+++ b/pgcli/packages/parseutils/__init__.py
@@ -1,5 +1,7 @@
 import sqlparse
 
+sqlparse.engine.grouping.MAX_GROUPING_DEPTH = None
+sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None
 
 BASE_KEYWORDS = [
     "drop",

--- a/pgcli/packages/parseutils/ctes.py
+++ b/pgcli/packages/parseutils/ctes.py
@@ -1,9 +1,12 @@
+import sqlparse
 from sqlparse import parse
 from sqlparse.tokens import Keyword, CTE, DML
 from sqlparse.sql import Identifier, IdentifierList, Parenthesis
 from collections import namedtuple
 from .meta import TableMetadata, ColumnMetadata
 
+sqlparse.engine.grouping.MAX_GROUPING_DEPTH = None
+sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None
 
 # TableExpression is a namedtuple representing a CTE, used internally
 # name: cte alias assigned in the query

--- a/pgcli/packages/parseutils/tables.py
+++ b/pgcli/packages/parseutils/tables.py
@@ -3,6 +3,9 @@ from collections import namedtuple
 from sqlparse.sql import IdentifierList, Identifier, Function
 from sqlparse.tokens import Keyword, DML, Punctuation
 
+sqlparse.engine.grouping.MAX_GROUPING_DEPTH = None
+sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None
+
 TableReference = namedtuple("TableReference", ["schema", "name", "alias", "is_function"])
 TableReference.ref = property(
     lambda self: self.alias or (self.name if self.name.islower() or self.name[0] == '"' else '"' + self.name + '"')

--- a/pgcli/packages/parseutils/utils.py
+++ b/pgcli/packages/parseutils/utils.py
@@ -3,6 +3,9 @@ import sqlparse
 from sqlparse.sql import Identifier
 from sqlparse.tokens import Token, Error
 
+sqlparse.engine.grouping.MAX_GROUPING_DEPTH = None
+sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None
+
 cleanup_regex = {
     # This matches only alphanumerics and underscores.
     "alphanum_underscore": re.compile(r"(\w+)$"),

--- a/pgcli/packages/prioritization.py
+++ b/pgcli/packages/prioritization.py
@@ -4,6 +4,8 @@ from sqlparse.tokens import Name
 from collections import defaultdict
 from .pgliterals.main import get_literals
 
+sqlparse.engine.grouping.MAX_GROUPING_DEPTH = None
+sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None
 
 white_space_regex = re.compile("\\s+", re.MULTILINE)
 

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -7,6 +7,8 @@ from .parseutils.tables import extract_tables
 from .parseutils.ctes import isolate_query_ctes
 from pgspecial.main import parse_special_command
 
+sqlparse.engine.grouping.MAX_GROUPING_DEPTH = None
+sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None
 
 Special = namedtuple("Special", [])
 Database = namedtuple("Database", [])

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -9,6 +9,9 @@ import psycopg.sql
 from psycopg.conninfo import make_conninfo
 import sqlparse
 
+sqlparse.engine.grouping.MAX_GROUPING_DEPTH = None
+sqlparse.engine.grouping.MAX_GROUPING_TOKENS = None
+
 from .packages.parseutils.meta import FunctionMetadata, ForeignKey
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Description
Fixes the pgcli-equivalent of this issue: https://github.com/dbcli/mycli/issues/1432

Ported from https://github.com/dbcli/mycli/pull/1433/changes

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [X] I've added this contribution to the `changelog.rst`.
- [X] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [X] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [X] I verified that my changes work as expected (this may include manually testing them in your local environment, or in other available environments). Cross this out if not relevant (for example, if you're making a documentation change).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
