### PR TITLE
Fix outdated project settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pgcli"
 authors = [{ name = "Pgcli Core Team", email = "pgcli-dev@googlegroups.com" }]
-license = { text = "BSD" }
+license = "BSD-3-Clause"
 description = "CLI for Postgres Database. With auto-completion and syntax highlighting."
 readme = "README.rst"
 classifiers = [
@@ -72,9 +72,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 include-package-data = false
-
-[tool.setuptools.dynamic]
-version = { attr = "pgcli.__version__" }
 
 [tool.setuptools.packages]
 find = { namespaces = false }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->

Project settings were outdated. This message popped up when running a release:

```
UserWarning: pyproject.toml: at [tool.setuptools.dynamic]
version = {attr = ...} is forcing setuptools to override the version setuptools-scm did already set
When using setuptools-scm it's invalid to use setuptools dynamic version as well, please remove it.
Setuptools-scm is responsible for setting the version, forcing setuptools to override creates errors.
  warnings.warn(
/private/var/folders/hb/1wqy7rfj7sn63602c00_kq180000gn/T/build-env-m79t558q/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2027-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
```
