### PR TITLE
fix: decode bytes from conn.info.get_parameters() to avoid TypeError on macOS

### DIFF
--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -243,6 +243,16 @@ class PGExecute:
         # user, etc. we connected to. Let's read it.
         # Note: moved this after setting autocommit because of #664.
         dsn_parameters = conn.info.get_parameters()
+        # On some platforms (e.g., macOS with Homebrew psycopg, Python 3.13+),
+        # get_parameters() can return bytes values instead of str.
+        # Decode them to str to avoid TypeError: replace() argument 2 must be str, not bytes
+        # in main.py get_prompt() and TypeError: cannot use a string pattern on a bytes-like object
+        # in pgcompleter.py escape_name(). See issues #1518.
+        if dsn_parameters:
+            dsn_parameters = {
+                k: v.decode() if isinstance(v, bytes) else v
+                for k, v in dsn_parameters.items()
+            }
 
         if dsn_parameters:
             self.dbname = dsn_parameters.get("dbname")
@@ -481,7 +491,7 @@ class PGExecute:
             with self.conn.cursor() as cur:
                 _logger.debug("Search path query. sql: %r", self.search_path_query)
                 cur.execute(self.search_path_query)
-                return [x[0] for x in cur.fetchall()]
+                return [x[0].decode() if isinstance(x[0], bytes) else x[0] for x in cur.fetchall()]
         except psycopg.ProgrammingError:
             fallback = "SELECT * FROM current_schemas(true)"
             with self.conn.cursor() as cur:


### PR DESCRIPTION
## Problem

`pgcli` crashes on startup on macOS (Homebrew, Python 3.13+/3.14+) with:

```
TypeError: replace() argument 2 must be str, not bytes
```

And in the completion refresher thread:

```
TypeError: cannot use a string pattern on a bytes-like object
```

## Root Cause

`psycopg.Connection.info.get_parameters()` can return a dictionary with `bytes` values instead of `str` on certain platforms (macOS with Homebrew psycopg, Python 3.13+). This occurs because psycopg's parameter_status returns raw bytes from the PostgreSQL protocol, and `get_parameters()` passes them through without decoding.

When `host` is `b'localhost'` instead of `'localhost'`, downstream code in `main.py`'s `get_prompt()` calls `string.replace("\\H", self.pgexecute.host)` which raises `TypeError` because `str.replace()` requires str arguments.

Similarly, `search_path()` returns raw cursor results that can be bytes, causing `pgcompleter.py`'s `escape_name()` to fail with `TypeError: cannot use a string pattern on a bytes-like object`.

## Changes

1. **pgcli/pgexecute.py - `connect()` method**: After calling `conn.info.get_parameters()`, decode any `bytes` values to `str` using `.decode()`.

2. **pgcli/pgexecute.py - `search_path()` method**: Decode individual schema name values from `bytes` to `str` if needed.

## Closes

Closes #1518