### PR TITLE
Suggest columns after a column named type

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,7 @@ Upcoming (TBD)
 Bug fixes:
 ----------
 * Restore cursor shape behaviour for Emacs mode
+* Suggest columns, not datatypes, after a column literally named ``type`` in a ``SELECT`` list.
 
 Features:
 ---------

--- a/pgcli/packages/sqlcompletion.py
+++ b/pgcli/packages/sqlcompletion.py
@@ -278,6 +278,29 @@ def suggest_special(text):
     return (Keyword(), Special())
 
 
+def _is_datatype_keyword(token, stmt):
+    """Decide whether a `type` token is the SQL TYPE keyword or a column name.
+
+    `type` is a non-reserved word in postgres, so sqlparse tags a column
+    literally named "type" as a keyword. The TYPE keyword only introduces a
+    datatype in DDL contexts (`ALTER COLUMN bar TYPE`, `SET DATA TYPE`,
+    `CREATE TYPE`), never directly inside a DML select/insert/update list.
+    """
+    if isinstance(token, str):
+        # An explicit internal request for datatype suggestions, e.g. the
+        # parenthesized column list in `CREATE TABLE foo (bar <CURSOR>`.
+        return True
+
+    if not token.is_keyword:
+        return False
+
+    prev_keyword, _ = find_prev_keyword(stmt.text_before_cursor.rstrip(), n_skip=1)
+    if prev_keyword is None:
+        return False
+
+    return prev_keyword.ttype is not sqlparse.tokens.Keyword.DML
+
+
 def suggest_based_on_last_token(token, stmt):
     if isinstance(token, str):
         token_v = token.lower()
@@ -492,7 +515,7 @@ def suggest_based_on_last_token(token, stmt):
             return suggest_based_on_last_token(prev_keyword, stmt)
         else:
             return ()
-    elif token_v in ("type", "::"):
+    elif token_v == "::" or (token_v == "type" and _is_datatype_keyword(token, stmt)):
         #   ALTER TABLE foo SET DATA TYPE bar
         #   SELECT foo::bar
         # Note that tables are a form of composite type in postgresql, so

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -801,6 +801,23 @@ def test_alter_column_type_suggests_types():
 @pytest.mark.parametrize(
     "text",
     [
+        "SELECT type ",
+        "SELECT type, ",
+        "SELECT id, type, ",
+    ],
+)
+def test_column_named_type_still_suggests_columns(text):
+    # `type` is a non-reserved word, so sqlparse tags a column literally
+    # named "type" as the TYPE keyword; it must not switch the SELECT list
+    # over to datatype suggestions.
+    suggestions = suggest_type(text, text)
+    assert Column in {type(s) for s in suggestions}
+    assert Datatype(schema=None) not in suggestions
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
         "CREATE TABLE foo (bar ",
         "CREATE TABLE foo (bar DOU",
         "CREATE TABLE foo (bar INT, baz ",


### PR DESCRIPTION
Fixes #1412

## Description
`type` is a non-reserved word in postgres, so sqlparse tags a column literally named `type` as the TYPE keyword. `suggest_based_on_last_token` matched that token unconditionally, so a query like `SELECT type, ` switched to datatype/table/schema suggestions and offered no column completions for the rest of the statement.

TYPE only introduces a datatype in DDL contexts (`ALTER COLUMN bar TYPE`, `SET DATA TYPE`), so it is now only treated that way when the preceding keyword is not a DML statement keyword. Cast operators (`::`) and parenthesized column lists (`CREATE TABLE foo (bar `) go through separate paths and are unaffected.

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected (new `test_column_named_type_still_suggests_columns` fails on `main` for all three cases and passes with the fix; the full completion suite, 2359 tests, is green).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
