### PR TITLE
Restore cursor shape behaviour for Emacs mode

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,4 +1,5 @@
 Upcoming (TBD)
+==============
 
 Bug fixes:
 ----------

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,3 +1,10 @@
+Upcoming (TBD)
+==============
+
+Bug fixes:
+----------
+* Restore cursor shape behaviour for Emacs mode
+
 4.5.0 (2026-06-02)
 ==================
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -3,7 +3,6 @@ Upcoming (TBD)
 Bug fixes:
 ----------
 * Restore cursor shape behaviour for Emacs mode
-Upcoming
 
 Features:
 ---------

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -1099,7 +1099,7 @@ class PGCli:
                 enable_suspend=True,
                 editing_mode=EditingMode.VI if self.vi_mode else EditingMode.EMACS,
                 search_ignore_case=True,
-                cursor=ModalCursorShapeConfig(),
+                cursor=ModalCursorShapeConfig() if self.vi_mode else None,
             )
 
             return prompt_app


### PR DESCRIPTION
## Description

I have my cursor configured to be a block character in my terminal emulator because it's more visible to me

## Checklist
<!--- We appreciate your help and want to give you credit. Please take a moment to put an `x` in the boxes below as you complete them. -->
- [x] I've added this contribution to the `changelog.rst`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
<!-- We would appreciate if you comply with our code style guidelines. -->
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected (this may include manually testing them in your local environment, or in other available environments). Cross this out if not relevant (for example, if you're making a documentation change).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
