### PR TITLE
Allow sqlparse 0.6.x

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -153,6 +153,7 @@ Contributors:
     * Tommi Kyntölä (kynde)
     * Diego
     * Chris (ChrisJr404)
+    * Pieter Ouwerkerk (pouwerkerk)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -7,6 +7,10 @@ Bug fixes:
 * Fix ``TypeError: cannot use a string pattern on a bytes-like object`` when
   completion metadata comes back as bytes (e.g. ``SQL_ASCII`` client encoding).
 * Suggest columns, not datatypes, after a column literally named ``type`` in a ``SELECT`` list.
+* Allow ``sqlparse`` 0.6.x. sqlparse 0.6.0 fixes several denial-of-service
+  issues (CVE-2026-59893, CVE-2026-54284, CVE-2026-71491) and a string-escaping
+  bug (CVE-2026-59894); the previous ``<0.6`` cap prevented users from
+  installing the fixed release.
 
 Features:
 ---------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "prompt_toolkit>=2.0.6,<4.0.0",
     "psycopg >= 3.0.14; sys_platform != 'win32'",
     "psycopg-binary >= 3.0.14; sys_platform == 'win32'",
-    "sqlparse >=0.3.0,<0.6",
+    "sqlparse >=0.3.0,<0.7",
     "configobj >= 5.0.6",
     "cli_helpers[styles] >= 2.4.0",
     # setproctitle is used to mask the password when running `ps` in command line.


### PR DESCRIPTION
## Description

Widens the `sqlparse` constraint from `<0.6` to `<0.7`.

`sqlparse` 0.6.0 ([released](https://github.com/andialbrecht/sqlparse/releases/tag/0.6.0) 2026-08-13) fixes several denial-of-service issues and a string-escaping bug: 
- [CVE-2026-59893](https://github.com/andialbrecht/sqlparse/security/advisories/GHSA-prg7-hcfm-mfcr) (DoS)
- CVE-2026-54284 (DoS)
- [CVE-2026-71491](https://github.com/andialbrecht/sqlparse/security/advisories/GHSA-f2ff-p2ww-7p4p) (DoS)
- [CVE-2026-59894](https://github.com/andialbrecht/sqlparse/security/advisories/GHSA-3496-9g83-7v6x) (string-escaping bug)

Its only other notable change is dropping Python 3.8/3.9, which `pgcli` no longer appears to support. With the current `<0.6` cap, anyone who has `pgcli` installed can't pick up the fixed sqlparse release (Dependabot flags it and the resolver refuses).

The `sqlparse.engine.grouping.MAX_GROUPING_DEPTH` / `MAX_GROUPING_TOKENS` knobs that `pgcli` sets to `None` still exist in 0.6.0 and behave the same.

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [x] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`). (No Python source changed in this PR.)
- [x] I verified that my changes work as expected: full test suite run locally on Python 3.13 with both sqlparse 0.5.4 and 0.6.0 — identical results (`2612 passed, 117 skipped, 1 xfailed, 1 xpassed`).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)

Fixes #1618.