### PR TITLE
Decode text results defensively when the client encoding cannot decode them (SQL_ASCII)

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -16,6 +16,17 @@ Bug fixes:
   as the OS user. The database argument is now kept, like psql; only when no
   database is given at all does the listing connect to ``postgres``.
 
+* Fix a prompt crash, garbled timezone output and a completion-refresh crash
+  when the client encoding cannot decode text (e.g. SQL_ASCII), where psycopg
+  returns text columns as raw bytes: the socket directory and timezone query
+  results are now decoded defensively (so the prompt no longer raises a
+  ``TypeError`` on Unix socket connections and the timezone startup message no
+  longer shows a ``b'...'``-prefixed value), and the function metadata rows
+  are decoded before building completions (so the background completion
+  refresh no longer dies in ``parse_defaults`` with a ``TypeError``). Same
+  guard as the completion metadata fix for issue #1405; see upstream issues
+  #1484 and #1518.
+
 4.6.0 (2026-08-26)
 ==================
 

--- a/pgcli/pgexecute.py
+++ b/pgcli/pgexecute.py
@@ -55,6 +55,23 @@ def register_typecasters(connection):
         connection.adapters.register_loader(forced_text_type, psycopg.types.string.TextLoader)
 
 
+def _decode_if_bytes(value):
+    """psycopg returns text columns as raw bytes when the client encoding
+    cannot be decoded (e.g. SQL_ASCII); decode defensively so callers can
+    treat the value as a regular str. See issues #1484 and #1518."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return value
+
+
+def _decode_row(row):
+    """psycopg returns text columns as raw bytes when the client encoding
+    cannot be decoded (e.g. SQL_ASCII); decode every scalar value and every
+    array element so callers can treat the whole row as regular str values.
+    See issues #1484 and #1518."""
+    return [[_decode_if_bytes(item) for item in value] if isinstance(value, list) else _decode_if_bytes(value) for value in row]
+
+
 # pg3: I don't know what is this
 class ProtocolSafeCursor(psycopg.Cursor):
     """This class wraps and suppresses Protocol Errors with pgbouncer database.
@@ -667,7 +684,7 @@ class PGExecute:
             _logger.debug("Socket directory Query. sql: %r", self.socket_directory_query)
             cur.execute(self.socket_directory_query)
             result = cur.fetchone()
-            return result[0] if result else ""
+            return _decode_if_bytes(result[0]) if result else ""
 
     def foreignkeys(self):
         """Yields ForeignKey named tuples"""
@@ -797,7 +814,7 @@ class PGExecute:
             _logger.debug("Functions Query. sql: %r", query)
             cur.execute(query)
             for row in cur:
-                yield FunctionMetadata(*row)
+                yield FunctionMetadata(*_decode_row(row))
 
     def datatypes(self):
         """Yields tuples of (schema_name, type_name)"""
@@ -899,7 +916,8 @@ class PGExecute:
         query = psycopg.sql.SQL("show time zone")
         with self.conn.cursor() as cur:
             cur.execute(query)
-            return cur.fetchone()[0]
+            result = cur.fetchone()
+            return _decode_if_bytes(result[0]) if result else ""
 
     def set_timezone(self, timezone: str):
         query = psycopg.sql.SQL("set time zone {}").format(psycopg.sql.Identifier(timezone))

--- a/tests/test_pgexecute.py
+++ b/tests/test_pgexecute.py
@@ -842,3 +842,94 @@ def test_virtual_database(executor):
     with patch.object(executor, "conn", virtual_connection):
         result = run(executor, "select 1")
         assert "Command not supported" in result
+
+
+# When the client encoding is one psycopg cannot decode (e.g. SQL_ASCII),
+# text columns come back as raw bytes. See issues #1484 and #1518.
+
+
+@dbtest
+def test_get_socket_directory_decodes_sql_ascii_bytes(executor):
+    with patch.object(executor.conn, "cursor") as mock_cursor:
+        mock_cursor.return_value.__enter__.return_value.fetchone.return_value = (b"/var/run/postgresql",)
+        assert executor.get_socket_directory() == "/var/run/postgresql"
+
+
+@dbtest
+def test_get_socket_directory_str_unchanged(executor):
+    with patch.object(executor.conn, "cursor") as mock_cursor:
+        mock_cursor.return_value.__enter__.return_value.fetchone.return_value = ("/var/run/postgresql",)
+        assert executor.get_socket_directory() == "/var/run/postgresql"
+
+
+@dbtest
+def test_get_timezone_decodes_sql_ascii_bytes(executor):
+    with patch.object(executor.conn, "cursor") as mock_cursor:
+        mock_cursor.return_value.__enter__.return_value.fetchone.return_value = (b"America/Argentina/Buenos_Aires",)
+        assert executor.get_timezone() == "America/Argentina/Buenos_Aires"
+
+
+@dbtest
+def test_get_timezone_str_unchanged(executor):
+    with patch.object(executor.conn, "cursor") as mock_cursor:
+        mock_cursor.return_value.__enter__.return_value.fetchone.return_value = ("UTC",)
+        assert executor.get_timezone() == "UTC"
+
+
+@dbtest
+def test_functions_decodes_sql_ascii_bytes(executor):
+    row = (
+        b"public",
+        b"func_with_default",
+        [b"x"],
+        [b"integer"],
+        [b"i"],
+        b"integer",
+        False,
+        False,
+        False,
+        False,
+        b"'10'::integer, NULL",
+    )
+    with patch.object(executor.conn, "cursor") as mock_cursor:
+        mock_cursor.return_value.__enter__.return_value.__iter__.return_value = iter([row])
+        funcs = list(executor.functions())
+
+    assert len(funcs) == 1
+    func = funcs[0]
+    assert func.schema_name == "public"
+    assert func.func_name == "func_with_default"
+    assert func.arg_names == ("x",)
+    assert func.arg_types == ("integer",)
+    assert func.arg_modes == ("i",)
+    assert func.return_type == "integer"
+    assert func.is_public is True
+    assert func.arg_defaults == ("'10'::integer", "NULL")
+
+
+@dbtest
+def test_functions_str_unchanged(executor):
+    row = (
+        "public",
+        "func_plain",
+        ["x"],
+        ["integer"],
+        ["i"],
+        "integer",
+        False,
+        False,
+        False,
+        False,
+        None,
+    )
+    with patch.object(executor.conn, "cursor") as mock_cursor:
+        mock_cursor.return_value.__enter__.return_value.__iter__.return_value = iter([row])
+        funcs = list(executor.functions())
+
+    assert len(funcs) == 1
+    func = funcs[0]
+    assert func.schema_name == "public"
+    assert func.func_name == "func_plain"
+    assert func.arg_names == ("x",)
+    assert func.return_type == "integer"
+    assert func.arg_defaults == ()


### PR DESCRIPTION
Fixes #1518. Fixes #1484.

When the client encoding cannot decode a text value (most commonly `SQL_ASCII`), psycopg returns text columns as raw `bytes` instead of `str`. Three code paths were passing those values through unguarded, producing the crashes reported in #1518 and #1484:

- The socket directory query result is used to build the prompt, so a Unix socket connection raised `TypeError: expected str, not bytes`.
- The `show time zone` result is printed in the startup message, showing a `b'...'`-prefixed value.
- The function metadata rows feed the background completion refresher; parsing their bytes with `parse_defaults()` killed the refresh thread with `TypeError: can only concatenate str (not "int") to str`.

The fix decodes those values defensively when they come back as bytes, with the same guard the completion metadata fix for #1405 already uses (`decode("utf-8", "replace")`): a `_decode_if_bytes()` helper, plus a `_decode_row()` variant for the function metadata rows, which contain array columns.

Deliberately narrow in scope: `function_definition()`, `search_path()`, `schemata()` and `databases()` also return text and are still unguarded, but they are not involved in the reported crashes. Guarding them can be a follow-up if anyone hits them.

Reproduced against a real `SQL_ASCII` cluster (3396 catalog functions; all metadata fields come back as plain `str` after the fix). 6 unit tests: 3 fail without the fix, 3 pin the already-working `str` path so it stays unchanged.

## Checklist

- [x] I've added this contribution to the `changelog.rst`.
- [x] I've added my name to the `AUTHORS` file (or it's already there).
- [ ] I installed pre-commit hooks (`pip install pre-commit && pre-commit install`).
- [x] Please squash merge this pull request (uncheck if you'd like us to merge as multiple commits)

Sorry about the missing checklist, that was me writing the description by hand instead of starting from the template.

The third box is honestly unchecked, with a small finding attached: `.pre-commit-config.yaml` pins `ruff-pre-commit` at `v0.11.7`, while `[testenv:style]` in `tox.ini` installs `ruff` unpinned (0.15.x today). The two disagree on formatting, so running the hook reformats code that the CI style job then wants reformatted back. I ran `ruff check` and `ruff format` matching the CI instead, both clean. Happy to open a separate PR bumping the pre-commit `rev` if you would like them to agree.
