### PR TITLE
Pass PG* env variables to integration tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,10 @@ deps = uv
 commands = uv pip install -e .[dev]
         behave tests/features --no-capture
 passenv =
+    PGHOST
+    PGPORT
+    PGUSER
+    PGPASSWORD
     PYTHONIOENCODING
 setenv =
     PYTHONIOENCODING = utf-8


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

When merging https://github.com/dbcli/pgcli/pull/1560, we lost `PG*` env vars in CI. CI is now broken. Let's fix.
