### PR TITLE
Remove stale xfail on schema-qualified INSERT parseutils test

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -154,6 +154,7 @@ Contributors:
     * Diego
     * Chris (ChrisJr404)
     * Pieter Ouwerkerk (pouwerkerk)
+    * Paco Cartones (pacocartones)
 
 Creator:
 --------

--- a/changelog.rst
+++ b/changelog.rst
@@ -9,6 +9,11 @@ Internal:
   ``Scenario: edit sql in file with external editor`` as an error. Raised to 10
   seconds; passing runs are unaffected because pexpect returns as soon as the
   expected text appears.
+* Remove a stale ``@pytest.mark.xfail`` on
+  ``test_simple_insert_single_table_schema_qualified``. It was marked for an old
+  ``sqlparse`` that mislabeled schema-qualified ``INSERT``; the test now passes
+  across the supported ``sqlparse`` range (0.3.0 to 0.6.x), so the marker only
+  hid a passing test (an unreported XPASS, since ``xfail_strict`` is not set).
 
 Bug fixes:
 ----------

--- a/changelog.rst
+++ b/changelog.rst
@@ -14,6 +14,13 @@ Internal:
   ``sqlparse`` that mislabeled schema-qualified ``INSERT``; the test now passes
   across the supported ``sqlparse`` range (0.3.0 to 0.6.x), so the marker only
   hid a passing test (an unreported XPASS, since ``xfail_strict`` is not set).
+* Document the still-needed ``@pytest.mark.xfail`` on
+  ``test_sub_select_multiple_col_name_completion``, which was added in 2015
+  without explanation. The parser still misidentifies the token before the
+  trailing comma in an incomplete multi-column sub-select
+  (``SELECT a, FROM abc``) as a table, so the marker now carries a ``reason``
+  recording that this remains an expected failure on the supported
+  ``sqlparse`` range.
 
 Bug fixes:
 ----------

--- a/tests/parseutils/test_parseutils.py
+++ b/tests/parseutils/test_parseutils.py
@@ -106,7 +106,6 @@ def test_simple_insert_single_table():
     assert tables == ((None, "abc", "abc", False),)
 
 
-@pytest.mark.xfail
 def test_simple_insert_single_table_schema_qualified():
     tables = extract_tables('insert into abc.def (id, name) values (1, "def")')
     assert tables == (("abc", "def", None, False),)

--- a/tests/test_sqlcompletion.py
+++ b/tests/test_sqlcompletion.py
@@ -450,7 +450,12 @@ def test_sub_select_col_name_completion():
     }
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(
+    reason="Parsing an incomplete multi-column sub-select still misidentifies the "
+    "token before the trailing comma as a table: 'SELECT a, FROM abc' yields "
+    "table_refs for both 'a' and 'abc' instead of just 'abc'. Confirmed still "
+    "failing on sqlparse 0.6.0."
+)
 def test_sub_select_multiple_col_name_completion():
     suggestions = suggest_type("SELECT * FROM (SELECT a, FROM abc", "SELECT * FROM (SELECT a, ")
     assert set(suggestions) == cols_etc("abc")


### PR DESCRIPTION
## Description

`test_simple_insert_single_table_schema_qualified` in
`tests/parseutils/test_parseutils.py` was marked `@pytest.mark.xfail` back when an
older `sqlparse` mislabeled schema-qualified `INSERT` statements. That has long
been fixed. The test now passes across the whole supported range
(`sqlparse >=0.3.0,<0.7` — I checked 0.3.0 and 0.6.0), so the marker only ever
produced an XPASS.

Since `xfail_strict` isn't set, that XPASS was silent, which means the assertion
wasn't actually guarding `extract_tables` anymore. This just drops the decorator
so the test does its job again. No production code changes.

Verified locally: the file passes repeatedly on both sqlparse 0.3.0 and 0.6.0,
and `ruff format`/`ruff check` are clean.

## Checklist
- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] I verified that my changes work as expected (this may include manually testing them in your local environment, or in other available environments). Cross this out if not relevant (for example, if you're making a documentation change).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)
