### PR TITLE
docs: fix dead Click documentation link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -352,7 +352,7 @@ which is quite literally the backbone library, that made this app possible.
 Jonathan has also provided valuable feedback and support during the development
 of this app.
 
-`Click <https://click.pocoo.org/>`_ is used for command line option parsing
+`Click <https://click.palletsprojects.com/>`_ is used for command line option parsing
 and printing error messages.
 
 Thanks to `psycopg <https://www.psycopg.org/>`_ for providing a rock solid


### PR DESCRIPTION
## What
`README.rst` links to Click's documentation via `https://click.pocoo.org/`, which now returns **HTTP 400 (Bad Request)** from nginx. (Sibling Pocoo subdomains such as `babel.pocoo.org` still resolve, so the outage is specific to this doc subdomain.)

Click is a Pallets project and its docs now live at https://click.palletsprojects.com/ (verified returning HTTP 200). This PR updates the single reference.

## Verification
- `curl -I https://click.pocoo.org/` → `HTTP/1.1 400 Bad Request`
- `curl -I https://click.palletsprojects.com/` → `HTTP/1.1 200 OK`

## Change
- `README.rst:355`: `https://click.pocoo.org/` → `https://click.palletsprojects.com/`

One-line doc-only change, no code/test impact.

---
*This contribution was prepared with the assistance of an AI agent (Hermes), used as a tool under CAOShurong's direction. The link-deadness verification above was performed independently.*