### PR TITLE
Fix typos in code comments

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -147,6 +147,7 @@ Contributors:
     * Devadathan M B (devadathanmb)
     * Charalampos Stratakis
     * Laszlo Bimba (bimlas)
+    * MJSHANG (mokashang)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -17,6 +17,10 @@ Bug fixes:
 * Hide timezone notice at startup when local and server timezones are the same.
 * Let `sqlparse` accept arbitrarily-large queries.
 
+Internal:
+---------
+* Fix typos in code comments.
+
 4.4.0 (2025-12-24)
 ==================
 

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -19,8 +19,8 @@ _logger = logging.getLogger(__name__)
 ViewDef = namedtuple("ViewDef", "nspname relname relkind viewdef reloptions checkoption")
 
 
-# we added this funcion to strip beginning comments
-# because sqlparse didn't handle tem well.  It won't be needed if sqlparse
+# we added this function to strip beginning comments
+# because sqlparse didn't handle them well.  It won't be needed if sqlparse
 # does parsing of this situation better
 
 

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -391,7 +391,7 @@ def test_execute_commented_first_line_and_special(executor, pgspecial, tmpdir):
     assert result[0].find("No help") >= 0
 
     # TODO: we probably don't want to do this but sqlparse is not parsing things well
-    # we relly want it to find help but right now, sqlparse isn't dropping the /*comment*/
+    # we really want it to find help but right now, sqlparse isn't dropping the /*comment*/
     # style comments after command
 
     statement = r"""/*comment1*/


### PR DESCRIPTION
## Description

Fix three small typos in code comments:

- `pgcli/pgexecute.py`: `funcion` → `function`, `tem` → `them`
- `tests/test_pgexecute.py`: `relly` → `really`

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected (this may include manually testing them in your local environment, or in other available environments). Cross this out if not relevant (for example, if you're making a documentation change).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
