### PR TITLE
Honor PSQL_EDITOR when opening the external editor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -152,6 +152,7 @@ Contributors:
     * Shayan Golshani (shgol)
     * Tommi Kyntölä (kynde)
     * Diego
+    * Chris (ChrisJr404)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,9 @@ Bug fixes:
 
 Features:
 ---------
+* Honor the ``PSQL_EDITOR`` environment variable when opening the external
+  editor (``\\e``, ``\\ev``, ``\\ef``, ``\\ne``), matching psql's precedence of
+  ``PSQL_EDITOR``, then ``EDITOR``, then ``VISUAL`` ([issue 1398](https://github.com/dbcli/pgcli/issues/1398)).
 * Add ``\\ne <name>`` to edit a named query in the external editor. Loads the
   named query's SQL into ``$EDITOR``; on save it is written back to the
   ``[named queries]`` section, creating it if it does not exist. Complements

--- a/pgcli/main.py
+++ b/pgcli/main.py
@@ -146,6 +146,17 @@ def notify_callback(notify: Notify):
     )
 
 
+def get_editor():
+    """Pick the external editor for ``\\e``/``\\ev``/``\\ef``/``\\ne``.
+
+    Mirrors psql, which checks ``PSQL_EDITOR`` first, then ``EDITOR``, then
+    ``VISUAL``. Returning ``None`` when none are set lets click fall back to
+    its platform default, so the behaviour is unchanged for anyone who wasn't
+    setting ``PSQL_EDITOR``.
+    """
+    return os.environ.get("PSQL_EDITOR") or os.environ.get("EDITOR") or os.environ.get("VISUAL") or None
+
+
 class PGCli:
     default_prompt = "\\u@\\h:\\d> "
     max_len_prompt = 30
@@ -331,7 +342,7 @@ class PGCli:
             return [(None, None, None, "Usage: \\ne <name>")]
 
         existing = NamedQueries.instance.get(name)
-        sql, message = special.open_external_editor(sql=existing or "")
+        sql, message = special.open_external_editor(sql=existing or "", editor=get_editor())
         if message:
             return [(None, None, None, message)]
 
@@ -832,7 +843,7 @@ class PGCli:
                     query = self.pgexecute.view_definition(spec)
                 elif editor_command == "\\ef":
                     query = self.pgexecute.function_definition(spec)
-            sql, message = special.open_external_editor(filename, sql=query)
+            sql, message = special.open_external_editor(filename, sql=query, editor=get_editor())
             if message:
                 # Something went wrong. Raise an exception and bail.
                 raise RuntimeError(message)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,6 +16,7 @@ from pgcli.main import (
     obfuscate_process_password,
     duration_in_words,
     format_output,
+    get_editor,
     notify_callback,
     PGCli,
     OutputSettings,
@@ -681,3 +682,22 @@ def test_edit_named_query():
         # Missing name -> usage message.
         out = cli.edit_named_query("")
         assert "Usage" in out[0][3]
+
+
+def test_get_editor_precedence():
+    """PSQL_EDITOR wins over EDITOR/VISUAL, like psql; None when nothing is set."""
+    env = {"PSQL_EDITOR": "psqled", "EDITOR": "myedit", "VISUAL": "myvisual"}
+    with mock.patch.dict(os.environ, env, clear=False):
+        assert get_editor() == "psqled"
+
+    # PSQL_EDITOR unset -> fall back to EDITOR.
+    with mock.patch.dict(os.environ, {"EDITOR": "myedit", "VISUAL": "myvisual"}, clear=True):
+        assert get_editor() == "myedit"
+
+    # Only VISUAL set.
+    with mock.patch.dict(os.environ, {"VISUAL": "myvisual"}, clear=True):
+        assert get_editor() == "myvisual"
+
+    # Nothing set -> None, so click uses its platform default.
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert get_editor() is None


### PR DESCRIPTION
## Description

Closes #1398. psql lets you point `\e` at a dedicated editor via `PSQL_EDITOR` so it doesn't have to be whatever `EDITOR`/`VISUAL` you use everywhere else, and pgcli didn't respect it.

pgcli hands editing off to `pgspecial.open_external_editor`, which calls `click.edit()` and lets click resolve the editor from `VISUAL`/`EDITOR`. That function already takes an `editor=` override, we just weren't passing anything. I added a small `get_editor()` helper that mirrors psql's lookup order (`PSQL_EDITOR`, then `EDITOR`, then `VISUAL`) and threaded its result through both editor call sites (`\e`/`\ev`/`\ef` and `\ne`). When none of those are set it returns `None`, which keeps click's existing platform-default behaviour, so nobody who wasn't setting `PSQL_EDITOR` sees a change.

Test-wise I added `test_get_editor_precedence` asserting `PSQL_EDITOR` wins over `EDITOR`/`VISUAL`, that it falls back to `EDITOR` then `VISUAL`, and returns `None` when the environment is empty. Ran `python -m pytest tests/test_main.py -k "editor or named_query"` (2 passed) and the full `tests/test_main.py` (60 passed, 10 db skips). `ruff check` and `ruff format --diff` are both clean.

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected.
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
