### PR TITLE
Raise the external-editor behave timeouts to reduce CI flakiness

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,15 @@
 Upcoming (TBD)
 ==============
 
+Internal:
+---------
+* Make the external-editor behave scenario less flaky: the ``expect_exact``
+  timeouts in ``tests/features/steps/iocommands.py`` were as low as 1-2
+  seconds, which intermittently expired on loaded CI runners and reported
+  ``Scenario: edit sql in file with external editor`` as an error. Raised to 10
+  seconds; passing runs are unaffected because pexpect returns as soon as the
+  expected text appears.
+
 Bug fixes:
 ----------
 * Restore cursor shape behaviour for Emacs mode

--- a/tests/features/steps/iocommands.py
+++ b/tests/features/steps/iocommands.py
@@ -12,8 +12,8 @@ def step_edit_file(context):
     if os.path.exists(context.editor_file_name):
         os.remove(context.editor_file_name)
     context.cli.sendline(r"\e {}".format(os.path.basename(context.editor_file_name)))
-    wrappers.expect_exact(context, 'Entering Ex mode.  Type "visual" to go to Normal mode.', timeout=2)
-    wrappers.expect_exact(context, ":", timeout=2)
+    wrappers.expect_exact(context, 'Entering Ex mode.  Type "visual" to go to Normal mode.', timeout=10)
+    wrappers.expect_exact(context, ":", timeout=10)
 
 
 @when("we type sql in the editor")
@@ -21,19 +21,19 @@ def step_edit_type_sql(context):
     context.cli.sendline("i")
     context.cli.sendline("select * from abc")
     context.cli.sendline(".")
-    wrappers.expect_exact(context, ":", timeout=2)
+    wrappers.expect_exact(context, ":", timeout=10)
 
 
 @when("we exit the editor")
 def step_edit_quit(context):
     context.cli.sendline("x")
-    wrappers.expect_exact(context, "written", timeout=2)
+    wrappers.expect_exact(context, "written", timeout=10)
 
 
 @then("we see the sql in prompt")
 def step_edit_done_sql(context):
     for match in "select * from abc".split(" "):
-        wrappers.expect_exact(context, match, timeout=1)
+        wrappers.expect_exact(context, match, timeout=10)
     # Cleanup the command line.
     context.cli.sendcontrol("c")
     # Cleanup the edited file.
@@ -48,10 +48,10 @@ def step_tee_ouptut(context):
     if os.path.exists(context.tee_file_name):
         os.remove(context.tee_file_name)
     context.cli.sendline(r"\o {}".format(os.path.basename(context.tee_file_name)))
-    wrappers.expect_exact(context, context.conf["pager_boundary"] + "\r\n", timeout=5)
-    wrappers.expect_exact(context, "Writing to file", timeout=5)
-    wrappers.expect_exact(context, context.conf["pager_boundary"] + "\r\n", timeout=5)
-    wrappers.expect_exact(context, "Time", timeout=5)
+    wrappers.expect_exact(context, context.conf["pager_boundary"] + "\r\n", timeout=10)
+    wrappers.expect_exact(context, "Writing to file", timeout=10)
+    wrappers.expect_exact(context, context.conf["pager_boundary"] + "\r\n", timeout=10)
+    wrappers.expect_exact(context, "Time", timeout=10)
 
 
 @when('we query "select 123456"')
@@ -62,7 +62,7 @@ def step_query_select_123456(context):
 @when("we stop teeing output")
 def step_notee_output(context):
     context.cli.sendline(r"\o")
-    wrappers.expect_exact(context, "Time", timeout=5)
+    wrappers.expect_exact(context, "Time", timeout=10)
 
 
 @then("we see 123456 in tee output")


### PR DESCRIPTION
## Description

The `edit sql in file with external editor` scenario in
`tests/features/iocommands.feature` errors intermittently on CI. It is a timing
issue, not a real failure: `expect_exact` waits only 2 seconds for the ex-mode
banner (and 1 second per token when checking the resulting prompt), which is
not always enough on a loaded runner.

When it expires, behave reports the scenario as an **error** and fail-fast then
cancels the sibling matrix jobs, so a single slow wait looks like a systematic
breakage across Python versions.

Recent examples: it hit #1543 on 3.10, #1544 and #1609 on other versions (both
went green on a later run with no code change), and my own fork's CI on commits
that touch nothing near the editor code. @j-bennet asked about exactly this in
#1543.

## Change

Raise the `expect_exact` timeouts in `tests/features/steps/iocommands.py` to 10
seconds (from 2s, 1s and 5s).

This does not slow down passing runs: pexpect returns as soon as the expected
text appears, so the timeout only bounds how long a *failing* wait blocks
before behave gives up.

## Validation

`behave features/iocommands.feature` green locally (2 scenarios, 12 steps), and
the full behave suite green as well (15 features, 61 scenarios, 0 failed). The
scenario has been stable in my fork since the change.

## Checklist

- [x] I've added this contribution to the `changelog.rst`.



---

Not a feature from my list in discussion #1603: this is one of the upstream bugs I ran into while maintaining the fork, listed in the status section at the bottom of that discussion.
