### PR TITLE
Fix TypeError when completion metadata is bytes

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,8 @@ Upcoming (TBD)
 Bug fixes:
 ----------
 * Restore cursor shape behaviour for Emacs mode
+* Fix ``TypeError: cannot use a string pattern on a bytes-like object`` when
+  completion metadata comes back as bytes (e.g. ``SQL_ASCII`` client encoding).
 
 Features:
 ---------

--- a/pgcli/pgcompleter.py
+++ b/pgcli/pgcompleter.py
@@ -141,6 +141,11 @@ class PGCompleter(Completer):
         self.all_completions = set(self.keywords + self.functions)
 
     def escape_name(self, name):
+        if isinstance(name, bytes):
+            # Identifiers come back as bytes when the client encoding is one
+            # psycopg cannot decode (e.g. SQL_ASCII), see issue #1405.
+            name = name.decode("utf-8", "replace")
+
         if name and ((not self.name_pattern.match(name)) or (name.upper() in self.reserved_words) or (name.upper() in self.functions)):
             name = '"%s"' % name
 

--- a/tests/test_pgcompleter.py
+++ b/tests/test_pgcompleter.py
@@ -92,3 +92,19 @@ def test_generate_alias_prefers_alias_over_upper_case_name(table_name, alias_map
 )
 def test_generate_alias_prefers_upper_case_name_over_underscore_name(table_name, alias):
     assert pgcompleter.generate_alias(table_name) == alias
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        (b"pg_catalog", "pg_catalog"),
+        (b"public", "public"),
+        (b"Mixed Case", '"Mixed Case"'),
+        (b"select", '"select"'),
+    ],
+)
+def test_escape_name_accepts_bytes(name, expected):
+    """Identifiers arrive as bytes under encodings psycopg cannot decode."""
+    completer = pgcompleter.PGCompleter()
+    assert completer.escape_name(name) == expected
+    assert completer.escaped_names([name]) == [expected]


### PR DESCRIPTION
Closes #1405

## Description
When the client encoding is one psycopg cannot decode (e.g. `SQL_ASCII`), catalog identifiers come back as `bytes`. `PGCompleter.escape_name` matched a `str` regex against them and raised `TypeError: cannot use a string pattern on a bytes-like object`, which killed the `completion_refresh` thread so completions never loaded. It now decodes bytes with the `replace` error handler first, matching the `PGCLIENTENCODING=utf8` workaround users found.

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [ ] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected (new parametrized test fails 4/4 on `main` with the reported `TypeError` and passes with the fix; `tests/test_pgcompleter.py` plus the completion suites are green, ruff check/format clean).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
