### PR TITLE
Fix NoneType crash completing functions with unnamed args

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -148,6 +148,7 @@ Contributors:
     * Charalampos Stratakis
     * Laszlo Bimba (bimlas)
     * Anjanna
+    * youdie006
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,11 @@
+4.5.1 (unreleased)
+==================
+
+Bug fixes:
+----------
+* Fix ``NoneType`` crash when completing functions with unnamed (variadic) arguments (#1204).
+
+
 4.5.0 (2026-06-02)
 ==================
 

--- a/pgcli/packages/parseutils/meta.py
+++ b/pgcli/packages/parseutils/meta.py
@@ -159,6 +159,6 @@ class FunctionMetadata:
 
         return [
             ColumnMetadata(name, typ, [])
-            for name, typ, mode in zip(self.arg_names, self.arg_types, self.arg_modes)
+            for name, typ, mode in zip(self.arg_names or [], self.arg_types or [], self.arg_modes)
             if mode in ("o", "b", "t")
         ]  # OUT, INOUT, TABLE

--- a/tests/parseutils/test_function_metadata.py
+++ b/tests/parseutils/test_function_metadata.py
@@ -11,3 +11,25 @@ def test_function_metadata_eq():
     assert not (f1 == f3)
     assert hash(f1) == hash(f2)
     assert hash(f1) != hash(f3)
+
+
+def test_function_metadata_fields_with_variadic_and_no_arg_names():
+    # Regression for issue #1204: a function with a VARIADIC argument that has
+    # a type but no name (e.g. `labels(variadic text[]) RETURNS hstore`) leaves
+    # arg_names as None while arg_modes is truthy. fields() must not raise
+    # "'NoneType' object is not iterable".
+    f = FunctionMetadata(
+        "public",
+        "labels",
+        None,  # arg_names: variadic arg has no name
+        ["text[]"],
+        ["v"],  # VARIADIC
+        "hstore",
+        False,
+        False,
+        False,
+        False,
+        None,
+    )
+    # No OUT/INOUT/TABLE columns, so fields() yields nothing.
+    assert f.fields() == []


### PR DESCRIPTION
## Description

`FunctionMetadata.fields()` (`pgcli/packages/parseutils/meta.py`) called `zip(self.arg_names, self.arg_types, self.arg_modes)`. For a function with unnamed (variadic) arguments — e.g. the hstore example `labels(variadic text[])` — `arg_names` is normalized to `None` while `arg_modes` stays truthy, so `zip(None, ...)` raised `'NoneType' object is not iterable` and crashed `get_completions()` (#1204).

The fix guards the zip with `or []` (the same guard `args()` already uses):

```python
for name, typ, mode in zip(self.arg_names or [], self.arg_types or [], self.arg_modes)
```

Added a regression test in `tests/parseutils/test_function_metadata.py` reproducing the variadic / no-arg-names case (red before the fix, green after). Full completion + parseutils sweep: 2450 passed; `ruff` clean.

Closes #1204

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected (pytest: regression test passes; full completion/parseutils sweep 2450 passed; `ruff` clean).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
